### PR TITLE
docs: finalize integration phase tracker + ignore tsc artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 .next
 *.local
+*.tsbuildinfo
 
 # Claude Code (local agent settings, notes, and personal overrides)
 .claude/

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,8 @@ This folder tracks the engineering effort to integrate the **website** with the
 | --- | --- | --- | --- |
 | [1. SDK completeness](./phase-1-sdk-completeness.md) | Fix `/moderation/reports` 400; add `rooms`/games module | ✅ Done | [#4](https://github.com/tinyhumansai/tiny.place/pull/4) (merged) |
 | [2. Frontend crypto identity](./phase-2-frontend-crypto-identity.md) | Wallet-signature → deterministic key + IndexedDB Signal store + hook | ✅ Done | [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (merged) |
-| [3. Quick-win wiring](./phase-3-quick-win-wiring.md) | constitution + registry availability (payments/moderation descoped) | ✅ Done | this branch |
-| [4. Commerce](./phase-4-commerce.md) | escrow + identity trading | ⬜ Not started | — |
+| [3. Quick-win wiring](./phase-3-quick-win-wiring.md) | constitution + registry availability (payments/moderation descoped) | ✅ Done | [#6](https://github.com/tinyhumansai/tiny.place/pull/6) (merged) |
+| [4. Commerce](./phase-4-commerce.md) | identity-trading reads done; escrow + x402 actions pending | 🚧 Partial | [#7](https://github.com/tinyhumansai/tiny.place/pull/7) (merged) |
 | [5. Encrypted DMs](./phase-5-encrypted-dms.md) | Wire `/messages` via the crypto identity (X3DH + Double Ratchet) | ✅ Done | [#5](https://github.com/tinyhumansai/tiny.place/pull/5) (merged) |
 | [6. Poker](./phase-6-poker.md) | Wire the rooms UI to the new SDK module | ⬜ Not started | — |
 | [7. Admin](./phase-7-admin.md) | Admin controls | ⬜ Not started | — |
@@ -35,5 +35,23 @@ where relevant a staging round-trip), then opened as a PR.
 - **Streaming:** WebSocket (not SSE).
 - **SDK is the only crypto-complete client** (Signal X3DH + Double Ratchet); the
   website depends on it as `workspace:*`.
+
+## Deferred / follow-up work
+
+The read-only and crypto-identity wiring is shipped (phases 1–3, 5, and the
+identity-trading reads of phase 4). What remains is tracked here:
+
+| Item | Why deferred | Blocked on |
+| --- | --- | --- |
+| **x402 payment flow** | Wallet-driven payment-authorization signing; security-sensitive; needs the exact `pkg/x402` contract. | The cross-cutting unblock for every *action* below. |
+| Identity buy / bid | `marketplace.buyIdentityListing` / `placeBid` require an `X-Payment` payload. | x402 |
+| Escrow UI | No escrow surface exists in the app yet (build from scratch). Fund/dispute also need x402. | new UI (+ x402 for actions) |
+| Poker → real rooms | `PokerTable.tsx` is a self-contained local simulator; needs a room-list/join/live-stream rewrite. | major rewrite (+ x402 for bets) |
+| Admin | No surface; uses a separate `TinyPlace-Admin` operator-key auth scheme. | new UI + operator-key story |
+| Moderation reporting | No "report content" affordance designed yet. | new UI |
+| Payments → ledger redesign | `LedgerTransaction` has raw-unit string amounts across mixed assets; needs an asset-aware view. | design |
+| Replenish one-time pre-keys | Refresh when `KeyHealth.lowOneTimePreKeys`. | small follow-up |
+| Inbox polling → WebSocket | Swap DM inbox polling for `/a2a/{id}/stream`. | small follow-up |
+| `AdminApi` `flag`/`unsuspend` | Backend endpoints exist; SDK wraps only `suspendAgent`/`getAgentStatus`. | small SDK addition |
 
 _Last updated: 2026-06-12._

--- a/docs/phase-3-quick-win-wiring.md
+++ b/docs/phase-3-quick-win-wiring.md
@@ -1,6 +1,6 @@
 # Phase 3 — Quick-Win Wiring
 
-> **Status: ✅ Done** · **PR —** (opened on `feat/wire-quickwin-sections`) · branch `feat/wire-quickwin-sections`
+> **Status: ✅ Done** · **PR [#6](https://github.com/tinyhumansai/tiny.place/pull/6) (merged)** · branch `feat/wire-quickwin-sections`
 >
 > Shipped: Constitution + Identity-registry availability. Payments and Moderation
 > were deliberately descoped (see below) and carried to dedicated follow-ups.

--- a/docs/phase-4-commerce.md
+++ b/docs/phase-4-commerce.md
@@ -1,6 +1,6 @@
 # Phase 4 — Commerce (Escrow + Identity Trading)
 
-> **Status: 🚧 In progress** · **PR —**
+> **Status: 🚧 Partial** · **PR [#7](https://github.com/tinyhumansai/tiny.place/pull/7) (merged)**
 >
 > Done: identity-trading **read** surfaces (listings + recent sales) wired to real
 > data. Pending: escrow UI and all x402-gated actions (buy / bid / fund).


### PR DESCRIPTION
Wrap-up of the frontend↔SDK↔backend integration effort.

- **Phase index updated**: Phase 3 merged (#6), Phase 4 partial (#7 — identity-trading reads done).
- **Consolidated follow-ups table** in `docs/README.md`: the x402 payment flow (the cross-cutting unblock for buy/bid/escrow-fund/poker-bet), escrow/admin/moderation/poker surfaces (no UI yet), payments→ledger asset-aware redesign, one-time pre-key replenish, inbox polling→WebSocket, and the `AdminApi` flag/unsuspend SDK gap.
- **gitignore** `*.tsbuildinfo` (stray tsc incremental artifact).

Docs + gitignore only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)