### PR TITLE
docs: correct stale "no tests" claim for Python and Rust SDKs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@ pnpm workspace (`pnpm-workspace.yaml` covers `website` and `sdk/*`); contracts a
 | --- | --- | --- |
 | `website/` | `@tinyplace/website` | The tiny.place web app — **Next.js 16 App Router** + React 19 + TypeScript |
 | `sdk/typescript/` | `@tinyhumansai/tinyplace` | **Flagship** TS SDK — the only one with full Signal E2E crypto; published to npm; used by the website |
-| `sdk/python/` | `tinyplace` | Python async SDK (aiohttp). REST wrapper — **no encryption**, no tests |
-| `sdk/rust/` | `tinyplace` | Rust async SDK (reqwest + tokio). **No encryption**, no tests |
+| `sdk/python/` | `tinyplace` | Python async SDK (aiohttp). REST wrapper — **no encryption**; has a test suite (`sdk/python/tests/`) |
+| `sdk/rust/` | `tinyplace` | Rust async SDK (reqwest + tokio). **No encryption**; has a test suite (`sdk/rust/tests/`, wiremock-mocked) |
 | `contracts-sol/` | — | Anchor/Solana: custody `escrow` program + `settlement_job` and `settlement_game_poker` policy programs (CPI into escrow) |
 | `gitbooks/` | — | ~30 markdown docs: the authoritative product + protocol spec |
 | `bobba_client/` | — | Empty placeholder |


### PR DESCRIPTION
## What

The `## Repo Layout` table in `CLAUDE.md` described both the Python and Rust SDKs as having **no tests**. That is no longer true:

- **Rust** (`sdk/rust/tests/`): 12 wiremock-mocked integration-test files, **396 tests, all passing** (`cargo test` → 396/396, exit 0).
- **Python** (`sdk/python/tests/`): 8 test files.

This updates the table to reflect the test suites while keeping the still-accurate **"no encryption"** caveat (only the TS SDK implements Signal E2E).

## Why

The stale claim is misleading for contributors deciding where coverage exists. No code change — documentation only.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository layout documentation to clarify that Python and Rust SDKs include dedicated test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->