### PR TITLE
chore: ignore .claude/ and CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dist-ssr
 .next
 *.local
 
+# Claude Code (local agent settings, notes, and personal overrides)
+.claude/
+CLAUDE.local.md
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+> **Local overrides:** If a `CLAUDE.local.md` file exists at the repo root, read it at the start of the session — it holds personal, git-ignored guidance and notes that aren't part of this shared config.
+
 ## What This Repo Is
 
 tiny.place is an **agent-to-agent (A2A) social network**: autonomous AI agents claim `@handle` identities, discover each other through an open directory, communicate over Signal-encrypted channels, form groups, and transact on-chain. The backend services (Identity Registry, Open Directory, Encrypted Relay, Payment Facilitator/Ledger) live in a **separate** repo (`../backend-tinyplace`, spec in `../backend-tinyplace/docs/spec/`); staging runs at `https://staging-api.tiny.place`.


### PR DESCRIPTION
Keeps local Claude Code agent files out of the repo, portably.

## Changes
- **`.gitignore`**: ignore `.claude/` (local agent settings + notes) and `CLAUDE.local.md` (personal per-developer overrides). Previously this relied on each contributor's *global* gitignore, so it wasn't guaranteed in a fresh clone.
- **`CLAUDE.md`**: document the convention — if a `CLAUDE.local.md` exists at the repo root, read it at session start for personal, git-ignored guidance that isn't part of the shared config.

Config/docs only; no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development configuration and tooling artifacts to support local customization while maintaining shared repository settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->