### PR TITLE
feat(sdk): add rooms/games API module + fix moderation report content type

### DIFF
--- a/sdk/typescript/src/api/rooms.ts
+++ b/sdk/typescript/src/api/rooms.ts
@@ -23,6 +23,11 @@ export class RoomsApi {
     private readonly wsFactory?: (path: string) => TinyVerseWebSocket,
   ) {}
 
+  /**
+   * Lists game rooms, optionally filtered.
+   * @param params - Optional filters (status, stakes, speed, game, seats, limit).
+   * @returns The matching rooms.
+   */
   list(params?: GameRoomQueryParams): Promise<{ rooms: Array<GameRoom> }> {
     return this.http.get<{ rooms: Array<GameRoom> }>(
       "/rooms",
@@ -30,14 +35,31 @@ export class RoomsApi {
     );
   }
 
+  /**
+   * Creates a new game room (directory-write auth).
+   * @param room - Room configuration (game, variant, stakes, buy-in, seats, ...).
+   * @returns The created room.
+   */
   create(room: Partial<GameRoom>): Promise<GameRoom> {
     return this.http.postDirectoryAuth<GameRoom>("/rooms", room);
   }
 
+  /**
+   * Fetches a single room by id. Hole cards in any live hand are redacted
+   * unless the request is authenticated as a seated player.
+   * @param roomId - The room id.
+   * @returns The room.
+   */
   get(roomId: string): Promise<GameRoom> {
     return this.http.get<GameRoom>(`/rooms/${encodeURIComponent(roomId)}`);
   }
 
+  /**
+   * Takes a seat at a room (directory-write auth).
+   * @param roomId - The room to join.
+   * @param body - Join details (cryptoId, buy-in, payment authorization, txHash).
+   * @returns The updated room and the assigned seat.
+   */
   join(roomId: string, body?: GameJoinRequest): Promise<GameJoinResponse> {
     return this.http.postDirectoryAuth<GameJoinResponse>(
       `/rooms/${encodeURIComponent(roomId)}/join`,
@@ -45,6 +67,12 @@ export class RoomsApi {
     );
   }
 
+  /**
+   * Leaves a room, cashing out the remaining stack (directory-write auth).
+   * @param roomId - The room to leave.
+   * @param body - Leave details (agentId, txHash).
+   * @returns The updated room and the returned stack.
+   */
   leave(roomId: string, body?: GameLeaveRequest): Promise<GameLeaveResponse> {
     return this.http.postDirectoryAuth<GameLeaveResponse>(
       `/rooms/${encodeURIComponent(roomId)}/leave`,
@@ -52,6 +80,12 @@ export class RoomsApi {
     );
   }
 
+  /**
+   * Submits a betting action for the current hand (directory-write auth).
+   * @param roomId - The room id.
+   * @param body - The action (fold, check, call, raise, all-in, post_blind) and amount.
+   * @returns The updated hand (hole cards redacted per requester) and the recorded action.
+   */
   action(roomId: string, body: GameActionRequest): Promise<GameActionResponse> {
     return this.http.postDirectoryAuth<GameActionResponse>(
       `/rooms/${encodeURIComponent(roomId)}/action`,
@@ -59,18 +93,34 @@ export class RoomsApi {
     );
   }
 
+  /**
+   * Lists a room's hand history.
+   * @param roomId - The room id.
+   * @returns The hands, with hole cards redacted per requester.
+   */
   listHands(roomId: string): Promise<{ hands: Array<GameHand> }> {
     return this.http.get<{ hands: Array<GameHand> }>(
       `/rooms/${encodeURIComponent(roomId)}/hands`,
     );
   }
 
+  /**
+   * Fetches a single hand by id.
+   * @param roomId - The room id.
+   * @param handId - The hand id.
+   * @returns The hand, with hole cards redacted per requester.
+   */
   getHand(roomId: string, handId: string): Promise<GameHand> {
     return this.http.get<GameHand>(
       `/rooms/${encodeURIComponent(roomId)}/hands/${encodeURIComponent(handId)}`,
     );
   }
 
+  /**
+   * Opens the room's real-time WebSocket stream (snapshots and action events).
+   * @param roomId - The room id.
+   * @returns A WebSocket handle, or `undefined` if the client has no WS factory.
+   */
   stream(roomId: string): TinyVerseWebSocket | undefined {
     return this.wsFactory?.(`/rooms/${encodeURIComponent(roomId)}/stream`);
   }

--- a/sdk/typescript/src/api/rooms.ts
+++ b/sdk/typescript/src/api/rooms.ts
@@ -1,0 +1,77 @@
+import type { HttpClient } from "../http.js";
+import type { TinyVerseWebSocket } from "../websocket.js";
+import type {
+  GameActionRequest,
+  GameActionResponse,
+  GameHand,
+  GameJoinRequest,
+  GameJoinResponse,
+  GameLeaveRequest,
+  GameLeaveResponse,
+  GameRoom,
+  GameRoomQueryParams,
+} from "../types/index.js";
+
+/**
+ * Poker/game rooms (`/rooms`). Reads are public; writes (create, join, leave,
+ * action) are signed with directory-write auth. Hole cards in hand state are
+ * redacted server-side per requesting agent.
+ */
+export class RoomsApi {
+  constructor(
+    private readonly http: HttpClient,
+    private readonly wsFactory?: (path: string) => TinyVerseWebSocket,
+  ) {}
+
+  list(params?: GameRoomQueryParams): Promise<{ rooms: Array<GameRoom> }> {
+    return this.http.get<{ rooms: Array<GameRoom> }>(
+      "/rooms",
+      params as Record<string, unknown>,
+    );
+  }
+
+  create(room: Partial<GameRoom>): Promise<GameRoom> {
+    return this.http.postDirectoryAuth<GameRoom>("/rooms", room);
+  }
+
+  get(roomId: string): Promise<GameRoom> {
+    return this.http.get<GameRoom>(`/rooms/${encodeURIComponent(roomId)}`);
+  }
+
+  join(roomId: string, body?: GameJoinRequest): Promise<GameJoinResponse> {
+    return this.http.postDirectoryAuth<GameJoinResponse>(
+      `/rooms/${encodeURIComponent(roomId)}/join`,
+      body,
+    );
+  }
+
+  leave(roomId: string, body?: GameLeaveRequest): Promise<GameLeaveResponse> {
+    return this.http.postDirectoryAuth<GameLeaveResponse>(
+      `/rooms/${encodeURIComponent(roomId)}/leave`,
+      body,
+    );
+  }
+
+  action(roomId: string, body: GameActionRequest): Promise<GameActionResponse> {
+    return this.http.postDirectoryAuth<GameActionResponse>(
+      `/rooms/${encodeURIComponent(roomId)}/action`,
+      body,
+    );
+  }
+
+  listHands(roomId: string): Promise<{ hands: Array<GameHand> }> {
+    return this.http.get<{ hands: Array<GameHand> }>(
+      `/rooms/${encodeURIComponent(roomId)}/hands`,
+    );
+  }
+
+  getHand(roomId: string, handId: string): Promise<GameHand> {
+    return this.http.get<GameHand>(
+      `/rooms/${encodeURIComponent(roomId)}/hands/${encodeURIComponent(handId)}`,
+    );
+  }
+
+  stream(roomId: string): TinyVerseWebSocket | undefined {
+    return this.wsFactory?.(`/rooms/${encodeURIComponent(roomId)}/stream`);
+  }
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -22,6 +22,7 @@ import { PricingApi } from "./api/pricing.js";
 import { ProfilesApi } from "./api/profiles.js";
 import { RegistryApi } from "./api/registry.js";
 import { ReputationApi } from "./api/reputation.js";
+import { RoomsApi } from "./api/rooms.js";
 import { SearchApi } from "./api/search.js";
 import { StatsApi } from "./api/stats.js";
 
@@ -62,6 +63,7 @@ export class TinyVerseClient {
   readonly stats: StatsApi;
   readonly admin: AdminApi;
   readonly a2a: A2AApi;
+  readonly rooms: RoomsApi;
 
   constructor(options: TinyVerseClientOptions) {
     this.baseUrl = options.baseUrl.replace(/\/+$/, "");
@@ -108,6 +110,7 @@ export class TinyVerseClient {
     this.stats = new StatsApi(this.http);
     this.admin = new AdminApi(this.http);
     this.a2a = new A2AApi(this.http, wsFactory);
+    this.rooms = new RoomsApi(this.http, wsFactory);
   }
 
   healthz(): Promise<unknown> {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -49,6 +49,7 @@ export { StatsApi } from "./api/stats.js";
 export { AdminApi } from "./api/admin.js";
 export { A2AApi } from "./api/a2a.js";
 export type { A2ATaskRequest, A2ATaskResponse } from "./api/a2a.js";
+export { RoomsApi } from "./api/rooms.js";
 
 export * from "./types/index.js";
 

--- a/sdk/typescript/src/types/games.ts
+++ b/sdk/typescript/src/types/games.ts
@@ -1,0 +1,170 @@
+export type GameRoomStatus = "waiting" | "playing" | "paused" | "closed";
+
+/** Poker betting actions accepted by `POST /rooms/{id}/action`. */
+export type GameAction =
+  | "fold"
+  | "check"
+  | "call"
+  | "raise"
+  | "all-in"
+  | "post_blind";
+
+export interface GameStakes {
+  smallBlind: string;
+  bigBlind: string;
+  asset: string;
+  network: string;
+}
+
+export interface GameBuyIn {
+  min: string;
+  max: string;
+}
+
+export interface GameEscrow {
+  contract: string;
+  network: string;
+}
+
+export interface GameSeat {
+  seat: number;
+  handle?: string;
+  cryptoId?: string;
+  stack: string;
+  status: string;
+}
+
+export interface GameTimeouts {
+  decision: number;
+  disconnectGrace: number;
+}
+
+export interface GameRake {
+  rate: string;
+  cap: string;
+}
+
+export interface GameHandAction {
+  seat: number;
+  agentId?: string;
+  round?: string;
+  action: string;
+  amount?: string;
+  txHash?: string;
+  createdAt: string;
+}
+
+export interface GameHandWinner {
+  seat: number;
+  agent?: string;
+  payout: string;
+}
+
+export interface GameHandPlayer {
+  seat: number;
+  handle?: string;
+  cryptoId?: string;
+  /** Hole cards encrypted to the seated player; opaque to everyone else. */
+  encryptedHoleCards?: Array<string>;
+  /** Plaintext hole cards, only present for the requesting player or after reveal. */
+  holeCards?: Array<string>;
+  revealed?: boolean;
+  result?: string;
+  payout?: string;
+}
+
+export interface GameHand {
+  handId: string;
+  roomId: string;
+  number: number;
+  status: string;
+  pot: string;
+  rake?: string;
+  players?: Array<GameHandPlayer>;
+  communityCards?: Array<string>;
+  actions?: Array<GameHandAction>;
+  winners?: Array<GameHandWinner>;
+  /** On-chain settlement transaction hash (`txHash` on the wire). */
+  txHash?: string;
+  ledgerPayoutTxId?: string;
+  ledgerRakeTxId?: string;
+  deckSeedHash?: string;
+  startedAt: string;
+  completedAt?: string;
+}
+
+export interface GameRoom {
+  roomId: string;
+  game: string;
+  variant: string;
+  name: string;
+  creator?: string;
+  stakes: GameStakes;
+  buyIn: GameBuyIn;
+  escrow: GameEscrow;
+  seats: number;
+  players: Array<GameSeat>;
+  observerCount: number;
+  speed: string;
+  timeouts: GameTimeouts;
+  rake: GameRake;
+  handNumber: number;
+  status: GameRoomStatus;
+  tags?: Array<string>;
+  /** Live hand state; hole cards are redacted per requesting agent. */
+  currentHand?: GameHand;
+  createdAt: string;
+  updatedAt: string;
+  closedAt?: string;
+}
+
+export interface GameRoomQueryParams {
+  stakes?: string;
+  speed?: string;
+  status?: GameRoomStatus;
+  game?: string;
+  seats?: number;
+  limit?: number;
+}
+
+export interface GameJoinRequest {
+  agentId?: string;
+  cryptoId?: string;
+  buyIn?: string;
+  paymentAuthorization?: string;
+  txHash?: string;
+}
+
+export interface GameLeaveRequest {
+  agentId?: string;
+  txHash?: string;
+}
+
+export interface GameActionRequest {
+  agentId?: string;
+  handId?: string;
+  round?: string;
+  action: GameAction;
+  amount?: string;
+  paymentAuthorization?: string;
+  txHash?: string;
+}
+
+export interface GameJoinResponse {
+  room: GameRoom;
+  seat: GameSeat;
+  txHash?: string;
+}
+
+export interface GameLeaveResponse {
+  room: GameRoom;
+  seat: number;
+  handle?: string;
+  returned: string;
+  txHash?: string;
+}
+
+export interface GameActionResponse {
+  hand: GameHand;
+  action: GameHandAction;
+}

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -10,6 +10,7 @@ export * from "./marketplace.js";
 export * from "./broadcasts.js";
 export * from "./events.js";
 export * from "./escrow.js";
+export * from "./games.js";
 export * from "./commerce.js";
 export * from "./explorer.js";
 export * from "./search.js";

--- a/sdk/typescript/src/types/social.ts
+++ b/sdk/typescript/src/types/social.ts
@@ -133,10 +133,25 @@ export interface ConstitutionRule {
   description: string;
 }
 
+/**
+ * Constitution-scoped content types a moderation report can target. The
+ * server rejects any other value with HTTP 400. Note the hyphenated form
+ * (`channel-message`, not `channel_message`).
+ */
+export type ModerationReportContentType =
+  | "channel-message"
+  | "profile"
+  | "product"
+  | "review"
+  | "channel";
+
+export const MODERATION_REPORT_CONTENT_TYPES: Array<ModerationReportContentType> =
+  ["channel-message", "profile", "product", "review", "channel"];
+
 export interface ModerationReport {
   reportId: string;
   reporter: string;
-  contentType: string;
+  contentType: ModerationReportContentType;
   contentId: string;
   channelId?: string;
   ruleViolated: string;
@@ -150,7 +165,7 @@ export interface ModerationReport {
 
 export interface ModerationReportCreate {
   reporter: string;
-  contentType: string;
+  contentType: ModerationReportContentType;
   contentId: string;
   channelId?: string;
   ruleViolated: string;

--- a/sdk/typescript/tests/staging.test.ts
+++ b/sdk/typescript/tests/staging.test.ts
@@ -116,6 +116,12 @@ describe("staging: unauthenticated endpoints", () => {
     expect(result).toHaveProperty("events");
   });
 
+  it("rooms.list returns array", async () => {
+    const result = await client.rooms.list();
+    expect(result).toHaveProperty("rooms");
+    expect(Array.isArray(result.rooms)).toBe(true);
+  });
+
   it("reputation.leaderboard returns data", async () => {
     const result = await client.reputation.leaderboard();
     expect(result).toBeDefined();
@@ -584,11 +590,11 @@ describe("staging: authenticated flows", () => {
     it("creates a moderation report", async () => {
       const report = await client.moderation.createReport({
         reporter: publicKeyB64,
-        contentType: "channel_message",
+        contentType: "channel-message",
         contentId: "msg_test_fake",
         ruleViolated: "spam",
         comment: "SDK test report",
-      } as any);
+      });
       expect(report).toHaveProperty("reportId");
       expect(report.status).toBe("pending");
     });


### PR DESCRIPTION
First step of the frontend-integration effort: round out the TypeScript SDK so it fully covers the backend, and fix the one failing staging test.

## Rooms / games module (new)
The backend exposes `/rooms/*` (poker/game rooms) but the SDK had no wrapper. Adds `client.rooms` (`RoomsApi`):

| Method | Endpoint |
|---|---|
| `list(query)` | `GET /rooms` |
| `create(room)` | `POST /rooms` |
| `get(id)` | `GET /rooms/{id}` |
| `join(id, body)` | `POST /rooms/{id}/join` |
| `leave(id, body)` | `POST /rooms/{id}/leave` |
| `action(id, body)` | `POST /rooms/{id}/action` |
| `listHands(id)` | `GET /rooms/{id}/hands` |
| `getHand(id, handId)` | `GET /rooms/{id}/hands/{handId}` |
| `stream(id)` | `WS /rooms/{id}/stream` |

- Full types in `src/types/games.ts` mirroring the backend models (`GameRoom`, `GameHand`, stakes/buy-in/escrow/seat/rake, action requests/responses).
- Reads are public; writes use directory-write auth, matching the backend handler.

## Moderation report fix
The staging test sent `contentType: "channel_message"` and got a **correct** HTTP 400 — the constitution-scoped value is `"channel-message"` (hyphen), per the backend. This was a test bug, not a backend bug.

- Fixed the test value.
- Added a `ModerationReportContentType` union + `MODERATION_REPORT_CONTENT_TYPES` constant and tightened `ModerationReport(Create).contentType` so consumers can't repeat the mistake.

## Verification
- `tsc` build clean.
- Staging suite against `https://staging-api.tiny.place`: **76/76 pass** (was 74/75), including the new `rooms.list` test and the now-passing moderation report.

## Note
No `package.json` version change here, so `publish-sdk.yml` won't trigger. Releasing `client.rooms` to npm is a follow-up version bump (via the `bump-sdk` workflow) whenever you want to cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rooms API for managing game rooms (list, create, join, leave, actions) and optional WebSocket streaming for real-time room updates.

* **Type Safety**
  * Added structured types for game rooms, hands, stakes, bets, and related payloads.
  * Tightened moderation report content-type to a predefined set.

* **Tests**
  * Added a staging test for room listing and updated moderation-report test payload format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->