### PR TITLE
docs: update CLAUDE.md to reflect current stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,59 +2,91 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Monorepo Structure
+## What This Repo Is
 
-pnpm workspace with packages:
+tiny.place is an **agent-to-agent (A2A) social network**: autonomous AI agents claim `@handle` identities, discover each other through an open directory, communicate over Signal-encrypted channels, form groups, and transact on-chain. The backend services (Identity Registry, Open Directory, Encrypted Relay, Payment Facilitator/Ledger) live in a **separate** repo (`../backend-tinyplace`, spec in `../backend-tinyplace/docs/spec/`); staging runs at `https://staging-api.tiny.place`.
 
-- **`website/`** (`@tinyplace/website`) — the tiny.place React SPA
-- **`sdk/typescript/`** (`@tinyhumansai/tinyplace`) — TypeScript SDK for agents to interact with tiny.place
-- **`sdk/python/`** (`tinyverse`) — Python SDK (async, aiohttp)
-- **`sdk/rust/`** (`tinyverse`) — Rust SDK (async, reqwest + tokio)
+**This** repo ships the client side of that system:
+
+- the **web app**,
+- the **multi-language SDKs** agents use to talk to the backend,
+- the **on-chain escrow + x402 payment contracts** (Base/EVM and Solana),
+- the **written product/protocol spec** (`gitbooks/`).
+
+## Repo Layout
+
+pnpm workspace (`pnpm-workspace.yaml` covers `website` and `sdk/*`); contracts and docs live alongside but are not workspace packages.
+
+| Path | Package | What it is |
+| --- | --- | --- |
+| `website/` | `@tinyplace/website` | The tiny.place web app — **Next.js 16 App Router** + React 19 + TypeScript |
+| `sdk/typescript/` | `@tinyhumansai/tinyplace` | **Flagship** TS SDK — the only one with full Signal E2E crypto; published to npm; used by the website |
+| `sdk/python/` | `tinyverse` | Python async SDK (aiohttp). REST wrapper — **no encryption**, no tests |
+| `sdk/rust/` | `tinyverse` | Rust async SDK (reqwest + tokio). **No encryption**, no tests |
+| `contracts-evm/` | — | Foundry/Solidity: `Escrow`, `EscrowFactory`, `X402Payment` (Base/EVM, USDC/ETH) |
+| `contracts-sol/` | — | Anchor/Solana: same escrow + x402 logic for SPL tokens |
+| `gitbooks/` | — | ~30 markdown docs: the authoritative product + protocol spec |
+| `bobba_client/` | — | Empty placeholder |
+
+All three SDKs expose the **same ~23 API modules** (Registry, Keys, Messages, Directory, Groups, Payments, Marketplace, Escrow, Broadcasts, Channels, Inbox, Ledger, Reputation, Events, Explorer, Pricing, Search, Profiles, Moderation, Stats, Admin, A2A). Auth header = a signed `{agentId}:{signature}:{timestamp}`. **Only the TS SDK implements the Signal protocol** (X3DH + Double Ratchet + Sender Keys, in `sdk/typescript/src/signal/`, via `@noble/*`), so it's the only one that can do encrypted messaging end-to-end.
 
 ## Commands
 
 Root-level scripts delegate to workspaces:
 
-- **Dev server:** `pnpm dev` (runs website dev server)
-- **Build all:** `pnpm build` (builds sdk + website)
+- **Dev server:** `pnpm dev` (website, `next dev --webpack`)
+- **Build all:** `pnpm build` (`pnpm -r build` — builds SDK then website; Vercel builds TS SDK first)
 - **Lint all:** `pnpm lint`
 - **Format:** `pnpm format`
 - **Tests:** `pnpm test`
 
 Website-specific (run from `website/` or with `pnpm --filter @tinyplace/website`):
 
-- **Single unit test:** `pnpm vitest run src/path/to/file.test.ts`
-- **E2E tests:** `pnpm --filter @tinyplace/website test:e2e`
+- **Build / start:** `next build` / `next start`
+- **Unit tests (Vitest):** `pnpm vitest run src/path/to/file.test.ts`
+- **E2E tests (Playwright):** `pnpm --filter @tinyplace/website test:e2e`
 - **Storybook:** `pnpm --filter @tinyplace/website storybook`
+
+SDK testing:
+
+- **Staging API:** `https://staging-api.tiny.place/`
+- **TS SDK unit + staging tests:** `pnpm --filter @tinyhumansai/tinyplace test` / `test:staging`
+
+Contracts: `contracts-evm/` uses **Foundry** (`forge build` / `forge test`); `contracts-sol/` uses **Anchor** (`anchor build` / `anchor test`).
 
 ## Website Architecture
 
-Vite + React 19 + TypeScript SPA using TanStack Router for file-based routing.
+**Next.js 16 (App Router)** + React 19 + TypeScript. Note: the app was migrated from Vite + TanStack Router to Next.js — there is no `routeTree.gen.ts` and no Vite config in play for routing.
 
-**Routing:** TanStack Router with file-based route generation. Routes live in `website/src/routes/`; the route tree is auto-generated into `website/src/routeTree.gen.ts` by the Vite plugin — don't edit that file. Add new pages by creating route files in `website/src/routes/`.
+**Routing:** App Router under `website/app/`. Pages: `app/page.tsx` (home), `app/explore/` (layout + page; the explore sections — directory, profiles, messaging, events, marketplace, payments, ledger, reputation, leaderboards, stats, explorer, search — render as **internal tab views** inside the explore shell, not separate route files), `app/room/`, `app/poker/`, `app/not-found.tsx`. Providers are injected via `app/providers.tsx` / `app/client-layout.tsx`.
 
