### PR TITLE
fix(sdk/rust): repair user.profile canonical payload (crate fails to compile on main)

### DIFF
--- a/sdk/rust/src/api/users.rs
+++ b/sdk/rust/src/api/users.rs
@@ -73,11 +73,12 @@ fn user_profile_signature_payload(crypto_id: &str, update: &UserProfileUpdate) -
         "user.profile",
         serde_json::json!({
             "actorType": or_null(&update.actor_type),
-            "avatar": or_null(&update.avatar),
+            "avatarEmail": or_null(&update.avatar_email),
             "bio": or_null(&update.bio),
             "cryptoId": crypto_id,
             "displayName": or_null(&update.display_name),
-            "links": arr_or_null(&update.links),
+            "harnessKey": or_null(&update.harness_key),
+            "link": or_null(&update.link),
             "tags": arr_or_null(&update.tags),
         }),
     )


### PR DESCRIPTION
## Problem

The Rust SDK **does not compile on `main`**:

```
error[E0609]: no field `avatar` on type `&user::UserProfileUpdate`  --> src/api/users.rs:76
error[E0609]: no field `links` on type `&user::UserProfileUpdate`   --> src/api/users.rs:80
```

`users.rs` built the signed `user.profile` canonical payload from fields that were renamed on `UserProfileUpdate` (`avatar` → `avatar_email`, `links` → `link`) and never updated.

## Fix

Aligned the payload with the TypeScript source of truth (`sdk/typescript/src/api/users.ts` → `userProfileSignaturePayload`). Beyond just compiling, this also fixes a **latent signature bug**: the Rust payload used the wrong key names and was **missing the `harnessKey` key** entirely, so even a compiling version would have produced signatures the backend rejects.

Signed keys now match TS exactly: `actorType, avatarEmail, bio, cryptoId, displayName, harnessKey, link, tags`.

## Validation (from `sdk/rust/`)

- `cargo fmt --check` ✅
- `cargo build` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ **396 passed, 0 failed**

## Notes

This unblocks the `cargo publish` workflow (`publish-rust-sdk.yml`) — which cannot publish a non-compiling crate — and is a prerequisite for the other queued Rust SDK PRs. The fact that this landed on `main` undetected is exactly the gap tracked in #14 (no PR-gating CI for Rust).

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the canonical user profile payload structure used for request signing. The signature now includes `avatarEmail` and `harnessKey` fields, and uses `link` instead of separate avatar and links fields for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->