### PR TITLE
feat: show own encryption address (copyable) in DMs

### DIFF
--- a/website/src/components/explore/DirectMessages.tsx
+++ b/website/src/components/explore/DirectMessages.tsx
@@ -16,6 +16,7 @@ export const DirectMessages = ({
 		isReady,
 		isEnabling,
 		error,
+		address,
 		enable,
 		peers,
 		threads,
@@ -27,6 +28,19 @@ export const DirectMessages = ({
 	const [selected, setSelected] = useState<string>("");
 	const [peerInput, setPeerInput] = useState<string>("");
 	const [messageInput, setMessageInput] = useState<string>("");
+	const [copied, setCopied] = useState<boolean>(false);
+
+	const handleCopy = (): void => {
+		if (!address) {
+			return;
+		}
+		void navigator.clipboard.writeText(address).then((): void => {
+			setCopied(true);
+			setTimeout((): void => {
+				setCopied(false);
+			}, 1500);
+		});
+	};
 
 	const handleSend = (): void => {
 		const text = messageInput.trim();
@@ -80,115 +94,146 @@ export const DirectMessages = ({
 	const activeThread = selected ? (threads[selected] ?? []) : [];
 
 	return (
-		<div className="grid grid-cols-[180px_1fr] gap-3">
-			<div
-				className={`flex flex-col gap-2 rounded-lg border p-2 ${panelClass}`}
-			>
-				<form
-					className="flex flex-col gap-1"
-					onSubmit={(event): void => {
-						event.preventDefault();
-						void addPeer(peerInput);
-						setPeerInput("");
-					}}
+		<div className="space-y-3">
+			{address ? (
+				<div
+					className={`flex items-center justify-between gap-2 rounded-lg border px-3 py-2 ${panelClass}`}
 				>
-					<input
-						placeholder="@handle or key"
-						value={peerInput}
-						className={`rounded-md border px-2 py-1 text-xs ${
-							isDark
-								? "border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-600"
-								: "border-neutral-200 bg-white text-black placeholder:text-neutral-400"
-						}`}
-						onChange={(event): void => {
-							setPeerInput(event.target.value);
-						}}
-					/>
-				</form>
-				{peers.length === 0 ? (
-					<p className={`px-1 text-xs ${mutedText}`}>No conversations yet</p>
-				) : null}
-				{peers.map((peer) => (
+					<div className="min-w-0">
+						<span className={`block text-xs ${mutedText}`}>Your address</span>
+						<span
+							className={`block truncate font-mono text-xs ${
+								isDark ? "text-white" : "text-black"
+							}`}
+						>
+							{`${address.slice(0, 10)}…${address.slice(-6)}`}
+						</span>
+					</div>
 					<button
-						key={peer.address}
 						type="button"
-						className={`truncate rounded-md px-2 py-1 text-left text-xs transition-colors ${
-							selected === peer.address
-								? isDark
-									? "bg-neutral-800 text-white"
-									: "bg-neutral-200 text-black"
-								: mutedText
+						className={`shrink-0 rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+							isDark
+								? "bg-neutral-800 text-neutral-300 hover:bg-neutral-700"
+								: "bg-neutral-200 text-neutral-600 hover:bg-neutral-300"
 						}`}
 						onClick={(): void => {
-							setSelected(peer.address);
+							handleCopy();
 						}}
 					>
-						{peer.label}
+						{copied ? "Copied" : "Copy"}
 					</button>
-				))}
-			</div>
-
-			<div className={`flex flex-col rounded-lg border ${panelClass}`}>
-				{!selected ? (
-					<div
-						className={`flex flex-1 items-center justify-center p-8 text-xs ${mutedText}`}
+				</div>
+			) : null}
+			<div className="grid grid-cols-[180px_1fr] gap-3">
+				<div
+					className={`flex flex-col gap-2 rounded-lg border p-2 ${panelClass}`}
+				>
+					<form
+						className="flex flex-col gap-1"
+						onSubmit={(event): void => {
+							event.preventDefault();
+							void addPeer(peerInput);
+							setPeerInput("");
+						}}
 					>
-						Select or add a conversation
-					</div>
-				) : (
-					<>
-						<div className="flex flex-1 flex-col gap-2 overflow-y-auto p-3">
-							{activeThread.length === 0 ? (
-								<p className={`text-xs ${mutedText}`}>
-									No messages yet — say hello
-								</p>
-							) : null}
-							{activeThread.map((message) => (
-								<div
-									key={message.id}
-									className={`max-w-[75%] rounded-lg px-2.5 py-1.5 text-xs ${
-										message.outgoing
-											? "self-end bg-blue-600 text-white"
-											: isDark
-												? "self-start bg-neutral-800 text-white"
-												: "self-start bg-neutral-100 text-black"
-									}`}
-								>
-									{message.text}
-								</div>
-							))}
-						</div>
-						<form
-							className="flex gap-2 border-t border-neutral-800/40 p-2"
-							onSubmit={(event): void => {
-								event.preventDefault();
-								handleSend();
+						<input
+							placeholder="@handle or key"
+							value={peerInput}
+							className={`rounded-md border px-2 py-1 text-xs ${
+								isDark
+									? "border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-600"
+									: "border-neutral-200 bg-white text-black placeholder:text-neutral-400"
+							}`}
+							onChange={(event): void => {
+								setPeerInput(event.target.value);
+							}}
+						/>
+					</form>
+					{peers.length === 0 ? (
+						<p className={`px-1 text-xs ${mutedText}`}>No conversations yet</p>
+					) : null}
+					{peers.map((peer) => (
+						<button
+							key={peer.address}
+							type="button"
+							className={`truncate rounded-md px-2 py-1 text-left text-xs transition-colors ${
+								selected === peer.address
+									? isDark
+										? "bg-neutral-800 text-white"
+										: "bg-neutral-200 text-black"
+									: mutedText
+							}`}
+							onClick={(): void => {
+								setSelected(peer.address);
 							}}
 						>
-							<input
-								placeholder="Type a message…"
-								value={messageInput}
-								className={`flex-1 rounded-md border px-2 py-1 text-xs ${
-									isDark
-										? "border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-600"
-										: "border-neutral-200 bg-white text-black placeholder:text-neutral-400"
-								}`}
-								onChange={(event): void => {
-									setMessageInput(event.target.value);
+							{peer.label}
+						</button>
+					))}
+				</div>
+
+				<div className={`flex flex-col rounded-lg border ${panelClass}`}>
+					{!selected ? (
+						<div
+							className={`flex flex-1 items-center justify-center p-8 text-xs ${mutedText}`}
+						>
+							Select or add a conversation
+						</div>
+					) : (
+						<>
+							<div className="flex flex-1 flex-col gap-2 overflow-y-auto p-3">
+								{activeThread.length === 0 ? (
+									<p className={`text-xs ${mutedText}`}>
+										No messages yet — say hello
+									</p>
+								) : null}
+								{activeThread.map((message) => (
+									<div
+										key={message.id}
+										className={`max-w-[75%] rounded-lg px-2.5 py-1.5 text-xs ${
+											message.outgoing
+												? "self-end bg-blue-600 text-white"
+												: isDark
+													? "self-start bg-neutral-800 text-white"
+													: "self-start bg-neutral-100 text-black"
+										}`}
+									>
+										{message.text}
+									</div>
+								))}
+							</div>
+							<form
+								className="flex gap-2 border-t border-neutral-800/40 p-2"
+								onSubmit={(event): void => {
+									event.preventDefault();
+									handleSend();
 								}}
-							/>
-							<button
-								disabled={isSending || !messageInput.trim()}
-								type="submit"
-								className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
-									isDark ? "bg-white text-black" : "bg-black text-white"
-								} ${isSending || !messageInput.trim() ? "opacity-50" : ""}`}
 							>
-								Send
-							</button>
-						</form>
-					</>
-				)}
+								<input
+									placeholder="Type a message…"
+									value={messageInput}
+									className={`flex-1 rounded-md border px-2 py-1 text-xs ${
+										isDark
+											? "border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-600"
+											: "border-neutral-200 bg-white text-black placeholder:text-neutral-400"
+									}`}
+									onChange={(event): void => {
+										setMessageInput(event.target.value);
+									}}
+								/>
+								<button
+									disabled={isSending || !messageInput.trim()}
+									type="submit"
+									className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+										isDark ? "bg-white text-black" : "bg-black text-white"
+									} ${isSending || !messageInput.trim() ? "opacity-50" : ""}`}
+								>
+									Send
+								</button>
+							</form>
+						</>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/website/src/hooks/use-direct-messages.ts
+++ b/website/src/hooks/use-direct-messages.ts
@@ -25,6 +25,8 @@ type UseDirectMessagesResult = {
 	isReady: boolean;
 	isEnabling: boolean;
 	error: string | undefined;
+	/** The user's own encryption address (public key) to share with peers. */
+	address: string | undefined;
 	enable: () => Promise<void>;
 	peers: Array<ConversationPeer>;
 	threads: Record<string, Array<DirectMessageEntry>>;
@@ -133,6 +135,7 @@ export function useDirectMessages(): UseDirectMessagesResult {
 		isReady,
 		isEnabling: status === "loading",
 		error,
+		address: identity?.signer.publicKeyBase64,
 		enable,
 		peers,
 		threads,


### PR DESCRIPTION
Surfaces the user's Signal **encryption address** (their public key) in the DMs panel once encryption is enabled, with a copy button — so they can share it with peers who want to message them. Previously the derived encryption identity was invisible in the UI, so there was no way to discover or hand out your own messaging address.

## Changes
- **`use-direct-messages.ts`** — expose `address` (`identity.signer.publicKeyBase64`).
- **`DirectMessages.tsx`** — render a "Your address" row above the conversation grid: truncated display (`first10…last6`), a **Copy** button that writes the *full* address to the clipboard (with a transient "Copied" state). Only shown when encryption is enabled.

## Safety
Only the **public** key is ever displayed/copied — never the seed or private key (those stay in IndexedDB). The address is a public messaging identifier (others need it to start an X3DH session), analogous to a wallet address.

## Notes
- The large line count in `DirectMessages.tsx` is mostly prettier re-indenting the existing conversation grid now that it's nested under a `space-y-3` wrapper; the only logical additions are the address row + copy handler.
- Validated: `tsc --noEmit`, ESLint (`--max-warnings 0`), and the pre-push build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now view and copy their address in direct messages. A visual indicator confirms when the address has been successfully copied to clipboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->