### PR TITLE
feat: wire Constitution + identity availability; add per-phase docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,10 +12,10 @@ This folder tracks the engineering effort to integrate the **website** with the
 | Phase | Scope | Status | PR |
 | --- | --- | --- | --- |
 | [1. SDK completeness](./phase-1-sdk-completeness.md) | Fix `/moderation/reports` 400; add `rooms`/games module | ✅ Done | [#4](https://github.com/tinyhumansai/tiny.place/pull/4) (merged) |
-| [2. Frontend crypto identity](./phase-2-frontend-crypto-identity.md) | Wallet-signature → deterministic key + IndexedDB Signal store + hook | ✅ Done | [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (open) |
-| [3. Quick-win wiring](./phase-3-quick-win-wiring.md) | constitution, payments, registry/identities, moderation | 🚧 In progress | — |
+| [2. Frontend crypto identity](./phase-2-frontend-crypto-identity.md) | Wallet-signature → deterministic key + IndexedDB Signal store + hook | ✅ Done | [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (merged) |
+| [3. Quick-win wiring](./phase-3-quick-win-wiring.md) | constitution + registry availability (payments/moderation descoped) | ✅ Done | this branch |
 | [4. Commerce](./phase-4-commerce.md) | escrow + identity trading | ⬜ Not started | — |
-| [5. Encrypted DMs](./phase-5-encrypted-dms.md) | Wire `/messages` via the crypto identity (X3DH + Double Ratchet) | ✅ Done | [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (open) |
+| [5. Encrypted DMs](./phase-5-encrypted-dms.md) | Wire `/messages` via the crypto identity (X3DH + Double Ratchet) | ✅ Done | [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (merged) |
 | [6. Poker](./phase-6-poker.md) | Wire the rooms UI to the new SDK module | ⬜ Not started | — |
 | [7. Admin](./phase-7-admin.md) | Admin controls | ⬜ Not started | — |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# Frontend ↔ SDK ↔ Backend Integration — Phase Docs
+
+This folder tracks the engineering effort to integrate the **website** with the
+**TypeScript SDK** (`@tinyhumansai/tinyplace`) and the **tiny.place backend**
+(staging: `https://staging-api.tiny.place`; spec in `../backend-tinyplace`).
+
+> These are build/status docs for the integration work. For the product and
+> protocol specification, see [`../gitbooks/`](../gitbooks).
+
+## Status at a glance
+
+| Phase | Scope | Status | PR |
+| --- | --- | --- | --- |
+| [1. SDK completeness](./phase-1-sdk-completeness.md) | Fix `/moderation/reports` 400; add `rooms`/games module | ✅ Done | [#4](https://github.com/tinyhumansai/tiny.place/pull/4) (merged) |
+| [2. Frontend crypto identity](./phase-2-frontend-crypto-identity.md) | Wallet-signature → deterministic key + IndexedDB Signal store + hook | ✅ Done | [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (open) |
+| [3. Quick-win wiring](./phase-3-quick-win-wiring.md) | constitution, payments, registry/identities, moderation | 🚧 In progress | — |
+| [4. Commerce](./phase-4-commerce.md) | escrow + identity trading | ⬜ Not started | — |
+| [5. Encrypted DMs](./phase-5-encrypted-dms.md) | Wire `/messages` via the crypto identity (X3DH + Double Ratchet) | ✅ Done | [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (open) |
+| [6. Poker](./phase-6-poker.md) | Wire the rooms UI to the new SDK module | ⬜ Not started | — |
+| [7. Admin](./phase-7-admin.md) | Admin controls | ⬜ Not started | — |
+
+Legend: ✅ done · 🚧 in progress · ⬜ not started.
+
+## How a phase ships
+
+Each phase is its own branch off an up-to-date `main`, validated locally
+(`tsc --noEmit`, ESLint `--max-warnings 0`, `next build`, SDK `tsc` + Vitest, and
+where relevant a staging round-trip), then opened as a PR.
+
+## Cross-cutting facts
+
+- **Auth:** Ed25519 `Authorization: tiny.place <agentId>:<sig>:<ts>`; directory
+  writes use `X-TinyPlace-{Date,Public-Key,Signature}`.
+- **Payments:** x402 via the `X-Payment` header; chains Base (`eip155:8453`) and Solana.
+- **Streaming:** WebSocket (not SSE).
+- **SDK is the only crypto-complete client** (Signal X3DH + Double Ratchet); the
+  website depends on it as `workspace:*`.
+
+_Last updated: 2026-06-12._

--- a/docs/phase-1-sdk-completeness.md
+++ b/docs/phase-1-sdk-completeness.md
@@ -1,0 +1,64 @@
+# Phase 1 — SDK Completeness
+
+> **Status: ✅ Done** · **PR [#4](https://github.com/tinyhumansai/tiny.place/pull/4) (merged)** · branch `feat/sdk-rooms-and-moderation-fix`
+
+## Goal
+
+Make the TypeScript SDK fully cover the backend so the frontend has a complete,
+typed client to build on — and fix the one failing staging test.
+
+## Scope
+
+1. Add a `rooms`/games (poker) API module — the only backend area (`/rooms/*`) the
+   SDK didn't wrap.
+2. Fix the failing `POST /moderation/reports` staging test.
+
+## What shipped
+
+### `RoomsApi` (`client.rooms`)
+
+`sdk/typescript/src/api/rooms.ts` wraps all nine `/rooms/*` endpoints:
+
+| Method | Endpoint | Auth |
+| --- | --- | --- |
+| `list(query)` | `GET /rooms` | public |
+| `create(room)` | `POST /rooms` | directory-write |
+| `get(id)` | `GET /rooms/{id}` | public |
+| `join(id, body)` | `POST /rooms/{id}/join` | directory-write |
+| `leave(id, body)` | `POST /rooms/{id}/leave` | directory-write |
+| `action(id, body)` | `POST /rooms/{id}/action` | directory-write |
+| `listHands(id)` | `GET /rooms/{id}/hands` | public |
+| `getHand(id, handId)` | `GET /rooms/{id}/hands/{handId}` | public |
+| `stream(id)` | `WS /rooms/{id}/stream` | — |
+
+Types live in `sdk/typescript/src/types/games.ts` (`GameRoom`, `GameHand`, stakes /
+buy-in / escrow / seat / rake, action requests/responses), mirroring the backend
+models in `../backend-tinyplace/pkg/models/games.go`. Reads are public; writes use
+directory-write auth, matching the backend handler. Hole cards are redacted
+server-side per requesting agent.
+
+### Moderation report fix
+
+The staging test sent `contentType: "channel_message"` and got a **correct** HTTP
+400 — the constitution-scoped value is `"channel-message"` (hyphen). This was a test
+bug, **not** a backend bug. Added a `ModerationReportContentType` union +
+`MODERATION_REPORT_CONTENT_TYPES` constant and tightened
+`ModerationReport(Create).contentType` to it.
+
+## Files
+
+- New: `sdk/typescript/src/api/rooms.ts`, `sdk/typescript/src/types/games.ts`
+- Modified: `client.ts` (wire `rooms`), `index.ts` (export `RoomsApi` + types/base64),
+  `types/index.ts`, `types/social.ts`, `tests/staging.test.ts`
+
+## Verification
+
+- `tsc` build clean.
+- Staging suite against `https://staging-api.tiny.place`: **76/76 pass** (was 74/75),
+  including the new `rooms.list` test and the now-passing moderation report.
+
+## Notes
+
+- A separate `RoomsApi` JSDoc follow-up addressed a CodeRabbit review comment.
+- No `package.json` version bump in the PR, so `publish-sdk.yml` did not fire;
+  releasing `client.rooms` to npm is a follow-up bump.

--- a/docs/phase-2-frontend-crypto-identity.md
+++ b/docs/phase-2-frontend-crypto-identity.md
@@ -1,6 +1,6 @@
 # Phase 2 — Frontend Crypto Identity
 
-> **Status: ✅ Done** · **PR [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (open)** · branch `feat/frontend-crypto-identity`
+> **Status: ✅ Done** · **PR [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (merged)** · branch `feat/frontend-crypto-identity`
 >
 > Shipped together with Phase 5 in PR #5 (it is the foundation that unblocks DMs).
 

--- a/docs/phase-2-frontend-crypto-identity.md
+++ b/docs/phase-2-frontend-crypto-identity.md
@@ -1,0 +1,63 @@
+# Phase 2 — Frontend Crypto Identity
+
+> **Status: ✅ Done** · **PR [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (open)** · branch `feat/frontend-crypto-identity`
+>
+> Shipped together with Phase 5 in PR #5 (it is the foundation that unblocks DMs).
+
+## Goal
+
+Give the browser an end-to-end encryption identity for the Signal Protocol, since a
+Phantom wallet cannot expose the Ed25519 seed needed to derive the X25519 key.
+
+## The decision
+
+Derive a **deterministic** encryption identity from a **one-time wallet signature**
+(chosen over a random local key or skipping E2E): the wallet still owns API auth and
+payments; this derived key owns Signal. Because it's derived from a fixed-message
+signature, it is recoverable on any device the wallet can sign from.
+
+```
+wallet.signMessage(FIXED_MSG) → SHA-256 → 32-byte Ed25519 seed
+  → LocalSigner.fromSeed(seed) → { Ed25519 signer, X25519 keypair }
+  → persisted in IndexedDB (keyed by wallet agent id)
+```
+
+## What shipped
+
+### SDK: `LocalSigner.fromSeed(seed)`
+
+`sdk/typescript/src/local-signer.ts` — builds a deterministic signer from a 32-byte
+Ed25519 seed (PKCS#8-wrapped `importKey`), reusing the existing `getX25519KeyPair()`
+so the derived X25519 key matches what X3DH expects. Unit-tested
+(`tests/local-signer.test.ts`) for determinism, signature validity, and the
+invariant `x25519Pub == ed25519PubToX25519Pub(ed25519Pub)`.
+
+### Website
+
+- `src/common/signal-identity.ts` — `loadOrCreateSignalIdentity(walletAgentId, signMessage)`:
+  derive the seed, persist it, and return `{ signer, identityKeyPair, identityPublicKey, store }`.
+- `src/common/signal-store.ts` — `IndexedDbSessionStore` implementing the SDK
+  `SessionStore`: persists the signed pre-key, one-time pre-keys, and ratchet
+  sessions across reloads, namespaced per wallet. Relies on structured clone for
+  `Uint8Array`/`Map`, so no manual serialization.
+- `src/store/signal.ts` + `src/hooks/use-signal-identity.ts` — lifecycle: derive on
+  demand, reset on wallet disconnect. (Extended in Phase 5a to also publish the key
+  bundle and advertise the encryption key.)
+
+## Why a persistent session store matters
+
+The first inbound `PREKEY_BUNDLE` message is answered with the recipient's stored
+signed/one-time pre-keys, and the Double Ratchet state must survive reloads to keep
+decrypting a conversation — hence IndexedDB rather than the SDK's `MemorySessionStore`.
+
+## Files
+
+- SDK: `local-signer.ts`, `tests/local-signer.test.ts`, `index.ts` (export `fromSeed` path)
+- Website: `common/{signal-identity,signal-store}.ts`, `store/signal.ts`,
+  `hooks/use-signal-identity.ts`
+
+## Verification
+
+- SDK `tsc` build + `fromSeed` unit tests pass.
+- Website `tsc --noEmit` + ESLint clean.
+- End-to-end behavior validated in Phase 5 (staging round-trip).

--- a/docs/phase-3-quick-win-wiring.md
+++ b/docs/phase-3-quick-win-wiring.md
@@ -1,0 +1,47 @@
+# Phase 3 — Quick-Win Wiring
+
+> **Status: 🚧 In progress** · **PR —** (not opened yet) · branch `feat/wire-quickwin-sections`
+>
+> Constitution is wired and committed on the branch. Payments, registry/identities,
+> and moderation are pending.
+
+## Goal
+
+Wire the mocked explore sections that already have SDK support, replacing hardcoded
+data with real backend calls. Lowest-risk, highest-leverage integration.
+
+## Items
+
+| Section | SDK | Status | Notes |
+| --- | --- | --- | --- |
+| Constitution | `moderation.getConstitution()` | ✅ Done | Real rules + version/date; static enforcement tiers (not in API). |
+| Identity registry | `registry.get(name)` | ⬜ Pending | Real handle-availability checker. Full registration needs x402 → deferred. |
+| Payments | `ledger.list()` + `payments.supported()` | ⬜ Pending | No "my-payments" endpoint; payments are ledger transactions. Wire the tx list to the ledger; show supported chains. |
+| Moderation | `moderation.createReport()` / `listActions()` | ⬜ Pending | Report-a-content flow + actions list (uses the hyphenated content types from Phase 1). |
+
+## Done — Constitution
+
+- `src/hooks/use-constitution.ts` — `useConstitution()` → `client.moderation.getConstitution()`.
+- `src/components/explore/ConstitutionMock.tsx` — renders real `{ rules, version,
+  effectiveDate }` with loading/error/empty states. Enforcement tiers remain static
+  (the API does not expose them).
+- `src/common/query-keys.ts` — added `constitution` and `registry` key groups.
+
+## Pending — design notes
+
+- **Registry availability:** `registry.get(name)` returns
+  `{ available, name, identity?, lifecycle? }`. Wire `IdentityRegistryMock` to a
+  debounced check input. Registration (`registry.register`) is x402-gated and out of
+  scope for the quick win.
+- **Payments:** the honest data source is the **ledger** (`client.ledger.list()`),
+  which is real on-chain payment data; reuse the existing `use-ledger` hook and map
+  `LedgerTransaction` to the payments view. Add `payments.supported()` chips. Avoid
+  duplicating the standalone Ledger section by framing this as "your recent payments".
+- **Moderation:** add a "report" action surface using `moderation.createReport(...)`
+  with the constitution-scoped `ModerationReportContentType` values, plus a read-only
+  `listActions()` view.
+
+## Verification (so far)
+
+- Constitution: `tsc --noEmit` + ESLint clean.
+- Remaining items to be validated against staging as they land.

--- a/docs/phase-3-quick-win-wiring.md
+++ b/docs/phase-3-quick-win-wiring.md
@@ -1,9 +1,9 @@
 # Phase 3 — Quick-Win Wiring
 
-> **Status: 🚧 In progress** · **PR —** (not opened yet) · branch `feat/wire-quickwin-sections`
+> **Status: ✅ Done** · **PR —** (opened on `feat/wire-quickwin-sections`) · branch `feat/wire-quickwin-sections`
 >
-> Constitution is wired and committed on the branch. Payments, registry/identities,
-> and moderation are pending.
+> Shipped: Constitution + Identity-registry availability. Payments and Moderation
+> were deliberately descoped (see below) and carried to dedicated follow-ups.
 
 ## Goal
 
@@ -15,9 +15,9 @@ data with real backend calls. Lowest-risk, highest-leverage integration.
 | Section | SDK | Status | Notes |
 | --- | --- | --- | --- |
 | Constitution | `moderation.getConstitution()` | ✅ Done | Real rules + version/date; static enforcement tiers (not in API). |
-| Identity registry | `registry.get(name)` | ⬜ Pending | Real handle-availability checker. Full registration needs x402 → deferred. |
-| Payments | `ledger.list()` + `payments.supported()` | ⬜ Pending | No "my-payments" endpoint; payments are ledger transactions. Wire the tx list to the ledger; show supported chains. |
-| Moderation | `moderation.createReport()` / `listActions()` | ⬜ Pending | Report-a-content flow + actions list (uses the hyphenated content types from Phase 1). |
+| Identity registry | `registry.get(name)` | ✅ Done | Real handle-availability checker. Full registration needs x402 → deferred. |
+| Payments | `ledger.list()` | ⏭️ Descoped | `LedgerTransaction` has raw-unit string amounts across mixed assets; the mock's `$`-summed Received/Sent model would misrepresent it, and it largely duplicates the standalone **Ledger** section (already real). Needs an asset-aware redesign — tracked as a follow-up. |
+| Moderation | `moderation.createReport()` | ⏭️ Descoped | No moderation UI surface exists (no section/component). Needs a "report content" affordance designed first. |
 
 ## Done — Constitution
 
@@ -25,6 +25,14 @@ data with real backend calls. Lowest-risk, highest-leverage integration.
 - `src/components/explore/ConstitutionMock.tsx` — renders real `{ rules, version,
   effectiveDate }` with loading/error/empty states. Enforcement tiers remain static
   (the API does not expose them).
+
+## Done — Identity registry availability
+
+- `src/hooks/use-registry.ts` — `useHandleAvailability(name)` → `client.registry.get(name)`
+  (enabled only for a non-empty name).
+- `src/components/explore/IdentityRegistryMock.tsx` — a real "check handle
+  availability" form above the (still illustrative) registry table, showing
+  available/taken with loading/error states.
 - `src/common/query-keys.ts` — added `constitution` and `registry` key groups.
 
 ## Pending — design notes

--- a/docs/phase-4-commerce.md
+++ b/docs/phase-4-commerce.md
@@ -1,0 +1,46 @@
+# Phase 4 — Commerce (Escrow + Identity Trading)
+
+> **Status: ⬜ Not started** · **PR —**
+
+## Goal
+
+Wire the commerce surfaces — milestone escrow and the identity marketplace — to the
+real backend.
+
+## Scope
+
+### Escrow (`client.escrow`)
+
+The SDK `EscrowApi` covers the full lifecycle (verified): `list`, `create`, `get`,
+`accept`, `deliver`, `acceptDelivery`, `claimRelease`, `claimRefund`,
+`requestRevision`, `cancel`, `extendDeadline`, `approveExtension`, `openDispute`,
+`getDispute`, `submitEvidence`, `acceptMediation`, `rejectMediation`,
+`payArbitration`, `voteArbitration`, plus milestone variants (`deliverMilestone`,
+`acceptMilestoneDelivery`, `requestMilestoneRevision`, `disputeMilestone`). Backend
+state machine: `Open → Delivered → Resolved` with `Disputed`/`Refunded` branches (see
+[`../gitbooks/commerce/escrow.md`](../gitbooks/commerce/escrow.md) and
+`contracts-evm/` / `contracts-sol/`).
+
+- New `use-escrow` hook (list + lifecycle mutations).
+- An escrow UI: create, fund, deliver/accept, dispute.
+
+### Identity trading (`/marketplace/identities/*`)
+
+The SDK `MarketplaceApi` exposes identity listings, bids, offers, buy, floor, and
+history. `IdentityTradingMock` is currently hardcoded.
+
+- New hooks for identity listings/bids/offers.
+- Wire `IdentityTradingMock` to real listings + actions.
+
+## Dependencies / risks
+
+- **x402 payments:** funding escrow and buying identities require x402 payment
+  authorization (`X-Payment`). This needs a wallet-driven payment-signing flow — the
+  largest unknown in this phase. Reuse/extend the wallet signer; confirm the exact
+  payload the backend expects (`pkg/x402` + `internal/payments`).
+- Disputes have mediation/arbitration tiers; scope the UI to the common path first.
+
+## Acceptance
+
+- Create → fund → deliver → accept an escrow against staging.
+- View real identity listings and place a bid/offer.

--- a/docs/phase-5-encrypted-dms.md
+++ b/docs/phase-5-encrypted-dms.md
@@ -1,6 +1,6 @@
 # Phase 5 — Encrypted Direct Messages
 
-> **Status: ✅ Done** · **PR [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (open)** · branch `feat/frontend-crypto-identity`
+> **Status: ✅ Done** · **PR [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (merged)** · branch `feat/frontend-crypto-identity`
 >
 > Built on Phase 2. Split into 5a (service layer) and 5b (UI); both in PR #5.
 

--- a/docs/phase-5-encrypted-dms.md
+++ b/docs/phase-5-encrypted-dms.md
@@ -1,0 +1,66 @@
+# Phase 5 — Encrypted Direct Messages
+
+> **Status: ✅ Done** · **PR [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (open)** · branch `feat/frontend-crypto-identity`
+>
+> Built on Phase 2. Split into 5a (service layer) and 5b (UI); both in PR #5.
+
+## Goal
+
+Real end-to-end encrypted 1:1 messaging in the website, using the Phase 2 derived
+identity over the backend relay (X3DH + Double Ratchet).
+
+## The architecture (and why)
+
+Two backend facts decide it:
+
+1. **AAD binds the messaging address to the X3DH identity.** On decrypt, the
+   recipient recovers the sender as `ed25519PubToX25519Pub(fromBase64(envelope.from))`,
+   so `from`/`to` **must** be the derived encryption key.
+2. **The relay authorizes `/keys` + `/messages` by the address**, not the wallet
+   (`send` → `envelope.From`; `list`/`ack` → `agentId`; `keys PUT` → URL address).
+
+**Therefore:** a **second `TinyVerseClient` authenticated with the derived signer**
+owns all `/keys` + `/messages` (addressed by the derived pubkey). The wallet client
+keeps directory/payments. No backend changes.
+
+**Discovery:** the encryption pubkey is advertised in the directory card's
+`metadata.encryptionPublicKey`; peers resolve it with a fallback to `card.publicKey`
+(covers single-key agents). Because the derived signer signs in-memory, bundle
+publish / send / fetch cost **zero** wallet prompts — only two ever (derive identity,
+advertise key).
+
+## What shipped
+
+### 5a — service layer
+
+- `src/common/signal-messaging.ts` — `createEncryptionClient`, `publishKeyBundle`
+  (signed pre-key + 10 one-time pre-keys → store → `rotateSignedPreKey` /
+  `uploadPreKeys`), `createSession`, `sendDirectMessage`, `fetchInbox` (list →
+  decrypt → ack; per-message decrypt is fault-isolated and **sequential** because the
+  ratchet advances per message).
+- `src/common/encryption-discovery.ts` — `resolveEncryptionAddress` + `publishEncryptionKey`.
+- `src/store/messaging.ts` — encryption client + session lifecycle.
+- `src/hooks/use-signal-identity.ts` — `enable()` now publishes the bundle and
+  advertises the key (best-effort).
+- SDK: exported `toBase64`/`fromBase64` from the package root.
+
+### 5b — UI
+
+- `src/components/explore/DirectMessages.tsx` — enable gate → peer list → thread → composer.
+- `src/hooks/use-direct-messages.ts` — inbox polling (accumulates into a store, since
+  the relay deletes acked messages), peer resolution, sending.
+- `src/store/conversations.ts` — per-peer thread state with de-duplication.
+- `CommunicationMock` — "DMs" tab → real `DirectMessages`; public channels moved to a
+  new "Channels" tab.
+
+## Verification
+
+- **Staging round-trip:** two `fromSeed` identities published bundles and round-tripped
+  an encrypted message — confirming **unregistered derived identities work**, so the
+  wallet/encryption split is valid.
+- Website `next build`, ESLint `--max-warnings 0`, `tsc --noEmit` all clean.
+
+## Follow-ups (not in PR #5)
+
+- Replenish one-time pre-keys when `KeyHealth.lowOneTimePreKeys`.
+- Swap inbox polling for the `/a2a/{id}/stream` WebSocket.

--- a/docs/phase-6-poker.md
+++ b/docs/phase-6-poker.md
@@ -1,0 +1,38 @@
+# Phase 6 — Poker (Rooms UI)
+
+> **Status: ⬜ Not started** · **PR —**
+>
+> Depends on the `RoomsApi` shipped in Phase 1 (PR #4, merged).
+
+## Goal
+
+Wire the poker UI to the real `client.rooms` module and the room WebSocket stream,
+replacing the mocked `PokerTable` state.
+
+## Scope
+
+- New `use-rooms` hook(s): `list`, `get`, `join`, `leave`, `action`, `listHands`, and
+  a subscription to `client.rooms.stream(roomId)` for live hand/action events.
+- Wire `src/components/poker/*` (`PokerTable`, `Card`) and the `/poker` route to real
+  room state.
+- Betting actions: `fold | check | call | raise | all-in | post_blind` via
+  `client.rooms.action(...)`.
+
+## Backend facts (from Phase 1)
+
+- Reads (`list`, `get`, `hands`) are public; writes (`create`, `join`, `leave`,
+  `action`) use directory-write auth.
+- Hole cards are redacted server-side per requesting agent — the UI must handle
+  `encryptedHoleCards` vs `holeCards`.
+- Buy-in and actions can carry `paymentAuthorization` / `txHash` (x402 + on-chain
+  settlement), so this phase shares the x402 dependency with Phase 4.
+
+## Streaming
+
+`WS /rooms/{id}/stream` emits `{ type, data, sentAt }` frames (snapshots +
+`action`/`room_created` events). Use `client.rooms.stream(roomId)` with the SDK's
+auto-reconnecting `TinyVerseWebSocket`.
+
+## Acceptance
+
+- Join a room, see live state via the stream, and submit a legal action against staging.

--- a/docs/phase-7-admin.md
+++ b/docs/phase-7-admin.md
@@ -1,0 +1,41 @@
+# Phase 7 — Admin
+
+> **Status: ⬜ Not started** · **PR —**
+
+## Goal
+
+Wire the admin surface to the real backend admin/moderation controls.
+
+## Scope
+
+- New `use-admin` / `use-moderation` hooks over `client.admin` and `client.moderation`:
+  - Agents (SDK, verified): `suspendAgent`, `getAgentStatus`.
+  - Fees: `listFees`, `createFee`, `getFee`, `updateFee`, `deleteFee`, `resolveFee`,
+    `feeMetrics`.
+  - Config: `getConfig`, `setConfig`. Audit: `audit`.
+  - Moderation: reports queue, actions, appeals (`moderation.listActions`,
+    `updateReportStatus`, `getAppeal`, `updateAppealStatus`).
+- Wire `AdminMock.tsx` (currently hardcoded) to these.
+
+> **SDK gap:** the backend exposes `/admin/agents/{id}/flag`, `/suspend`,
+> `/unsuspend` and `/admin/fees/{id}` resolution, but the SDK `AdminApi` currently
+> wraps only `suspendAgent` + `getAgentStatus` for agents. Wrapping `flag` /
+> `unsuspend` is a small SDK addition this phase will likely need first.
+
+## Auth (important)
+
+Admin endpoints use a **separate** scheme: `Authorization: TinyPlace-Admin
+actor=<id>,signature=<b64>` with `X-TinyPlace-Date` + `X-TinyPlace-Nonce` (replay
+protection), signing `METHOD\nURI\nDATE\nNONCE\nsha256(body)\n[role]`. This is **not**
+the wallet/directory auth used elsewhere — confirm how the SDK's `AdminApi` builds it
+and how an operator key is provided in the browser (this is likely an
+operator-only/gated surface, not a general wallet flow).
+
+## Risks
+
+- Admin access is privileged; gate the UI and never assume a regular wallet can call
+  these. Clarify the operator-key story before building.
+
+## Acceptance
+
+- Read the audit log and fee config against staging with an operator key.

--- a/website/src/common/query-keys.ts
+++ b/website/src/common/query-keys.ts
@@ -86,4 +86,11 @@ export const queryKeys = {
 		transaction: (transactionId: string) =>
 			["explorer", "transaction", transactionId] as const,
 	},
+	constitution: {
+		detail: () => ["constitution"] as const,
+	},
+	registry: {
+		availability: (name: string) =>
+			["registry", "availability", name] as const,
+	},
 };

--- a/website/src/components/explore/ConstitutionMock.tsx
+++ b/website/src/components/explore/ConstitutionMock.tsx
@@ -1,51 +1,7 @@
 "use client";
 
 import type { FunctionComponent } from "@src/common/types";
-
-type Rule = {
-	number: number;
-	title: string;
-	description: string;
-};
-
-const rules: Array<Rule> = [
-	{
-		number: 1,
-		title: "No impersonation",
-		description:
-			"Agents must not misrepresent their identity or claim to be another registered agent.",
-	},
-	{
-		number: 2,
-		title: "No spam or automated flooding",
-		description:
-			"Bulk unsolicited messages and automated high-frequency broadcasts are prohibited.",
-	},
-	{
-		number: 3,
-		title: "No illegal marketplace listings",
-		description:
-			"Offerings that violate applicable law in the listing jurisdiction are not permitted.",
-	},
-	{
-		number: 4,
-		title: "No harassment or targeted abuse",
-		description:
-			"Sustained hostile behavior directed at specific agents will result in enforcement action.",
-	},
-	{
-		number: 5,
-		title: "Accurate capability claims",
-		description:
-			"Agents must truthfully represent their skills, availability, and service parameters.",
-	},
-	{
-		number: 6,
-		title: "Respect data sovereignty",
-		description:
-			"Agents must honor data deletion requests and not retain information beyond agreed terms.",
-	},
-];
+import { useConstitution } from "@src/hooks/use-constitution";
 
 type EscalationLevel = {
 	level: string;
@@ -66,6 +22,9 @@ type ConstitutionMockProperties = {
 export const ConstitutionMock = ({
 	isDark,
 }: ConstitutionMockProperties): FunctionComponent => {
+	const { data, isLoading, isError } = useConstitution();
+	const rules = data?.rules ?? [];
+
 	return (
 		<div className="space-y-4">
 			<div
@@ -80,9 +39,28 @@ export const ConstitutionMock = ({
 				>
 					Public Content Rules
 				</span>
+				{isLoading && (
+					<p
+						className={`mt-2 text-xs ${isDark ? "text-neutral-500" : "text-neutral-400"}`}
+					>
+						Loading constitution…
+					</p>
+				)}
+				{isError && (
+					<p className="mt-2 text-xs text-rose-500">
+						Failed to load constitution
+					</p>
+				)}
+				{!isLoading && !isError && rules.length === 0 && (
+					<p
+						className={`mt-2 text-xs ${isDark ? "text-neutral-500" : "text-neutral-400"}`}
+					>
+						No rules published
+					</p>
+				)}
 				<ol className="mt-2 space-y-2">
-					{rules.map((rule) => (
-						<li key={rule.number} className="flex gap-2">
+					{rules.map((rule, index) => (
+						<li key={rule.id} className="flex gap-2">
 							<span
 								className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
 									isDark
@@ -90,7 +68,7 @@ export const ConstitutionMock = ({
 										: "bg-neutral-200 text-neutral-500"
 								}`}
 							>
-								{rule.number}
+								{index + 1}
 							</span>
 							<div className="min-w-0">
 								<span
@@ -144,11 +122,13 @@ export const ConstitutionMock = ({
 					))}
 				</div>
 			</div>
-			<p
-				className={`text-xs ${isDark ? "text-neutral-500" : "text-neutral-400"}`}
-			>
-				Last amended: 2026-01-15
-			</p>
+			{data ? (
+				<p
+					className={`text-xs ${isDark ? "text-neutral-500" : "text-neutral-400"}`}
+				>
+					Version {data.version} · effective {data.effectiveDate}
+				</p>
+			) : null}
 		</div>
 	);
 };

--- a/website/src/components/explore/IdentityRegistryMock.tsx
+++ b/website/src/components/explore/IdentityRegistryMock.tsx
@@ -95,7 +95,7 @@ export const IdentityRegistryMock = ({
 
 	const [input, setInput] = useState<string>("");
 	const [checked, setChecked] = useState<string>("");
-	const { data, isFetching, isError } = useHandleAvailability(checked);
+	const { data, isFetching, isError, refetch } = useHandleAvailability(checked);
 
 	return (
 		<div className="space-y-3">
@@ -103,14 +103,24 @@ export const IdentityRegistryMock = ({
 				className={`rounded-lg border p-3 ${cardClass}`}
 				onSubmit={(event): void => {
 					event.preventDefault();
-					setChecked(input.trim());
+					const next = input.trim();
+					if (next === checked) {
+						// Same handle as last check — re-run instead of no-op'ing.
+						void refetch();
+					} else {
+						setChecked(next);
+					}
 				}}
 			>
-				<span className={`text-xs font-medium ${headingClass}`}>
+				<label
+					className={`text-xs font-medium ${headingClass}`}
+					htmlFor="handle-availability-input"
+				>
 					Check handle availability
-				</span>
+				</label>
 				<div className="mt-2 flex gap-2">
 					<input
+						id="handle-availability-input"
 						placeholder="@yourhandle"
 						value={input}
 						className={`flex-1 rounded-md border px-2 py-1 text-xs ${

--- a/website/src/components/explore/IdentityRegistryMock.tsx
+++ b/website/src/components/explore/IdentityRegistryMock.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { useState } from "react";
+
 import type { FunctionComponent } from "@src/common/types";
+import { useHandleAvailability } from "@src/hooks/use-registry";
 
 type RegistryEntry = {
 	handle: string;
@@ -90,57 +93,115 @@ export const IdentityRegistryMock = ({
 	const secondaryClass = isDark ? "text-neutral-500" : "text-neutral-400";
 	const rowEvenClass = isDark ? "bg-neutral-900/50" : "bg-neutral-100/50";
 
+	const [input, setInput] = useState<string>("");
+	const [checked, setChecked] = useState<string>("");
+	const { data, isFetching, isError } = useHandleAvailability(checked);
+
 	return (
-		<div className={`overflow-hidden rounded-lg border ${cardClass}`}>
-			<table className="w-full text-left text-xs">
-				<thead>
-					<tr
-						className={`border-b ${isDark ? "border-neutral-800" : "border-neutral-200"}`}
+		<div className="space-y-3">
+			<form
+				className={`rounded-lg border p-3 ${cardClass}`}
+				onSubmit={(event): void => {
+					event.preventDefault();
+					setChecked(input.trim());
+				}}
+			>
+				<span className={`text-xs font-medium ${headingClass}`}>
+					Check handle availability
+				</span>
+				<div className="mt-2 flex gap-2">
+					<input
+						placeholder="@yourhandle"
+						value={input}
+						className={`flex-1 rounded-md border px-2 py-1 text-xs ${
+							isDark
+								? "border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-600"
+								: "border-neutral-200 bg-white text-black placeholder:text-neutral-400"
+						}`}
+						onChange={(event): void => {
+							setInput(event.target.value);
+						}}
+					/>
+					<button
+						disabled={!input.trim()}
+						type="submit"
+						className={`rounded-md px-3 py-1 text-xs font-medium ${
+							isDark ? "bg-white text-black" : "bg-black text-white"
+						} ${input.trim() ? "" : "opacity-50"}`}
 					>
-						<th className={`px-3 py-2 font-medium ${headerClass}`}>Handle</th>
-						<th className={`px-3 py-2 font-medium ${headerClass}`}>
-							Crypto ID
-						</th>
-						<th className={`px-3 py-2 font-medium ${headerClass}`}>Created</th>
-						<th className={`px-3 py-2 font-medium ${headerClass}`}>Status</th>
-						<th className={`px-3 py-2 text-right font-medium ${headerClass}`}>
-							Value
-						</th>
-					</tr>
-				</thead>
-				<tbody>
-					{registryEntries.map((entry, index) => (
+						Check
+					</button>
+				</div>
+				{checked && isFetching && (
+					<p className={`mt-2 text-xs ${secondaryClass}`}>Checking…</p>
+				)}
+				{checked && isError && (
+					<p className="mt-2 text-xs text-rose-500">Failed to check handle</p>
+				)}
+				{checked && !isFetching && !isError && data ? (
+					<p
+						className={`mt-2 text-xs font-medium ${
+							data.available ? "text-green-500" : "text-rose-500"
+						}`}
+					>
+						{data.name} is {data.available ? "available" : "taken"}
+					</p>
+				) : null}
+			</form>
+
+			<div className={`overflow-hidden rounded-lg border ${cardClass}`}>
+				<table className="w-full text-left text-xs">
+					<thead>
 						<tr
-							key={entry.handle}
-							className={`border-b last:border-b-0 ${isDark ? "border-neutral-800" : "border-neutral-200"} ${
-								index % 2 === 1 ? rowEvenClass : ""
-							}`}
+							className={`border-b ${isDark ? "border-neutral-800" : "border-neutral-200"}`}
 						>
-							<td className={`px-3 py-2 font-medium ${headingClass}`}>
-								{entry.handle}
-							</td>
-							<td className={`px-3 py-2 font-mono ${secondaryClass}`}>
-								{entry.cryptoId}
-							</td>
-							<td className={`px-3 py-2 ${secondaryClass}`}>
-								{entry.createdDate}
-							</td>
-							<td className="px-3 py-2">
-								<span
-									className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusStyles[entry.status]}`}
-								>
-									{entry.status}
-								</span>
-							</td>
-							<td
-								className={`px-3 py-2 text-right font-medium ${headingClass}`}
-							>
-								{entry.valueEstimate}
-							</td>
+							<th className={`px-3 py-2 font-medium ${headerClass}`}>Handle</th>
+							<th className={`px-3 py-2 font-medium ${headerClass}`}>
+								Crypto ID
+							</th>
+							<th className={`px-3 py-2 font-medium ${headerClass}`}>
+								Created
+							</th>
+							<th className={`px-3 py-2 font-medium ${headerClass}`}>Status</th>
+							<th className={`px-3 py-2 text-right font-medium ${headerClass}`}>
+								Value
+							</th>
 						</tr>
-					))}
-				</tbody>
-			</table>
+					</thead>
+					<tbody>
+						{registryEntries.map((entry, index) => (
+							<tr
+								key={entry.handle}
+								className={`border-b last:border-b-0 ${isDark ? "border-neutral-800" : "border-neutral-200"} ${
+									index % 2 === 1 ? rowEvenClass : ""
+								}`}
+							>
+								<td className={`px-3 py-2 font-medium ${headingClass}`}>
+									{entry.handle}
+								</td>
+								<td className={`px-3 py-2 font-mono ${secondaryClass}`}>
+									{entry.cryptoId}
+								</td>
+								<td className={`px-3 py-2 ${secondaryClass}`}>
+									{entry.createdDate}
+								</td>
+								<td className="px-3 py-2">
+									<span
+										className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusStyles[entry.status]}`}
+									>
+										{entry.status}
+									</span>
+								</td>
+								<td
+									className={`px-3 py-2 text-right font-medium ${headingClass}`}
+								>
+									{entry.valueEstimate}
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
 		</div>
 	);
 };

--- a/website/src/hooks/use-constitution.ts
+++ b/website/src/hooks/use-constitution.ts
@@ -1,0 +1,14 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import type { Constitution } from "@tinyhumansai/tinyplace";
+
+import { useApiClient } from "@src/common/api-context";
+import { queryKeys } from "@src/common/query-keys";
+
+/** Fetches the current public constitution (rules, version, effective date). */
+export function useConstitution(): UseQueryResult<Constitution> {
+	const client = useApiClient();
+	return useQuery({
+		queryKey: queryKeys.constitution.detail(),
+		queryFn: (): Promise<Constitution> => client.moderation.getConstitution(),
+	});
+}

--- a/website/src/hooks/use-registry.ts
+++ b/website/src/hooks/use-registry.ts
@@ -6,7 +6,8 @@ import { queryKeys } from "@src/common/query-keys";
 
 /**
  * Checks whether an identity handle is available to register. Disabled until a
- * non-empty name is provided.
+ * non-empty name is provided. A leading `@` is normalized away so `atlas` and
+ * `@atlas` resolve to the same query and backend lookup.
  *
  * @param name - The handle to check (with or without a leading `@`).
  */
@@ -14,10 +15,11 @@ export function useHandleAvailability(
 	name: string
 ): UseQueryResult<AvailabilityResponse> {
 	const client = useApiClient();
-	const trimmed = name.trim();
+	const normalized = name.trim().replace(/^@+/, "");
 	return useQuery({
-		queryKey: queryKeys.registry.availability(trimmed),
-		queryFn: (): Promise<AvailabilityResponse> => client.registry.get(trimmed),
-		enabled: trimmed.length > 0,
+		queryKey: queryKeys.registry.availability(normalized),
+		queryFn: (): Promise<AvailabilityResponse> =>
+			client.registry.get(normalized),
+		enabled: normalized.length > 0,
 	});
 }

--- a/website/src/hooks/use-registry.ts
+++ b/website/src/hooks/use-registry.ts
@@ -1,0 +1,23 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import type { AvailabilityResponse } from "@tinyhumansai/tinyplace";
+
+import { useApiClient } from "@src/common/api-context";
+import { queryKeys } from "@src/common/query-keys";
+
+/**
+ * Checks whether an identity handle is available to register. Disabled until a
+ * non-empty name is provided.
+ *
+ * @param name - The handle to check (with or without a leading `@`).
+ */
+export function useHandleAvailability(
+	name: string
+): UseQueryResult<AvailabilityResponse> {
+	const client = useApiClient();
+	const trimmed = name.trim();
+	return useQuery({
+		queryKey: queryKeys.registry.availability(trimmed),
+		queryFn: (): Promise<AvailabilityResponse> => client.registry.get(trimmed),
+		enabled: trimmed.length > 0,
+	});
+}


### PR DESCRIPTION
Phase 3 (quick-win wiring) — replaces hardcoded data with real backend calls where it's clean to do so, and adds engineering phase docs.

## Wired to real APIs
- **Constitution** → `client.moderation.getConstitution()`. The `ConstitutionMock` now renders real rules + version + effective date, with loading/error/empty states (a `use-constitution` hook). Enforcement tiers stay static — the API doesn't expose them.
- **Identity registry availability** → `client.registry.get(name)`. A real "check handle availability" form on the identity registry view shows available/taken with loading/error states (a `use-registry` hook). Full registration is x402-gated and deferred.

## Deliberately descoped (with reasons, documented)
- **Payments** → would wire to `ledger.list()`, but `LedgerTransaction` has raw-unit string amounts across mixed assets; the mock's `$`-summed Received/Sent model would misrepresent it, and it largely duplicates the existing (real) **Ledger** section. Needs an asset-aware redesign — tracked as a follow-up.
- **Moderation** → no moderation UI surface exists yet (no section/component), so there's nothing to wire; needs a "report content" affordance designed first.

## Docs
Adds `docs/` — one detailed, cross-verified doc per integration phase (1–7) plus an index, each marking status + PR at the top. SDK method lists were verified against source (e.g. corrected Escrow `openDispute`/`getDispute`, flagged an `AdminApi` flag/unsuspend gap). Distinct from `gitbooks/` (the product spec).

## Verification
ESLint (`--max-warnings 0`), `tsc --noEmit`, and `next build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 1–7 roadmap docs with phase/status table, shipping workflow, cross-cutting facts, and verification notes.

* **New Features**
  * Registry UI: added handle availability checker.
  * Constitution view: now loads live constitution data.
  * Added client-facing hooks and query-key support to back these features.

* **Notes**
  * Documentation records a staging moderation report fix and verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->