### PR TITLE
feat(sdk/rust): wire the `feedback` module into the client

### DIFF
--- a/sdk/rust/src/api/feedback.rs
+++ b/sdk/rust/src/api/feedback.rs
@@ -47,11 +47,7 @@ impl FeedbackApi {
     }
 
     /// Vote on a feedback item, signed as `vote.voter`.
-    pub async fn vote(
-        &self,
-        feedback_id: &str,
-        vote: FeedbackVoteRequest,
-    ) -> Result<FeedbackItem> {
+    pub async fn vote(&self, feedback_id: &str, vote: FeedbackVoteRequest) -> Result<FeedbackItem> {
         let voter = vote.voter.clone();
         self.http
             .post_directory_auth_as(

--- a/sdk/rust/src/api/mod.rs
+++ b/sdk/rust/src/api/mod.rs
@@ -12,6 +12,7 @@ pub mod docs;
 pub mod escrow;
 pub mod events;
 pub mod explorer;
+pub mod feedback;
 pub mod groups;
 pub mod inbox;
 pub mod jobs;

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -20,6 +20,7 @@ use crate::api::docs::DocsApi;
 use crate::api::escrow::EscrowApi;
 use crate::api::events::EventsApi;
 use crate::api::explorer::ExplorerApi;
+use crate::api::feedback::FeedbackApi;
 use crate::api::groups::GroupsApi;
 use crate::api::inbox::InboxApi;
 use crate::api::jobs::JobsApi;
@@ -94,6 +95,7 @@ pub struct TinyPlaceClient {
     pub lottery: LotteryApi,
     pub artifacts: ArtifactsApi,
     pub docs: DocsApi,
+    pub feedback: FeedbackApi,
 }
 
 impl TinyPlaceClient {
@@ -139,6 +141,7 @@ impl TinyPlaceClient {
             lottery: LotteryApi::new(http.clone()),
             artifacts: ArtifactsApi::new(http.clone()),
             docs: DocsApi::new(http.clone()),
+            feedback: FeedbackApi::new(http.clone()),
             http,
         }
     }

--- a/sdk/rust/tests/api_misc.rs
+++ b/sdk/rust/tests/api_misc.rs
@@ -16,11 +16,12 @@ use tinyplace::api::moderation::{
 };
 use tinyplace::types::{
     ArtifactCreateRequest, ArtifactQueryParams, ArtifactRecipientUpdate, AttestationCreate,
-    FeeConfig, FeeResolveParams, GameActionRequest, GameEmergencyWithdrawalRequest,
-    GameJoinRequest, GameLeaveRequest, GameOperatorRequest, GameRoom, GameRoomQueryParams,
-    GameSettleRequest, LeaderboardQueryParams, LotteryBuyRequest, LotteryDrawRequest,
-    LotteryRoundQueryParams, ModerationAction, ModerationReportCreate, ReputationReviewCreate,
-    ReputationVouchCreate, TrustGraphQueryParams,
+    FeeConfig, FeeResolveParams, FeedbackCreate, FeedbackListParams, FeedbackStatusUpdate,
+    FeedbackVoteRequest, GameActionRequest, GameEmergencyWithdrawalRequest, GameJoinRequest,
+    GameLeaveRequest, GameOperatorRequest, GameRoom, GameRoomQueryParams, GameSettleRequest,
+    LeaderboardQueryParams, LotteryBuyRequest, LotteryDrawRequest, LotteryRoundQueryParams,
+    ModerationAction, ModerationReportCreate, ReputationReviewCreate, ReputationVouchCreate,
+    TrustGraphQueryParams,
 };
 
 // --- RoomsApi ---
@@ -1021,4 +1022,89 @@ async fn artifacts_update_recipients() {
     let req = only_request(&server).await;
     assert_eq!(req.method.as_str(), "PUT");
     assert!(req.url.path().contains("/artifacts/art1/recipients"));
+}
+
+// --- FeedbackApi ---
+
+#[tokio::test]
+async fn feedback_list() {
+    let server = any_ok(json!({"feedback": []})).await;
+    let client = client_for(&server);
+    let _ = client
+        .feedback
+        .list(Some(&FeedbackListParams::default()))
+        .await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "GET");
+    assert!(req.url.path().contains("/feedback"));
+}
+
+#[tokio::test]
+async fn feedback_list_admin() {
+    let server = any_ok(json!({"feedback": []})).await;
+    let client = client_for(&server);
+    let _ = client.feedback.list_admin(None).await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "GET");
+    assert!(req.url.path().contains("/feedback"));
+}
+
+#[tokio::test]
+async fn feedback_get() {
+    let server = any_empty_ok().await;
+    let client = client_for(&server);
+    let _ = client.feedback.get("fb1").await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "GET");
+    assert!(req.url.path().contains("/feedback/fb1"));
+}
+
+#[tokio::test]
+async fn feedback_create() {
+    let server = any_empty_ok().await;
+    let client = client_for(&server);
+    let _ = client
+        .feedback
+        .create(FeedbackCreate {
+            author: "@alice".into(),
+            title: "Bug".into(),
+            description: "Something broke".into(),
+            ..Default::default()
+        })
+        .await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    assert!(req.url.path().contains("/feedback"));
+}
+
+#[tokio::test]
+async fn feedback_vote() {
+    let server = any_empty_ok().await;
+    let client = client_for(&server);
+    let _ = client
+        .feedback
+        .vote(
+            "fb1",
+            FeedbackVoteRequest {
+                voter: "@alice".into(),
+                ..Default::default()
+            },
+        )
+        .await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    assert!(req.url.path().contains("/feedback/fb1/vote"));
+}
+
+#[tokio::test]
+async fn feedback_update_status() {
+    let server = any_empty_ok().await;
+    let client = client_for(&server);
+    let _ = client
+        .feedback
+        .update_status("fb1", FeedbackStatusUpdate::default())
+        .await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "PUT");
+    assert!(req.url.path().contains("/feedback/fb1/status"));
 }


### PR DESCRIPTION
## What

`sdk/rust/src/api/feedback.rs` and `sdk/rust/src/types/feedback.rs` already existed, but the module was **never declared or exposed** — there was no `pub mod feedback;` in `api/mod.rs` and no `feedback` field on `TinyPlaceClient`, so `FeedbackApi` was completely unreachable.

This wires it in:
- `pub mod feedback;` in `sdk/rust/src/api/mod.rs`
- `pub feedback: FeedbackApi` field + initializer on `TinyPlaceClient` (`client.rs`), matching every other namespace
- wiremock tests in `tests/api_misc.rs` covering all six methods: `list`, `list_admin`, `get`, `create`, `vote`, `update_status`

## Validation (from `sdk/rust/`)

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (6 new feedback tests pass; full suite green)

## ⚠️ Stacked on #32

This branch is based on #32 (the compile fix), since the crate does not build on `main` without it. The first commit here is that fix; **merge #32 first** and this PR will reduce to just the feedback-wiring commit on rebase.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feedback API introduced to the Rust SDK client. The new feedback module provides comprehensive feedback management capabilities, allowing developers to list existing feedback items, create new feedback, vote on feedback entries, and update feedback status. The feedback API is fully integrated into the client with a dedicated namespace for easy access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->