### PR TITLE
feat: end-to-end encrypted direct messaging (wallet-derived Signal identity)

### DIFF
--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -62,6 +62,8 @@ export {
   serializePreKey,
   generateX25519KeyPair,
   ed25519PubToX25519Pub,
+  toBase64,
+  fromBase64,
 } from "./signal/index.js";
 export type {
   SessionStore,

--- a/sdk/typescript/src/local-signer.ts
+++ b/sdk/typescript/src/local-signer.ts
@@ -49,6 +49,37 @@ export class LocalSigner extends Signer {
     return new LocalSigner(keyPair);
   }
 
+  /**
+   * Derives a deterministic signer from a 32-byte Ed25519 seed. The same seed
+   * always yields the same identity (agentId, public key, and X25519 keys),
+   * which makes it suitable for recovering an encryption identity from a value
+   * the user can reproduce (e.g. a wallet signature over a fixed message).
+   *
+   * @param seed - Exactly 32 bytes of secret seed material.
+   * @returns A signer backed by the derived Ed25519 key.
+   */
+  static async fromSeed(seed: Uint8Array): Promise<LocalSigner> {
+    if (seed.length !== 32) {
+      throw new Error(`Ed25519 seed must be 32 bytes, got ${seed.length}`);
+    }
+    // PKCS#8 PrivateKeyInfo prefix for an Ed25519 key, followed by the raw seed.
+    const prefix = new Uint8Array([
+      0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70,
+      0x04, 0x22, 0x04, 0x20,
+    ]);
+    const pkcs8 = new Uint8Array(prefix.length + seed.length);
+    pkcs8.set(prefix, 0);
+    pkcs8.set(seed, prefix.length);
+    const privateKey = await globalThis.crypto.subtle.importKey(
+      "pkcs8",
+      pkcs8,
+      { name: "Ed25519" },
+      true,
+      ["sign"],
+    );
+    return LocalSigner.fromPrivateKey(privateKey);
+  }
+
   async sign(data: Uint8Array): Promise<Uint8Array> {
     const crypto = globalThis.crypto;
     const buffer = new ArrayBuffer(data.byteLength);

--- a/sdk/typescript/tests/local-signer.test.ts
+++ b/sdk/typescript/tests/local-signer.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { LocalSigner } from "../src/index.js";
+import { ed25519PubToX25519Pub, toBase64 } from "../src/signal/crypto.js";
+
+const seed = new Uint8Array(32).map((_, i) => (i * 7 + 3) & 0xff);
+
+describe("LocalSigner.fromSeed", () => {
+  it("rejects seeds that are not 32 bytes", async () => {
+    await expect(LocalSigner.fromSeed(new Uint8Array(16))).rejects.toThrow();
+  });
+
+  it("is deterministic — same seed yields the same identity", async () => {
+    const a = await LocalSigner.fromSeed(seed);
+    const b = await LocalSigner.fromSeed(seed);
+    expect(a.agentId).toBe(b.agentId);
+    expect(a.publicKeyBase64).toBe(b.publicKeyBase64);
+  });
+
+  it("different seeds yield different identities", async () => {
+    const a = await LocalSigner.fromSeed(seed);
+    const other = new Uint8Array(32).fill(9);
+    const b = await LocalSigner.fromSeed(other);
+    expect(a.publicKeyBase64).not.toBe(b.publicKeyBase64);
+  });
+
+  it("produces verifiable Ed25519 signatures", async () => {
+    const signer = await LocalSigner.fromSeed(seed);
+    const message = new TextEncoder().encode("hello tiny.place");
+    const signature = await signer.sign(message);
+    const key = await globalThis.crypto.subtle.importKey(
+      "raw",
+      signer.publicKey,
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    const ok = await globalThis.crypto.subtle.verify(
+      "Ed25519",
+      key,
+      signature,
+      message,
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("derives an X25519 keypair consistent with the Ed25519 identity key", async () => {
+    const signer = await LocalSigner.fromSeed(seed);
+    const x = await signer.getX25519KeyPair();
+    // The X25519 public key must equal the Montgomery form of the Ed25519
+    // identity key, which is what X3DH uses on the other side.
+    expect(toBase64(x.publicKey)).toBe(
+      toBase64(ed25519PubToX25519Pub(signer.publicKey)),
+    );
+  });
+});

--- a/website/src/common/encryption-discovery.ts
+++ b/website/src/common/encryption-discovery.ts
@@ -14,7 +14,10 @@ export const ENCRYPTION_PUBLIC_KEY_METADATA = "encryptionPublicKey";
  */
 export function resolveEncryptionAddress(card: AgentCard): string {
 	const advertised = card.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA];
-	const address = advertised ?? card.publicKey;
+	const address =
+		typeof advertised === "string" && advertised.length > 0
+			? advertised
+			: card.publicKey;
 	if (!address) {
 		throw new Error(
 			`Agent ${card.agentId} has no encryption public key or wallet public key`
@@ -26,12 +29,13 @@ export function resolveEncryptionAddress(card: AgentCard): string {
 /**
  * Advertises the wallet's Signal encryption pubkey in its directory agent card so
  * other agents can discover where to fetch its key bundle and address messages.
- * Best-effort: if the card cannot be read or written, the error is returned so the
- * caller can decide whether to treat it as fatal.
+ * No-op if the card already advertises this key.
  *
  * @param walletClient - A client authenticated with the wallet (directory-write).
  * @param walletAgentId - The wallet's agent id (the card to update).
  * @param encryptionPublicKey - The derived encryption public key (base64).
+ * @throws If the card cannot be read or written. Callers that treat advertising as
+ * best-effort should wrap this in try/catch.
  */
 export async function publishEncryptionKey(
 	walletClient: TinyVerseClient,

--- a/website/src/common/encryption-discovery.ts
+++ b/website/src/common/encryption-discovery.ts
@@ -1,0 +1,52 @@
+import type { AgentCard, TinyVerseClient } from "@tinyhumansai/tinyplace";
+
+/** Agent-card metadata key under which the Signal encryption pubkey is advertised. */
+export const ENCRYPTION_PUBLIC_KEY_METADATA = "encryptionPublicKey";
+
+/**
+ * Resolves the messaging/encryption address (base64 Ed25519 pubkey) for an agent
+ * card. Prefers the explicitly advertised encryption key; falls back to the card's
+ * own `publicKey`, which covers single-key agents whose messaging address is their
+ * identity key.
+ *
+ * @param card - The agent card to resolve.
+ * @returns The base64 encryption public key to address messages and bundles to.
+ */
+export function resolveEncryptionAddress(card: AgentCard): string {
+	const advertised = card.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA];
+	const address = advertised ?? card.publicKey;
+	if (!address) {
+		throw new Error(
+			`Agent ${card.agentId} has no encryption public key or wallet public key`
+		);
+	}
+	return address;
+}
+
+/**
+ * Advertises the wallet's Signal encryption pubkey in its directory agent card so
+ * other agents can discover where to fetch its key bundle and address messages.
+ * Best-effort: if the card cannot be read or written, the error is returned so the
+ * caller can decide whether to treat it as fatal.
+ *
+ * @param walletClient - A client authenticated with the wallet (directory-write).
+ * @param walletAgentId - The wallet's agent id (the card to update).
+ * @param encryptionPublicKey - The derived encryption public key (base64).
+ */
+export async function publishEncryptionKey(
+	walletClient: TinyVerseClient,
+	walletAgentId: string,
+	encryptionPublicKey: string
+): Promise<void> {
+	const card = await walletClient.directory.getAgent(walletAgentId);
+	const metadata = { ...card.metadata };
+	if (metadata[ENCRYPTION_PUBLIC_KEY_METADATA] === encryptionPublicKey) {
+		return;
+	}
+	metadata[ENCRYPTION_PUBLIC_KEY_METADATA] = encryptionPublicKey;
+	await walletClient.directory.upsertAgent(walletAgentId, {
+		...card,
+		metadata,
+		updatedAt: new Date().toISOString(),
+	});
+}

--- a/website/src/common/signal-identity.ts
+++ b/website/src/common/signal-identity.ts
@@ -1,0 +1,99 @@
+import { LocalSigner, type X25519KeyPair } from "@tinyhumansai/tinyplace";
+
+import {
+	IndexedDbSessionStore,
+	loadStoredSeed,
+	openSignalDatabase,
+	storeSeed,
+} from "@src/common/signal-store";
+
+type SignMessageFunction = (message: Uint8Array) => Promise<Uint8Array>;
+
+/**
+ * Fixed message the wallet signs to derive the end-to-end encryption identity.
+ * The signature is deterministic per wallet, so the same wallet always recovers
+ * the same encryption keys. Bumping the version invalidates derived keys.
+ */
+export const ENCRYPTION_IDENTITY_MESSAGE =
+	"tiny.place encryption identity v1\n\n" +
+	"Sign this message to derive your end-to-end encryption keys. " +
+	"This is free, off-chain, and does not authorize any transaction.";
+
+/**
+ * The Signal/encryption identity for the current wallet. This is intentionally
+ * separate from the wallet itself: the wallet still signs API auth and payments,
+ * while this derived key powers Signal Protocol (X3DH + Double Ratchet). It is
+ * derived deterministically from a wallet signature, so it is recoverable.
+ */
+export interface SignalIdentity {
+	/** Ed25519 signer for the encryption identity (signs pre-keys, decrypts). */
+	signer: LocalSigner;
+	/** Long-term X25519 identity key pair used in X3DH. */
+	identityKeyPair: X25519KeyPair;
+	/** Raw Ed25519 identity public key (published in the agent's key bundle). */
+	identityPublicKey: Uint8Array;
+	/** Persistent IndexedDB-backed Signal session store. */
+	store: IndexedDbSessionStore;
+}
+
+async function deriveSeedFromSignature(
+	signature: Uint8Array
+): Promise<Uint8Array> {
+	// Copy into a fresh ArrayBuffer so the type is a plain BufferSource (avoids
+	// the SharedArrayBuffer ambiguity in Uint8Array<ArrayBufferLike>).
+	const buffer = new ArrayBuffer(signature.byteLength);
+	new Uint8Array(buffer).set(signature);
+	const digest = await globalThis.crypto.subtle.digest("SHA-256", buffer);
+	return new Uint8Array(digest);
+}
+
+/**
+ * Loads the wallet's encryption identity, deriving and persisting it on first
+ * use. On the first call for a wallet the user is prompted to sign
+ * {@link ENCRYPTION_IDENTITY_MESSAGE}; afterwards the seed is read from
+ * IndexedDB and no prompt is shown.
+ *
+ * @param walletAgentId - The wallet-derived agent id that scopes this identity.
+ * @param signMessage - The wallet's message-signing function.
+ * @returns The resolved Signal identity (signer, keys, and session store).
+ */
+export async function loadOrCreateSignalIdentity(
+	walletAgentId: string,
+	signMessage: SignMessageFunction
+): Promise<SignalIdentity> {
+	const db = await openSignalDatabase();
+
+	let seed = await loadStoredSeed(db, walletAgentId);
+	if (!seed) {
+		const message = new TextEncoder().encode(ENCRYPTION_IDENTITY_MESSAGE);
+		const signature = await signMessage(message);
+		seed = await deriveSeedFromSignature(signature);
+		await storeSeed(db, walletAgentId, seed);
+	}
+
+	const signer = await LocalSigner.fromSeed(seed);
+	const identityKeyPair = await signer.getX25519KeyPair();
+	const store = new IndexedDbSessionStore(db, walletAgentId, identityKeyPair);
+
+	return {
+		signer,
+		identityKeyPair,
+		identityPublicKey: signer.publicKey,
+		store,
+	};
+}
+
+/**
+ * Whether the given wallet already has a persisted encryption identity (so it
+ * can be loaded without prompting for a signature).
+ *
+ * @param walletAgentId - The wallet-derived agent id.
+ * @returns True if a seed is already stored for this wallet.
+ */
+export async function hasSignalIdentity(
+	walletAgentId: string
+): Promise<boolean> {
+	const db = await openSignalDatabase();
+	const seed = await loadStoredSeed(db, walletAgentId);
+	return seed !== undefined;
+}

--- a/website/src/common/signal-messaging.ts
+++ b/website/src/common/signal-messaging.ts
@@ -160,24 +160,30 @@ export async function fetchInbox(
 	// Sequential by design: the Double Ratchet advances per message, so decryption
 	// must happen in delivery order — these awaits cannot be parallelized.
 	for (const envelope of messages) {
+		let plaintext: Uint8Array;
 		try {
 			const senderX25519 = ed25519PubToX25519Pub(fromBase64(envelope.from));
 			// eslint-disable-next-line no-await-in-loop
-			const plaintext = await session.decrypt(
-				envelope.from,
-				senderX25519,
-				envelope
-			);
-			decrypted.push({
-				id: envelope.id,
-				from: envelope.from,
-				text: new TextDecoder().decode(plaintext),
-				at: envelope.timestamp,
-			});
+			plaintext = await session.decrypt(envelope.from, senderX25519, envelope);
+		} catch (error) {
+			console.warn(`Failed to decrypt message ${envelope.id}:`, error);
+			continue;
+		}
+
+		decrypted.push({
+			id: envelope.id,
+			from: envelope.from,
+			text: new TextDecoder().decode(plaintext),
+			at: envelope.timestamp,
+		});
+
+		// Acknowledge separately: the message is already decrypted (the ratchet has
+		// advanced), so an ack failure must not be reported as a decrypt failure.
+		try {
 			// eslint-disable-next-line no-await-in-loop
 			await encClient.messages.acknowledge(envelope.id, address);
 		} catch (error) {
-			console.warn(`Failed to decrypt message ${envelope.id}:`, error);
+			console.warn(`Failed to acknowledge message ${envelope.id}:`, error);
 		}
 	}
 

--- a/website/src/common/signal-messaging.ts
+++ b/website/src/common/signal-messaging.ts
@@ -1,0 +1,185 @@
+import {
+	SignalSession,
+	ed25519PubToX25519Pub,
+	fromBase64,
+	generatePreKeys,
+	generateSignedPreKey,
+	serializePreKey,
+	serializeSignedKey,
+	type TinyVerseClient,
+} from "@tinyhumansai/tinyplace";
+
+import { createClient } from "@src/common/api-client";
+import type { SignalIdentity } from "@src/common/signal-identity";
+
+/** Number of one-time pre-keys uploaded per publish. */
+const ONE_TIME_PREKEY_COUNT = 10;
+
+/** A decrypted inbound direct message. */
+export interface DecryptedMessage {
+	id: string;
+	/** Sender messaging address (base64 encryption pubkey). */
+	from: string;
+	text: string;
+	at: string;
+}
+
+let messageCounter = 0;
+
+function nextMessageId(): string {
+	messageCounter += 1;
+	return `msg_${new Date().getTime()}_${messageCounter}`;
+}
+
+/**
+ * Builds the dedicated messaging client, authenticated with the derived
+ * encryption signer. This client owns all `/keys` and `/messages` traffic and is
+ * addressed by the derived public key — distinct from the wallet client used for
+ * directory and payments.
+ *
+ * @param identity - The resolved Signal identity.
+ * @returns A client signing requests with the encryption identity.
+ */
+export function createEncryptionClient(
+	identity: SignalIdentity
+): TinyVerseClient {
+	return createClient(identity.signer);
+}
+
+/**
+ * Generates and publishes the identity's Signal key bundle (signed pre-key plus a
+ * batch of one-time pre-keys), persisting the private halves in the session store
+ * so inbound X3DH messages can be answered across reloads.
+ *
+ * @param encClient - The encryption-authenticated client.
+ * @param identity - The resolved Signal identity.
+ */
+export async function publishKeyBundle(
+	encClient: TinyVerseClient,
+	identity: SignalIdentity
+): Promise<void> {
+	const address = identity.signer.publicKeyBase64;
+
+	const signedPreKey = await generateSignedPreKey(
+		identity.signer,
+		`spk_${new Date().getTime()}`
+	);
+	const preKeys = await generatePreKeys(
+		identity.signer,
+		1,
+		ONE_TIME_PREKEY_COUNT
+	);
+
+	await identity.store.storeSignedPreKey(signedPreKey);
+	await Promise.all(
+		preKeys.map((preKey) => identity.store.storePreKey(preKey))
+	);
+
+	await encClient.keys.rotateSignedPreKey(address, {
+		identityKey: address,
+		signedPreKey: serializeSignedKey(signedPreKey),
+	});
+	await encClient.keys.uploadPreKeys(address, {
+		identityKey: address,
+		preKeys: preKeys.map(serializePreKey),
+	});
+}
+
+/**
+ * Creates the long-lived Signal session bound to this identity's persistent store.
+ *
+ * @param identity - The resolved Signal identity.
+ * @returns A session for encrypting and decrypting direct messages.
+ */
+export function createSession(identity: SignalIdentity): SignalSession {
+	return new SignalSession(identity.store, identity.identityKeyPair.publicKey);
+}
+
+/**
+ * Encrypts and sends a direct message to a recipient addressed by their encryption
+ * public key. On the first message to a recipient, their key bundle is fetched to
+ * bootstrap the X3DH handshake.
+ *
+ * @param encClient - The encryption-authenticated client.
+ * @param session - The sender's Signal session.
+ * @param identity - The sender's Signal identity.
+ * @param toEncKeyB64 - The recipient's encryption public key (base64).
+ * @param text - The plaintext message.
+ */
+export async function sendDirectMessage(
+	encClient: TinyVerseClient,
+	session: SignalSession,
+	identity: SignalIdentity,
+	toEncKeyB64: string,
+	text: string
+): Promise<void> {
+	const hasSession = await session.hasSession(toEncKeyB64);
+	const bundle = hasSession
+		? undefined
+		: await encClient.keys.getBundle(toEncKeyB64);
+	const recipientX25519 = ed25519PubToX25519Pub(fromBase64(toEncKeyB64));
+
+	const encrypted = await session.encrypt(
+		toEncKeyB64,
+		recipientX25519,
+		new TextEncoder().encode(text),
+		bundle
+	);
+
+	await encClient.messages.send({
+		id: nextMessageId(),
+		from: identity.signer.publicKeyBase64,
+		to: toEncKeyB64,
+		timestamp: new Date().toISOString(),
+		deviceId: 1,
+		type: encrypted.type,
+		body: encrypted.body,
+		signal: encrypted.signal,
+	});
+}
+
+/**
+ * Fetches, decrypts, and acknowledges all pending inbound messages. Each message
+ * is decrypted independently so a single undecryptable envelope does not abort the
+ * batch.
+ *
+ * @param encClient - The encryption-authenticated client.
+ * @param session - The recipient's Signal session.
+ * @param identity - The recipient's Signal identity.
+ * @returns The successfully decrypted messages, oldest first.
+ */
+export async function fetchInbox(
+	encClient: TinyVerseClient,
+	session: SignalSession,
+	identity: SignalIdentity
+): Promise<Array<DecryptedMessage>> {
+	const address = identity.signer.publicKeyBase64;
+	const { messages } = await encClient.messages.list(address);
+	const decrypted: Array<DecryptedMessage> = [];
+
+	// Sequential by design: the Double Ratchet advances per message, so decryption
+	// must happen in delivery order — these awaits cannot be parallelized.
+	for (const envelope of messages) {
+		try {
+			const senderX25519 = ed25519PubToX25519Pub(fromBase64(envelope.from));
+			// eslint-disable-next-line no-await-in-loop
+			const plaintext = await session.decrypt(
+				envelope.from,
+				senderX25519,
+				envelope
+			);
+			decrypted.push({
+				id: envelope.id,
+				from: envelope.from,
+				text: new TextDecoder().decode(plaintext),
+				at: envelope.timestamp,
+			});
+			// eslint-disable-next-line no-await-in-loop
+			await encClient.messages.acknowledge(envelope.id, address);
+		} catch (error) {
+			console.warn(`Failed to decrypt message ${envelope.id}:`, error);
+		}
+	}
+
+	return decrypted;
+}

--- a/website/src/common/signal-store.ts
+++ b/website/src/common/signal-store.ts
@@ -1,0 +1,236 @@
+import type {
+	PreKeyPair,
+	SessionState,
+	SessionStore,
+	SignedPreKeyPair,
+	X25519KeyPair,
+} from "@tinyhumansai/tinyplace";
+
+const DB_NAME = "tinyplace-signal";
+const DB_VERSION = 1;
+
+const STORE_SEEDS = "seeds";
+const STORE_SIGNED_PREKEYS = "signedPreKeys";
+const STORE_PREKEYS = "preKeys";
+const STORE_SESSIONS = "sessions";
+const STORE_META = "meta";
+
+const ALL_STORES = [
+	STORE_SEEDS,
+	STORE_SIGNED_PREKEYS,
+	STORE_PREKEYS,
+	STORE_SESSIONS,
+	STORE_META,
+] as const;
+
+function promisifyRequest<T>(request: IDBRequest<T>): Promise<T> {
+	return new Promise((resolve, reject) => {
+		request.onsuccess = (): void => {
+			resolve(request.result);
+		};
+		request.onerror = (): void => {
+			reject(request.error ?? new Error("IndexedDB request failed"));
+		};
+	});
+}
+
+/** Opens (and migrates) the shared Signal IndexedDB database. */
+export function openSignalDatabase(): Promise<IDBDatabase> {
+	return new Promise((resolve, reject) => {
+		const request = globalThis.indexedDB.open(DB_NAME, DB_VERSION);
+		request.onupgradeneeded = (): void => {
+			const db = request.result;
+			for (const store of ALL_STORES) {
+				if (!db.objectStoreNames.contains(store)) {
+					db.createObjectStore(store);
+				}
+			}
+		};
+		request.onsuccess = (): void => {
+			resolve(request.result);
+		};
+		request.onerror = (): void => {
+			reject(request.error ?? new Error("Failed to open Signal database"));
+		};
+	});
+}
+
+async function idbGet<T>(
+	db: IDBDatabase,
+	store: string,
+	key: string
+): Promise<T | undefined> {
+	const tx = db.transaction(store, "readonly");
+	return promisifyRequest<T | undefined>(
+		tx.objectStore(store).get(key) as IDBRequest<T | undefined>
+	);
+}
+
+async function idbPut(
+	db: IDBDatabase,
+	store: string,
+	key: string,
+	value: unknown
+): Promise<void> {
+	const tx = db.transaction(store, "readwrite");
+	await promisifyRequest(tx.objectStore(store).put(value, key));
+}
+
+async function idbDelete(
+	db: IDBDatabase,
+	store: string,
+	key: string
+): Promise<void> {
+	const tx = db.transaction(store, "readwrite");
+	await promisifyRequest(tx.objectStore(store).delete(key));
+}
+
+async function idbGetAllByPrefix<T>(
+	db: IDBDatabase,
+	store: string,
+	prefix: string
+): Promise<Array<T>> {
+	const tx = db.transaction(store, "readonly");
+	const range = IDBKeyRange.bound(prefix, `${prefix}￿`);
+	return promisifyRequest<Array<T>>(
+		tx.objectStore(store).getAll(range) as IDBRequest<Array<T>>
+	);
+}
+
+/** Reads a persisted identity seed for a wallet, if one exists. */
+export async function loadStoredSeed(
+	db: IDBDatabase,
+	ownerId: string
+): Promise<Uint8Array | undefined> {
+	return idbGet<Uint8Array>(db, STORE_SEEDS, ownerId);
+}
+
+/** Persists an identity seed for a wallet. */
+export async function storeSeed(
+	db: IDBDatabase,
+	ownerId: string,
+	seed: Uint8Array
+): Promise<void> {
+	await idbPut(db, STORE_SEEDS, ownerId, seed);
+}
+
+/**
+ * IndexedDB-backed {@link SessionStore}. Persists the Signal signed pre-key,
+ * one-time pre-keys, and ratchet sessions so encrypted conversations survive
+ * reloads. All records are namespaced by the owning wallet's agent id so
+ * multiple identities can share one browser. The identity X25519 key itself is
+ * derived from the seed (via the signer) and supplied at construction.
+ *
+ * Records contain `Uint8Array` and `Map` values, which the structured-clone
+ * algorithm used by IndexedDB preserves, so no manual serialization is needed.
+ */
+export class IndexedDbSessionStore implements SessionStore {
+	private readonly db: IDBDatabase;
+	private readonly ownerId: string;
+	private readonly identityKeyPair: X25519KeyPair;
+
+	public constructor(
+		db: IDBDatabase,
+		ownerId: string,
+		identityKeyPair: X25519KeyPair
+	) {
+		this.db = db;
+		this.ownerId = ownerId;
+		this.identityKeyPair = identityKeyPair;
+	}
+
+	private scoped(id: string): string {
+		return `${this.ownerId}:${id}`;
+	}
+
+	private prefix(): string {
+		return `${this.ownerId}:`;
+	}
+
+	public getIdentityX25519KeyPair(): Promise<X25519KeyPair> {
+		return Promise.resolve(this.identityKeyPair);
+	}
+
+	public async getSignedPreKey(
+		keyId: string
+	): Promise<SignedPreKeyPair | null> {
+		const result = await idbGet<SignedPreKeyPair>(
+			this.db,
+			STORE_SIGNED_PREKEYS,
+			this.scoped(keyId)
+		);
+		return result ?? null;
+	}
+
+	public async getActiveSignedPreKey(): Promise<SignedPreKeyPair> {
+		const activeId = await idbGet<string>(
+			this.db,
+			STORE_META,
+			this.scoped("activeSignedPreKey")
+		);
+		if (!activeId) {
+			throw new Error("No active signed pre-key");
+		}
+		const key = await this.getSignedPreKey(activeId);
+		if (!key) {
+			throw new Error("Active signed pre-key not found");
+		}
+		return key;
+	}
+
+	public async storeSignedPreKey(preKey: SignedPreKeyPair): Promise<void> {
+		await idbPut(
+			this.db,
+			STORE_SIGNED_PREKEYS,
+			this.scoped(preKey.keyId),
+			preKey
+		);
+		await idbPut(
+			this.db,
+			STORE_META,
+			this.scoped("activeSignedPreKey"),
+			preKey.keyId
+		);
+	}
+
+	public async getPreKey(keyId: string): Promise<PreKeyPair | null> {
+		const result = await idbGet<PreKeyPair>(
+			this.db,
+			STORE_PREKEYS,
+			this.scoped(keyId)
+		);
+		return result ?? null;
+	}
+
+	public async removePreKey(keyId: string): Promise<void> {
+		await idbDelete(this.db, STORE_PREKEYS, this.scoped(keyId));
+	}
+
+	public async storePreKey(preKey: PreKeyPair): Promise<void> {
+		await idbPut(this.db, STORE_PREKEYS, this.scoped(preKey.keyId), preKey);
+	}
+
+	public async getAllPreKeys(): Promise<Array<PreKeyPair>> {
+		return idbGetAllByPrefix<PreKeyPair>(this.db, STORE_PREKEYS, this.prefix());
+	}
+
+	public async getSession(address: string): Promise<SessionState | null> {
+		const result = await idbGet<SessionState>(
+			this.db,
+			STORE_SESSIONS,
+			this.scoped(address)
+		);
+		return result ?? null;
+	}
+
+	public async storeSession(
+		address: string,
+		session: SessionState
+	): Promise<void> {
+		await idbPut(this.db, STORE_SESSIONS, this.scoped(address), session);
+	}
+
+	public async removeSession(address: string): Promise<void> {
+		await idbDelete(this.db, STORE_SESSIONS, this.scoped(address));
+	}
+}

--- a/website/src/common/signal-store.ts
+++ b/website/src/common/signal-store.ts
@@ -85,6 +85,29 @@ async function idbDelete(
 	await promisifyRequest(tx.objectStore(store).delete(key));
 }
 
+/** Writes several records across stores in a single atomic transaction. */
+function idbPutAll(
+	db: IDBDatabase,
+	entries: Array<{ store: string; key: string; value: unknown }>
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const stores = Array.from(new Set(entries.map((entry) => entry.store)));
+		const tx = db.transaction(stores, "readwrite");
+		tx.oncomplete = (): void => {
+			resolve();
+		};
+		tx.onerror = (): void => {
+			reject(tx.error ?? new Error("IndexedDB transaction failed"));
+		};
+		tx.onabort = (): void => {
+			reject(tx.error ?? new Error("IndexedDB transaction aborted"));
+		};
+		for (const entry of entries) {
+			tx.objectStore(entry.store).put(entry.value, entry.key);
+		}
+	});
+}
+
 async function idbGetAllByPrefix<T>(
 	db: IDBDatabase,
 	store: string,
@@ -179,18 +202,20 @@ export class IndexedDbSessionStore implements SessionStore {
 	}
 
 	public async storeSignedPreKey(preKey: SignedPreKeyPair): Promise<void> {
-		await idbPut(
-			this.db,
-			STORE_SIGNED_PREKEYS,
-			this.scoped(preKey.keyId),
-			preKey
-		);
-		await idbPut(
-			this.db,
-			STORE_META,
-			this.scoped("activeSignedPreKey"),
-			preKey.keyId
-		);
+		// Atomic: persist the key and mark it active in one transaction, so a partial
+		// failure can't leave a stored key that getActiveSignedPreKey() can't find.
+		await idbPutAll(this.db, [
+			{
+				store: STORE_SIGNED_PREKEYS,
+				key: this.scoped(preKey.keyId),
+				value: preKey,
+			},
+			{
+				store: STORE_META,
+				key: this.scoped("activeSignedPreKey"),
+				value: preKey.keyId,
+			},
+		]);
 	}
 
 	public async getPreKey(keyId: string): Promise<PreKeyPair | null> {

--- a/website/src/components/explore/CommunicationMock.tsx
+++ b/website/src/components/explore/CommunicationMock.tsx
@@ -5,23 +5,26 @@ import { useState } from "react";
 import type { FunctionComponent } from "@src/common/types";
 
 import { BroadcastsMock } from "./BroadcastsMock";
+import { DirectMessages } from "./DirectMessages";
 import { GroupsMock } from "./GroupsMock";
 import { InboxMock } from "./InboxMock";
 import { MessagingMock } from "./MessagingMock";
 
-const tabs = ["dms", "groups", "broadcasts", "inbox"] as const;
+const tabs = ["dms", "channels", "groups", "broadcasts", "inbox"] as const;
 
 type Tab = (typeof tabs)[number];
 
 const tabLabels: Record<Tab, string> = {
 	dms: "DMs",
+	channels: "Channels",
 	groups: "Groups",
 	broadcasts: "Broadcasts",
 	inbox: "Inbox",
 };
 
 const tabComponents: Record<Tab, React.ComponentType<{ isDark: boolean }>> = {
-	dms: MessagingMock,
+	dms: DirectMessages,
+	channels: MessagingMock,
 	groups: GroupsMock,
 	broadcasts: BroadcastsMock,
 	inbox: InboxMock,

--- a/website/src/components/explore/DirectMessages.tsx
+++ b/website/src/components/explore/DirectMessages.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useState } from "react";
+
+import type { FunctionComponent } from "@src/common/types";
+import { useDirectMessages } from "@src/hooks/use-direct-messages";
+
+type DirectMessagesProperties = {
+	isDark: boolean;
+};
+
+export const DirectMessages = ({
+	isDark,
+}: DirectMessagesProperties): FunctionComponent => {
+	const {
+		isReady,
+		isEnabling,
+		error,
+		enable,
+		peers,
+		threads,
+		addPeer,
+		send,
+		isSending,
+	} = useDirectMessages();
+
+	const [selected, setSelected] = useState<string>("");
+	const [peerInput, setPeerInput] = useState<string>("");
+	const [messageInput, setMessageInput] = useState<string>("");
+
+	const panelClass = isDark
+		? "border-neutral-800 bg-neutral-950"
+		: "border-neutral-200 bg-white";
+	const mutedText = isDark ? "text-neutral-500" : "text-neutral-400";
+
+	if (!isReady) {
+		return (
+			<div
+				className={`flex flex-col items-center justify-center gap-3 rounded-lg border p-8 text-center ${panelClass}`}
+			>
+				<p className={`text-sm ${mutedText}`}>
+					End-to-end encrypted messaging needs a one-time signature to derive
+					your encryption keys.
+				</p>
+				<button
+					disabled={isEnabling}
+					type="button"
+					className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+						isDark
+							? "bg-white text-black hover:bg-neutral-200"
+							: "bg-black text-white hover:bg-neutral-800"
+					} ${isEnabling ? "opacity-50" : ""}`}
+					onClick={(): void => {
+						void enable();
+					}}
+				>
+					{isEnabling ? "Deriving keys…" : "Enable encryption"}
+				</button>
+				{error ? <p className="text-xs text-rose-500">{error}</p> : null}
+			</div>
+		);
+	}
+
+	const activeThread = selected ? (threads[selected] ?? []) : [];
+
+	return (
+		<div className="grid grid-cols-[180px_1fr] gap-3">
+			<div
+				className={`flex flex-col gap-2 rounded-lg border p-2 ${panelClass}`}
+			>
+				<form
+					className="flex flex-col gap-1"
+					onSubmit={(event): void => {
+						event.preventDefault();
+						void addPeer(peerInput);
+						setPeerInput("");
+					}}
+				>
+					<input
+						placeholder="@handle or key"
+						value={peerInput}
+						className={`rounded-md border px-2 py-1 text-xs ${
+							isDark
+								? "border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-600"
+								: "border-neutral-200 bg-white text-black placeholder:text-neutral-400"
+						}`}
+						onChange={(event): void => {
+							setPeerInput(event.target.value);
+						}}
+					/>
+				</form>
+				{peers.length === 0 ? (
+					<p className={`px-1 text-xs ${mutedText}`}>No conversations yet</p>
+				) : null}
+				{peers.map((peer) => (
+					<button
+						key={peer.address}
+						type="button"
+						className={`truncate rounded-md px-2 py-1 text-left text-xs transition-colors ${
+							selected === peer.address
+								? isDark
+									? "bg-neutral-800 text-white"
+									: "bg-neutral-200 text-black"
+								: mutedText
+						}`}
+						onClick={(): void => {
+							setSelected(peer.address);
+						}}
+					>
+						{peer.label}
+					</button>
+				))}
+			</div>
+
+			<div className={`flex flex-col rounded-lg border ${panelClass}`}>
+				{!selected ? (
+					<div
+						className={`flex flex-1 items-center justify-center p-8 text-xs ${mutedText}`}
+					>
+						Select or add a conversation
+					</div>
+				) : (
+					<>
+						<div className="flex flex-1 flex-col gap-2 overflow-y-auto p-3">
+							{activeThread.length === 0 ? (
+								<p className={`text-xs ${mutedText}`}>
+									No messages yet — say hello
+								</p>
+							) : null}
+							{activeThread.map((message) => (
+								<div
+									key={message.id}
+									className={`max-w-[75%] rounded-lg px-2.5 py-1.5 text-xs ${
+										message.outgoing
+											? "self-end bg-blue-600 text-white"
+											: isDark
+												? "self-start bg-neutral-800 text-white"
+												: "self-start bg-neutral-100 text-black"
+									}`}
+								>
+									{message.text}
+								</div>
+							))}
+						</div>
+						<form
+							className="flex gap-2 border-t border-neutral-800/40 p-2"
+							onSubmit={(event): void => {
+								event.preventDefault();
+								void send(selected, messageInput);
+								setMessageInput("");
+							}}
+						>
+							<input
+								placeholder="Type a message…"
+								value={messageInput}
+								className={`flex-1 rounded-md border px-2 py-1 text-xs ${
+									isDark
+										? "border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-600"
+										: "border-neutral-200 bg-white text-black placeholder:text-neutral-400"
+								}`}
+								onChange={(event): void => {
+									setMessageInput(event.target.value);
+								}}
+							/>
+							<button
+								disabled={isSending || !messageInput.trim()}
+								type="submit"
+								className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+									isDark ? "bg-white text-black" : "bg-black text-white"
+								} ${isSending || !messageInput.trim() ? "opacity-50" : ""}`}
+							>
+								Send
+							</button>
+						</form>
+					</>
+				)}
+			</div>
+		</div>
+	);
+};

--- a/website/src/components/explore/DirectMessages.tsx
+++ b/website/src/components/explore/DirectMessages.tsx
@@ -28,6 +28,22 @@ export const DirectMessages = ({
 	const [peerInput, setPeerInput] = useState<string>("");
 	const [messageInput, setMessageInput] = useState<string>("");
 
+	const handleSend = (): void => {
+		const text = messageInput.trim();
+		if (!text || !selected || isSending) {
+			return;
+		}
+		// Clear the draft only after the send succeeds, so a failed send keeps the
+		// user's text instead of silently dropping it.
+		void send(selected, text)
+			.then((): void => {
+				setMessageInput("");
+			})
+			.catch((): void => {
+				/* keep the draft; the hook logs the failure */
+			});
+	};
+
 	const panelClass = isDark
 		? "border-neutral-800 bg-neutral-950"
 		: "border-neutral-200 bg-white";
@@ -146,8 +162,7 @@ export const DirectMessages = ({
 							className="flex gap-2 border-t border-neutral-800/40 p-2"
 							onSubmit={(event): void => {
 								event.preventDefault();
-								void send(selected, messageInput);
-								setMessageInput("");
+								handleSend();
 							}}
 						>
 							<input

--- a/website/src/hooks/use-direct-messages.ts
+++ b/website/src/hooks/use-direct-messages.ts
@@ -1,0 +1,143 @@
+"use client";
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { useApiClient } from "@src/common/api-context";
+import { resolveEncryptionAddress } from "@src/common/encryption-discovery";
+import {
+	fetchInbox,
+	sendDirectMessage,
+	type DecryptedMessage,
+} from "@src/common/signal-messaging";
+import { useSignalIdentity } from "@src/hooks/use-signal-identity";
+import {
+	useConversationsStore,
+	type ConversationPeer,
+	type DirectMessageEntry,
+} from "@src/store/conversations";
+import { useMessagingStore } from "@src/store/messaging";
+import { useSignalStore } from "@src/store/signal";
+
+const INBOX_POLL_INTERVAL_MS = 5_000;
+
+type UseDirectMessagesResult = {
+	isReady: boolean;
+	isEnabling: boolean;
+	error: string | undefined;
+	enable: () => Promise<void>;
+	peers: Array<ConversationPeer>;
+	threads: Record<string, Array<DirectMessageEntry>>;
+	/** Resolves an @handle / agent id / raw encryption key to a peer and adds it. */
+	addPeer: (input: string) => Promise<void>;
+	send: (address: string, text: string) => Promise<void>;
+	isSending: boolean;
+};
+
+/**
+ * Drives the encrypted direct-message experience: identity enablement, inbox
+ * polling (decrypt + accumulate, since the relay deletes acknowledged messages),
+ * peer resolution via the directory, and sending.
+ */
+export function useDirectMessages(): UseDirectMessagesResult {
+	const walletClient = useApiClient();
+	const {
+		status,
+		isReady,
+		error,
+		enable: enableIdentity,
+	} = useSignalIdentity();
+	const identity = useSignalStore((state) => state.identity);
+	const encryptionClient = useMessagingStore((state) => state.encryptionClient);
+	const session = useMessagingStore((state) => state.session);
+
+	const peers = useConversationsStore((state) => state.peers);
+	const threads = useConversationsStore((state) => state.threads);
+	const addPeerToStore = useConversationsStore((state) => state.addPeer);
+	const appendOutgoing = useConversationsStore((state) => state.appendOutgoing);
+	const appendIncoming = useConversationsStore((state) => state.appendIncoming);
+
+	useQuery({
+		queryKey: ["direct-messages", "inbox", identity?.signer.publicKeyBase64],
+		enabled: isReady && Boolean(encryptionClient && session && identity),
+		refetchInterval: INBOX_POLL_INTERVAL_MS,
+		queryFn: async (): Promise<Array<DecryptedMessage>> => {
+			if (!encryptionClient || !session || !identity) {
+				return [];
+			}
+			const messages = await fetchInbox(encryptionClient, session, identity);
+			appendIncoming(messages);
+			return messages;
+		},
+	});
+
+	const sendMutation = useMutation({
+		mutationFn: async (input: {
+			address: string;
+			text: string;
+		}): Promise<void> => {
+			if (!encryptionClient || !session || !identity) {
+				throw new Error("Encryption is not ready");
+			}
+			await sendDirectMessage(
+				encryptionClient,
+				session,
+				identity,
+				input.address,
+				input.text
+			);
+		},
+	});
+
+	const enable = useCallback(async (): Promise<void> => {
+		await enableIdentity();
+	}, [enableIdentity]);
+
+	const addPeer = useCallback(
+		async (input: string): Promise<void> => {
+			const trimmed = input.trim();
+			if (!trimmed) {
+				return;
+			}
+			if (trimmed.startsWith("@") || trimmed.startsWith("tiny1")) {
+				const card = await walletClient.directory.getAgent(trimmed);
+				addPeerToStore({
+					address: resolveEncryptionAddress(card),
+					label: card.username ?? card.agentId,
+				});
+				return;
+			}
+			addPeerToStore({ address: trimmed, label: `${trimmed.slice(0, 10)}…` });
+		},
+		[walletClient, addPeerToStore]
+	);
+
+	const send = useCallback(
+		async (address: string, text: string): Promise<void> => {
+			const body = text.trim();
+			if (!body) {
+				return;
+			}
+			await sendMutation.mutateAsync({ address, text: body });
+			appendOutgoing(address, {
+				id: `local_${new Date().getTime()}`,
+				text: body,
+				at: new Date().toISOString(),
+				outgoing: true,
+			});
+		},
+		[sendMutation, appendOutgoing]
+	);
+
+	return {
+		isReady,
+		isEnabling: status === "loading",
+		error,
+		enable,
+		peers,
+		threads,
+		addPeer,
+		send,
+		isSending: sendMutation.isPending,
+	};
+}

--- a/website/src/hooks/use-signal-identity.ts
+++ b/website/src/hooks/use-signal-identity.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useWallet } from "@solana/wallet-adapter-react";
+import { useCallback, useEffect } from "react";
+
+import type { SignalIdentity } from "@src/common/signal-identity";
+import { useAuthStore } from "@src/store/auth";
+import { useSignalStore, type SignalStatus } from "@src/store/signal";
+
+type UseSignalIdentityResult = {
+	status: SignalStatus;
+	identity: SignalIdentity | undefined;
+	error: string | undefined;
+	/** True once the encryption identity is derived and ready to use. */
+	isReady: boolean;
+	/** True while the wallet is connected and can derive an identity. */
+	canEnable: boolean;
+	/**
+	 * Derives or loads the encryption identity for the connected wallet. Prompts
+	 * for a wallet signature only on first use; subsequent calls load from
+	 * IndexedDB. Resolves to the identity, or `undefined` if no wallet/signer.
+	 */
+	enable: () => Promise<SignalIdentity | undefined>;
+};
+
+/**
+ * Manages the wallet's end-to-end encryption identity (separate from the wallet
+ * auth signer). Resets the identity automatically when the wallet disconnects.
+ */
+export function useSignalIdentity(): UseSignalIdentityResult {
+	const { connected, signMessage } = useWallet();
+	const agentId = useAuthStore((state) => state.agentId);
+	const status = useSignalStore((state) => state.status);
+	const identity = useSignalStore((state) => state.identity);
+	const error = useSignalStore((state) => state.error);
+	const enableIdentity = useSignalStore((state) => state.enable);
+	const reset = useSignalStore((state) => state.reset);
+
+	useEffect(() => {
+		if (!connected) {
+			reset();
+		}
+	}, [connected, reset]);
+
+	const canEnable = connected && Boolean(signMessage) && Boolean(agentId);
+
+	const enable = useCallback(async (): Promise<SignalIdentity | undefined> => {
+		if (!agentId || !signMessage) {
+			return undefined;
+		}
+		await enableIdentity(agentId, signMessage);
+		return useSignalStore.getState().identity;
+	}, [agentId, signMessage, enableIdentity]);
+
+	return {
+		status,
+		identity,
+		error,
+		isReady: status === "ready",
+		canEnable,
+		enable,
+	};
+}

--- a/website/src/hooks/use-signal-identity.ts
+++ b/website/src/hooks/use-signal-identity.ts
@@ -8,6 +8,7 @@ import { publishEncryptionKey } from "@src/common/encryption-discovery";
 import type { SignalIdentity } from "@src/common/signal-identity";
 import { publishKeyBundle } from "@src/common/signal-messaging";
 import { useAuthStore } from "@src/store/auth";
+import { useConversationsStore } from "@src/store/conversations";
 import { useMessagingStore } from "@src/store/messaging";
 import { useSignalStore, type SignalStatus } from "@src/store/signal";
 
@@ -42,13 +43,15 @@ export function useSignalIdentity(): UseSignalIdentityResult {
 	const reset = useSignalStore((state) => state.reset);
 	const setupMessaging = useMessagingStore((state) => state.setup);
 	const resetMessaging = useMessagingStore((state) => state.reset);
+	const resetConversations = useConversationsStore((state) => state.reset);
 
 	useEffect(() => {
 		if (!connected) {
 			reset();
 			resetMessaging();
+			resetConversations();
 		}
-	}, [connected, reset, resetMessaging]);
+	}, [connected, reset, resetMessaging, resetConversations]);
 
 	const canEnable = connected && Boolean(signMessage) && Boolean(agentId);
 
@@ -62,25 +65,32 @@ export function useSignalIdentity(): UseSignalIdentityResult {
 			return undefined;
 		}
 
-		// Bring messaging online once per identity: build the encryption client +
-		// session, publish the key bundle, and advertise the encryption key on the
-		// directory card. Publishing is best-effort so a transient failure does not
-		// invalidate the derived identity.
-		if (!useMessagingStore.getState().session) {
+		// (Re)build the messaging client + session when the active identity changes
+		// (first enable, or a wallet/agent switch), clearing the previous user's
+		// conversations so they can't leak across identities.
+		const address = readyIdentity.signer.publicKeyBase64;
+		if (useMessagingStore.getState().address !== address) {
+			resetConversations();
 			setupMessaging(readyIdentity);
-			const encryptionClient = useMessagingStore.getState().encryptionClient;
-			if (encryptionClient) {
+		}
+
+		// Publish the key bundle and advertise the encryption key. Both are tracked
+		// independently and retried on every enable() until they succeed, so a
+		// transient failure can't leave the user unreachable for DMs.
+		const encryptionClient = useMessagingStore.getState().encryptionClient;
+		if (encryptionClient) {
+			if (!useMessagingStore.getState().bundlePublished) {
 				try {
 					await publishKeyBundle(encryptionClient, readyIdentity);
+					useMessagingStore.getState().markBundlePublished();
 				} catch (publishError) {
 					console.warn("Failed to publish key bundle:", publishError);
 				}
+			}
+			if (!useMessagingStore.getState().keyAdvertised) {
 				try {
-					await publishEncryptionKey(
-						walletClient,
-						agentId,
-						readyIdentity.signer.publicKeyBase64
-					);
+					await publishEncryptionKey(walletClient, agentId, address);
+					useMessagingStore.getState().markKeyAdvertised();
 				} catch (advertiseError) {
 					console.warn("Failed to advertise encryption key:", advertiseError);
 				}
@@ -88,7 +98,14 @@ export function useSignalIdentity(): UseSignalIdentityResult {
 		}
 
 		return readyIdentity;
-	}, [agentId, signMessage, enableIdentity, setupMessaging, walletClient]);
+	}, [
+		agentId,
+		signMessage,
+		enableIdentity,
+		setupMessaging,
+		resetConversations,
+		walletClient,
+	]);
 
 	return {
 		status,

--- a/website/src/hooks/use-signal-identity.ts
+++ b/website/src/hooks/use-signal-identity.ts
@@ -3,8 +3,12 @@
 import { useWallet } from "@solana/wallet-adapter-react";
 import { useCallback, useEffect } from "react";
 
+import { useApiClient } from "@src/common/api-context";
+import { publishEncryptionKey } from "@src/common/encryption-discovery";
 import type { SignalIdentity } from "@src/common/signal-identity";
+import { publishKeyBundle } from "@src/common/signal-messaging";
 import { useAuthStore } from "@src/store/auth";
+import { useMessagingStore } from "@src/store/messaging";
 import { useSignalStore, type SignalStatus } from "@src/store/signal";
 
 type UseSignalIdentityResult = {
@@ -29,18 +33,22 @@ type UseSignalIdentityResult = {
  */
 export function useSignalIdentity(): UseSignalIdentityResult {
 	const { connected, signMessage } = useWallet();
+	const walletClient = useApiClient();
 	const agentId = useAuthStore((state) => state.agentId);
 	const status = useSignalStore((state) => state.status);
 	const identity = useSignalStore((state) => state.identity);
 	const error = useSignalStore((state) => state.error);
 	const enableIdentity = useSignalStore((state) => state.enable);
 	const reset = useSignalStore((state) => state.reset);
+	const setupMessaging = useMessagingStore((state) => state.setup);
+	const resetMessaging = useMessagingStore((state) => state.reset);
 
 	useEffect(() => {
 		if (!connected) {
 			reset();
+			resetMessaging();
 		}
-	}, [connected, reset]);
+	}, [connected, reset, resetMessaging]);
 
 	const canEnable = connected && Boolean(signMessage) && Boolean(agentId);
 
@@ -49,8 +57,38 @@ export function useSignalIdentity(): UseSignalIdentityResult {
 			return undefined;
 		}
 		await enableIdentity(agentId, signMessage);
-		return useSignalStore.getState().identity;
-	}, [agentId, signMessage, enableIdentity]);
+		const readyIdentity = useSignalStore.getState().identity;
+		if (!readyIdentity) {
+			return undefined;
+		}
+
+		// Bring messaging online once per identity: build the encryption client +
+		// session, publish the key bundle, and advertise the encryption key on the
+		// directory card. Publishing is best-effort so a transient failure does not
+		// invalidate the derived identity.
+		if (!useMessagingStore.getState().session) {
+			setupMessaging(readyIdentity);
+			const encryptionClient = useMessagingStore.getState().encryptionClient;
+			if (encryptionClient) {
+				try {
+					await publishKeyBundle(encryptionClient, readyIdentity);
+				} catch (publishError) {
+					console.warn("Failed to publish key bundle:", publishError);
+				}
+				try {
+					await publishEncryptionKey(
+						walletClient,
+						agentId,
+						readyIdentity.signer.publicKeyBase64
+					);
+				} catch (advertiseError) {
+					console.warn("Failed to advertise encryption key:", advertiseError);
+				}
+			}
+		}
+
+		return readyIdentity;
+	}, [agentId, signMessage, enableIdentity, setupMessaging, walletClient]);
 
 	return {
 		status,

--- a/website/src/store/conversations.ts
+++ b/website/src/store/conversations.ts
@@ -1,0 +1,88 @@
+import { create } from "zustand";
+
+/** A single direct message in a conversation thread. */
+export interface DirectMessageEntry {
+	id: string;
+	text: string;
+	at: string;
+	outgoing: boolean;
+}
+
+/** A conversation peer, addressed by encryption pubkey with a display label. */
+export interface ConversationPeer {
+	/** Recipient messaging address (base64 encryption pubkey). */
+	address: string;
+	/** Human-friendly label (handle, agent id, or truncated key). */
+	label: string;
+}
+
+type ConversationsState = {
+	peers: Array<ConversationPeer>;
+	/** Messages keyed by peer address, oldest first. */
+	threads: Record<string, Array<DirectMessageEntry>>;
+	/** Registers a peer to converse with (no-op if already present). */
+	addPeer: (peer: ConversationPeer) => void;
+	/** Appends an outgoing message to a peer's thread. */
+	appendOutgoing: (address: string, message: DirectMessageEntry) => void;
+	/** Appends decrypted inbound messages, de-duplicated by id, to their threads. */
+	appendIncoming: (
+		messages: Array<{ id: string; from: string; text: string; at: string }>
+	) => void;
+	/** Clears all conversations (e.g. on wallet disconnect). */
+	reset: () => void;
+};
+
+export const useConversationsStore = create<ConversationsState>()((set) => ({
+	peers: [],
+	threads: {},
+	addPeer: (peer): void => {
+		set((state) => {
+			if (state.peers.some((existing) => existing.address === peer.address)) {
+				return state;
+			}
+			return { peers: [...state.peers, peer] };
+		});
+	},
+	appendOutgoing: (address, message): void => {
+		set((state) => ({
+			threads: {
+				...state.threads,
+				[address]: [...(state.threads[address] ?? []), message],
+			},
+		}));
+	},
+	appendIncoming: (messages): void => {
+		if (messages.length === 0) {
+			return;
+		}
+		set((state) => {
+			const threads = { ...state.threads };
+			const peers = [...state.peers];
+			for (const message of messages) {
+				const existing = threads[message.from] ?? [];
+				if (existing.some((entry) => entry.id === message.id)) {
+					continue;
+				}
+				threads[message.from] = [
+					...existing,
+					{
+						id: message.id,
+						text: message.text,
+						at: message.at,
+						outgoing: false,
+					},
+				];
+				if (!peers.some((peer) => peer.address === message.from)) {
+					peers.push({
+						address: message.from,
+						label: `${message.from.slice(0, 10)}…`,
+					});
+				}
+			}
+			return { threads, peers };
+		});
+	},
+	reset: (): void => {
+		set({ peers: [], threads: {} });
+	},
+}));

--- a/website/src/store/messaging.ts
+++ b/website/src/store/messaging.ts
@@ -8,26 +8,52 @@ import {
 } from "@src/common/signal-messaging";
 
 type MessagingState = {
+	/** Messaging address (derived encryption pubkey) the client/session is bound to. */
+	address: string | undefined;
 	/** Client authenticated with the encryption identity (owns /keys + /messages). */
 	encryptionClient: TinyVerseClient | undefined;
 	/** Long-lived Signal session bound to the identity's persistent store. */
 	session: SignalSession | undefined;
+	/** Whether the key bundle has been published to the relay this session. */
+	bundlePublished: boolean;
+	/** Whether the encryption key has been advertised on the directory card. */
+	keyAdvertised: boolean;
 	/** Builds the encryption client and session from a ready identity. */
 	setup: (identity: SignalIdentity) => void;
+	markBundlePublished: () => void;
+	markKeyAdvertised: () => void;
 	/** Tears down the messaging clients (e.g. on wallet disconnect). */
 	reset: () => void;
 };
 
 export const useMessagingStore = create<MessagingState>()((set) => ({
+	address: undefined,
 	encryptionClient: undefined,
 	session: undefined,
+	bundlePublished: false,
+	keyAdvertised: false,
 	setup: (identity): void => {
 		set({
+			address: identity.signer.publicKeyBase64,
 			encryptionClient: createEncryptionClient(identity),
 			session: createSession(identity),
+			bundlePublished: false,
+			keyAdvertised: false,
 		});
 	},
+	markBundlePublished: (): void => {
+		set({ bundlePublished: true });
+	},
+	markKeyAdvertised: (): void => {
+		set({ keyAdvertised: true });
+	},
 	reset: (): void => {
-		set({ encryptionClient: undefined, session: undefined });
+		set({
+			address: undefined,
+			encryptionClient: undefined,
+			session: undefined,
+			bundlePublished: false,
+			keyAdvertised: false,
+		});
 	},
 }));

--- a/website/src/store/messaging.ts
+++ b/website/src/store/messaging.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+import type { SignalSession, TinyVerseClient } from "@tinyhumansai/tinyplace";
+
+import type { SignalIdentity } from "@src/common/signal-identity";
+import {
+	createEncryptionClient,
+	createSession,
+} from "@src/common/signal-messaging";
+
+type MessagingState = {
+	/** Client authenticated with the encryption identity (owns /keys + /messages). */
+	encryptionClient: TinyVerseClient | undefined;
+	/** Long-lived Signal session bound to the identity's persistent store. */
+	session: SignalSession | undefined;
+	/** Builds the encryption client and session from a ready identity. */
+	setup: (identity: SignalIdentity) => void;
+	/** Tears down the messaging clients (e.g. on wallet disconnect). */
+	reset: () => void;
+};
+
+export const useMessagingStore = create<MessagingState>()((set) => ({
+	encryptionClient: undefined,
+	session: undefined,
+	setup: (identity): void => {
+		set({
+			encryptionClient: createEncryptionClient(identity),
+			session: createSession(identity),
+		});
+	},
+	reset: (): void => {
+		set({ encryptionClient: undefined, session: undefined });
+	},
+}));

--- a/website/src/store/signal.ts
+++ b/website/src/store/signal.ts
@@ -12,10 +12,13 @@ export type SignalStatus = "idle" | "loading" | "ready" | "error";
 type SignalState = {
 	status: SignalStatus;
 	identity: SignalIdentity | undefined;
+	/** The wallet agent id the current identity was derived for. */
+	agentId: string | undefined;
 	error: string | undefined;
 	/**
 	 * Derives (first use) or loads the wallet's encryption identity. Idempotent
-	 * while loading/ready for the same wallet.
+	 * while loading/ready for the *same* wallet; re-derives when the wallet agent
+	 * changes so a different user never reuses the previous identity.
 	 */
 	enable: (
 		walletAgentId: string,
@@ -28,10 +31,14 @@ type SignalState = {
 export const useSignalStore = create<SignalState>()((set, get) => ({
 	status: "idle",
 	identity: undefined,
+	agentId: undefined,
 	error: undefined,
 	enable: async (walletAgentId, signMessage): Promise<void> => {
-		const { status } = get();
-		if (status === "loading" || status === "ready") {
+		const { status, agentId } = get();
+		if (
+			(status === "loading" || status === "ready") &&
+			agentId === walletAgentId
+		) {
 			return;
 		}
 		set({ status: "loading", error: undefined });
@@ -40,7 +47,7 @@ export const useSignalStore = create<SignalState>()((set, get) => ({
 				walletAgentId,
 				signMessage
 			);
-			set({ status: "ready", identity });
+			set({ status: "ready", identity, agentId: walletAgentId });
 		} catch (error) {
 			set({
 				status: "error",
@@ -49,6 +56,11 @@ export const useSignalStore = create<SignalState>()((set, get) => ({
 		}
 	},
 	reset: (): void => {
-		set({ status: "idle", identity: undefined, error: undefined });
+		set({
+			status: "idle",
+			identity: undefined,
+			agentId: undefined,
+			error: undefined,
+		});
 	},
 }));

--- a/website/src/store/signal.ts
+++ b/website/src/store/signal.ts
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+
+import {
+	loadOrCreateSignalIdentity,
+	type SignalIdentity,
+} from "@src/common/signal-identity";
+
+type SignMessageFunction = (message: Uint8Array) => Promise<Uint8Array>;
+
+export type SignalStatus = "idle" | "loading" | "ready" | "error";
+
+type SignalState = {
+	status: SignalStatus;
+	identity: SignalIdentity | undefined;
+	error: string | undefined;
+	/**
+	 * Derives (first use) or loads the wallet's encryption identity. Idempotent
+	 * while loading/ready for the same wallet.
+	 */
+	enable: (
+		walletAgentId: string,
+		signMessage: SignMessageFunction
+	) => Promise<void>;
+	/** Clears the in-memory identity (e.g. on wallet disconnect). */
+	reset: () => void;
+};
+
+export const useSignalStore = create<SignalState>()((set, get) => ({
+	status: "idle",
+	identity: undefined,
+	error: undefined,
+	enable: async (walletAgentId, signMessage): Promise<void> => {
+		const { status } = get();
+		if (status === "loading" || status === "ready") {
+			return;
+		}
+		set({ status: "loading", error: undefined });
+		try {
+			const identity = await loadOrCreateSignalIdentity(
+				walletAgentId,
+				signMessage
+			);
+			set({ status: "ready", identity });
+		} catch (error) {
+			set({
+				status: "error",
+				error: error instanceof Error ? error.message : "Unknown error",
+			});
+		}
+	},
+	reset: (): void => {
+		set({ status: "idle", identity: undefined, error: undefined });
+	},
+}));


### PR DESCRIPTION
Adds a complete end-to-end encrypted direct-messaging feature to the website, plus the SDK primitive it needs. Verified end-to-end against staging.

## The problem
A Phantom wallet can't expose the Ed25519 seed, so it can't derive the X25519 key the Signal Protocol needs — encrypted DMs were impossible with the wallet alone.

## The design
- **Derived encryption identity:** a deterministic Ed25519/X25519 identity is derived from a *one-time* wallet signature (`SHA-256(signature)` → seed → `LocalSigner.fromSeed`), persisted in IndexedDB. The wallet still owns auth + payments; this derived key owns Signal.
- **Two clients:** the relay binds the messaging address to the X3DH identity (associated data) and authorizes `/keys`+`/messages` by that address, so a **second `TinyVerseClient` authenticated with the derived signer** owns all messaging, addressed by the derived pubkey. No backend changes.
- **Discovery:** the encryption pubkey is advertised in the directory card's `metadata.encryptionPublicKey`; peers resolve it (falling back to `card.publicKey` for single-key agents).
- Since the derived signer signs in-memory, bundle publish / send / fetch cost **zero wallet prompts** — only two ever (derive identity, advertise key).

## What's included
**SDK**
- `LocalSigner.fromSeed(seed)` — deterministic signer from a 32-byte Ed25519 seed (unit-tested: determinism, signature validity, X25519/Ed25519 consistency).
- Export `toBase64` / `fromBase64` from the package root.

**Website**
- `signal-identity.ts` + `signal-store.ts` — derive/persist identity; `IndexedDbSessionStore` (persists signed pre-key, one-time pre-keys, ratchet sessions across reloads).
- `signal-messaging.ts` — `publishKeyBundle`, `sendDirectMessage`, `fetchInbox` (X3DH + Double Ratchet over the relay).
- `encryption-discovery.ts` — advertise/resolve the encryption address.
- `use-signal-identity.ts` / `use-direct-messages.ts` + `store/{signal,messaging,conversations}.ts` — lifecycle, inbox polling, sending.
- `DirectMessages.tsx` — real encrypted DM UI (enable gate → peer list → thread → composer). The "DMs" tab is now real E2E; public channels moved to a new "Channels" tab.

## Verification
- SDK: `tsc` build + 26 unit tests (incl. new `fromSeed` tests) pass.
- A staging round-trip (two `fromSeed` identities) published bundles and round-tripped an encrypted message — confirming unregistered derived identities work.
- Website: `next build`, ESLint (`--max-warnings 0`), and `tsc --noEmit` all clean.

## Follow-ups (not in this PR)
- Replenish one-time pre-keys when `KeyHealth.lowOneTimePreKeys`.
- Swap inbox polling for the `/a2a/{id}/stream` WebSocket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end encrypted Direct Messages UI with peer discovery, composer, and threaded conversations.
  * Encrypted inbox with automatic decryption and acknowledgement.
  * Wallet-derived encryption identity (persistent) and one-click enable flow.
  * Publishing of encryption keys for recipient discovery; channels tab added to Explore.

* **Tests**
  * Added test coverage for deterministic local signer derivation and signature verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->