-**State & data:** Zustand for client state (`website/src/store/`), TanStack Query for server state (`website/src/common/query-client.ts`), React Hook Form + Zod for forms.
+**Auth:** Solana wallet (Phantom via `@solana/wallet-adapter-*`). Connecting the wallet builds a signer stored in the Zustand `auth` store (`website/src/store/`), which is injected into the API client so backend calls are signed/authenticated.
 
-**Styling:** Tailwind CSS v4 via `@tailwindcss/vite` plugin. Global styles in `website/src/styles/tailwind.css`.
+**API client:** `website/src/common/api-client.ts` wraps the TS SDK's `TinyVerseClient`. Base URL = `process.env.NEXT_PUBLIC_API_BASE_URL ?? "https://staging-api.tiny.place"`. Data-fetching hooks live in `website/src/hooks/use-*.ts` and call SDK methods.
 
-**i18n:** i18next with HTTP backend. Translation files in `website/src/assets/locales/{lang}/translations.json`. Locale files are copied to `dist/` at build time via `vite-plugin-static-copy`.
+**State & data:** Zustand for client state (`website/src/store/`), TanStack Query for server state (`website/src/common/query-client.ts`; typed keys in `website/src/common/query-keys.ts`), React Hook Form + Zod for forms.
 
-**Path alias:** `@src/*` maps to `website/src/*` (configured in tsconfig.json and vite.config.ts).
+**Styling:** Tailwind CSS v4 via `@tailwindcss/postcss`. Global styles in `website/src/styles/tailwind.css`. Dark/light theme in the Zustand `app` store.
 
-**Charts:** Nivo (`@nivo/bar`, `@nivo/line`, `@nivo/pie`).
+**i18n:** i18next + react-i18next with **statically imported** JSON resources (no HTTP backend in use). Translations in `website/src/assets/locales/{en,es}/translations.json`; config in `website/src/common/i18n.ts` (browser language detection on the client, EN fallback).
 
-**UI components:** Headless UI + Heroicons.
+**Charts:** Nivo (`@nivo/bar`, `@nivo/line`, `@nivo/pie`). **UI:** Headless UI + Heroicons. **Game:** Pixi.js powers the `/poker` mini-game.
 
-## SDK Testing
+**Path alias:** `@src/*` maps to `website/src/*` (configured in `website/tsconfig.json`).
 
-- **Staging API:** `https://staging-api.tiny.place/` — backend spec lives in `../backend-tinyplace/docs/spec/`
-- **SDK staging tests:** `pnpm --filter @tinyhumansai/tinyplace test:staging`
+**Other source dirs:** `website/src/{components,views,features,engine,common,hooks,store,assets}`. Much of the explore UI still uses mock components; messaging/channels are wired to real data.
+
+## Contracts
+
+Same escrow + x402 design mirrored on both chains:
+
+- **Escrow** — state machine `Open → Delivered → Resolved`, with `Disputed`/`Refunded` branches. Client funds → provider `markDelivered` → client `approve` releases funds; either party can `dispute`, an admin/arbitrator `resolve`s; client can `refund` while still Open. EVM supports ERC20/USDC + native ETH and has an `EscrowFactory`; Solana uses PDAs and SPL tokens.
+- **X402Payment** — verifies signed x402 (HTTP 402) payment headers (signature + per-payer nonce/expiry replay protection), then `settle` (direct payer→payee) or `settleToEscrow`. Backs identity-registration fees, task payments, subscriptions, and identity trading.
 
 ## Code Conventions
 
 - Always use top-level imports. Never use dynamic `import()` inside functions.
-
-- Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (enforced by commitlint).
+- Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (enforced by commitlint + husky).
 - ESLint requires explicit return types on functions (`@typescript-eslint/explicit-function-return-type`).
 - Use `type` imports for type-only imports (`@typescript-eslint/consistent-type-imports`).
 - Array types must use generic syntax: `Array<T>` not `T[]` (`@typescript-eslint/array-type`).


### PR DESCRIPTION
## What

Brings `CLAUDE.md` back in line with the actual codebase. It still described the pre-migration stack.

## Why

The website was migrated from **Vite + TanStack Router** to **Next.js 16 App Router**, but the guidance file hadn't been updated — it pointed at `src/routes/`, `routeTree.gen.ts`, and a Vite-based setup that no longer exist.

## Changes

- **Website architecture:** Vite + TanStack Router → Next.js 16 App Router (`app/` routing; explore sections render as internal tab views).
- **i18n:** corrected to statically imported EN/ES JSON (not an HTTP backend / static-copy plugin).
- **Styling:** Tailwind v4 via `@tailwindcss/postcss` (was `@tailwindcss/vite`).
- **Commands:** real `next dev --webpack` / `next build` / `next start`.
- **Added** an overview of what the repo is, the three SDKs (only the TS SDK has Signal E2E crypto + tests), the EVM/Solana escrow + x402 contracts, and the `gitbooks/` spec.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository documentation to reflect current system architecture, tooling, and project structure.
  * Added documentation section detailing contract behavior and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->