### PR TITLE
fix: unique one-time-prekey ids (fixes MAC failure on re-enable) + ack undecryptable DMs

### DIFF
--- a/website/src/common/signal-messaging.ts
+++ b/website/src/common/signal-messaging.ts
@@ -69,9 +69,13 @@ export async function publishKeyBundle(
 		identity.signer,
 		`spk_${new Date().getTime()}`
 	);
+	// Use a unique start id (not a fixed 1) so prekey ids differ on every publish.
+	// Re-publishing then ADDS fresh prekeys instead of colliding (relay 409) and
+	// orphaning the relay's copy: the local store keeps a private for whatever
+	// prekey the relay advertises, which is what X3DH on the sender side needs.
 	const preKeys = await generatePreKeys(
 		identity.signer,
-		1,
+		Date.now(),
 		ONE_TIME_PREKEY_COUNT
 	);
 
@@ -181,6 +185,19 @@ export async function fetchInbox(
 			plaintext = await session.decrypt(envelope.from, senderX25519, envelope);
 		} catch (error) {
 			console.warn(`Failed to decrypt message ${envelope.id}:`, error);
+			// An envelope we can't decrypt is unreadable regardless, so acknowledge
+			// it to drop it from the relay and avoid re-fetching it on every poll
+			// (an unbounded retry loop). Trade-off: we discard a message we could
+			// never have read.
+			try {
+				// eslint-disable-next-line no-await-in-loop
+				await encClient.messages.acknowledge(envelope.id, address);
+			} catch (ackError) {
+				console.warn(
+					`Failed to acknowledge undecryptable message ${envelope.id}:`,
+					ackError
+				);
+			}
 			continue;
 		}
 


### PR DESCRIPTION
## The bug
Two-party encrypted DMs fail on the recipient with **`MAC verification failed`** if the recipient ever clicked **"Enable encryption" more than once**.

`publishKeyBundle` generated one-time prekeys with **fixed ids `pk_1..pk_10`** on every enable. On a re-enable:
1. the local IndexedDB store **overwrites** `pk_1..pk_10` with new random keys, but
2. the relay upload returns **`409`** (those ids already exist), so the relay keeps the **old** prekeys.

Now the relay advertises an old prekey *public* whose matching *private* is gone locally → X3DH derives the wrong root key → the recipient can't decrypt (MAC fails). Confirmed live: `409` on `PUT /keys/{id}/prekeys`, then a loop of `MAC verification failed` in the recipient's console.

## The fix
- **Unique prekey ids:** use `Date.now()` as the prekey start id (mirroring the existing `spk_${timestamp}` signed-prekey id). Re-publishing now **adds** fresh, non-colliding prekeys, so the local store always retains a private for whatever the relay advertises — no more orphaning.
- **Stop the poison-message loop:** `fetchInbox` now **acknowledges** an envelope that fails to decrypt (wrapped in its own try/catch), instead of re-fetching it on every 5s poll forever. An undecryptable message is unreadable either way; this drops it so it can't block the inbox or spam the console.

## Scope / notes
- One file: `website/src/common/signal-messaging.ts`. ESLint + `tsc` clean.
- **Recovery caveat:** this prevents *future* corruption. Identities whose bundles were already corrupted by the old code still have orphaned prekeys on the relay; a clean two-party test is most reliable with a freshly-enabled identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved pre-key publishing so identifiers are generated uniquely each time, reducing the chance of messaging setup conflicts that could disrupt local session storage.
  * Updated inbox message handling so messages that can’t be decrypted are properly acknowledged, preventing repeated reprocessing across refreshes while retaining error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->