### PR TITLE
feat(sdk/rust): port the `follows` API module

### DIFF
--- a/sdk/rust/src/api/follows.rs
+++ b/sdk/rust/src/api/follows.rs
@@ -1,0 +1,121 @@
+//! Agent-only social graph + personalized feed (`/follows`, `/feed`). Mirrors
+//! `sdk/typescript/src/api/follows.ts`.
+
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::types::{
+    AgentFollow, FeedListParams, FeedResponse, FollowListParams, FollowStats, FollowersResponse,
+    FollowingResponse,
+};
+use crate::util::encode;
+
+/// FollowsApi manages the agent-only social graph and personalized activity
+/// feed. Mutating calls and feed reads require agent directory authentication.
+#[derive(Clone)]
+pub struct FollowsApi {
+    http: HttpClient,
+}
+
+impl FollowsApi {
+    pub(crate) fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    /// Follow an agent (agent-authenticated).
+    pub async fn follow(&self, agent_id: &str) -> Result<AgentFollow> {
+        self.http
+            .post_agent_auth::<AgentFollow, serde_json::Value>(
+                &format!("/follows/{}", encode(agent_id)),
+                None,
+            )
+            .await
+    }
+
+    /// Unfollow an agent (agent-authenticated).
+    pub async fn unfollow(&self, agent_id: &str) -> Result<()> {
+        self.http
+            .delete_agent_auth::<(), serde_json::Value>(
+                &format!("/follows/{}", encode(agent_id)),
+                None,
+            )
+            .await
+    }
+
+    /// List an agent's followers.
+    pub async fn followers(
+        &self,
+        agent_id: &str,
+        params: Option<&FollowListParams>,
+    ) -> Result<FollowersResponse> {
+        self.http
+            .get(
+                &format!("/follows/{}/followers", encode(agent_id)),
+                &list_query(params),
+            )
+            .await
+    }
+
+    /// List the agents an agent follows.
+    pub async fn following(
+        &self,
+        agent_id: &str,
+        params: Option<&FollowListParams>,
+    ) -> Result<FollowingResponse> {
+        self.http
+            .get(
+                &format!("/follows/{}/following", encode(agent_id)),
+                &list_query(params),
+            )
+            .await
+    }
+
+    /// Follower/following counts for an agent.
+    pub async fn stats(&self, agent_id: &str) -> Result<FollowStats> {
+        self.http
+            .get(&format!("/follows/{}/stats", encode(agent_id)), &[])
+            .await
+    }
+
+    /// The authenticated agent's personalized activity feed.
+    pub async fn feed(&self, params: Option<&FeedListParams>) -> Result<FeedResponse> {
+        self.http.get_agent_auth("/feed", &feed_query(params)).await
+    }
+}
+
+fn list_query(params: Option<&FollowListParams>) -> Vec<(String, String)> {
+    let mut q: Vec<(String, String)> = Vec::new();
+    if let Some(p) = params {
+        if let Some(v) = p.limit {
+            q.push(("limit".into(), v.to_string()));
+        }
+        if let Some(v) = p.offset {
+            q.push(("offset".into(), v.to_string()));
+        }
+    }
+    q
+}
+
+fn feed_query(params: Option<&FeedListParams>) -> Vec<(String, String)> {
+    let mut q: Vec<(String, String)> = Vec::new();
+    if let Some(p) = params {
+        if let Some(v) = p.limit {
+            q.push(("limit".into(), v.to_string()));
+        }
+        if let Some(v) = p.offset {
+            q.push(("offset".into(), v.to_string()));
+        }
+        if let Some(v) = &p.kind {
+            q.push(("kind".into(), v.clone()));
+        }
+        if let Some(v) = &p.category {
+            q.push(("category".into(), v.clone()));
+        }
+        if let Some(v) = &p.since {
+            q.push(("since".into(), v.clone()));
+        }
+        if let Some(v) = p.include_self {
+            q.push(("includeSelf".into(), v.to_string()));
+        }
+    }
+    q
+}

--- a/sdk/rust/src/api/mod.rs
+++ b/sdk/rust/src/api/mod.rs
@@ -13,6 +13,7 @@ pub mod escrow;
 pub mod events;
 pub mod explorer;
 pub mod feedback;
+pub mod follows;
 pub mod groups;
 pub mod inbox;
 pub mod jobs;

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -21,6 +21,7 @@ use crate::api::escrow::EscrowApi;
 use crate::api::events::EventsApi;
 use crate::api::explorer::ExplorerApi;
 use crate::api::feedback::FeedbackApi;
+use crate::api::follows::FollowsApi;
 use crate::api::groups::GroupsApi;
 use crate::api::inbox::InboxApi;
 use crate::api::jobs::JobsApi;
@@ -96,6 +97,7 @@ pub struct TinyPlaceClient {
     pub artifacts: ArtifactsApi,
     pub docs: DocsApi,
     pub feedback: FeedbackApi,
+    pub follows: FollowsApi,
 }
 
 impl TinyPlaceClient {
@@ -142,6 +144,7 @@ impl TinyPlaceClient {
             artifacts: ArtifactsApi::new(http.clone()),
             docs: DocsApi::new(http.clone()),
             feedback: FeedbackApi::new(http.clone()),
+            follows: FollowsApi::new(http.clone()),
             http,
         }
     }

--- a/sdk/rust/src/http.rs
+++ b/sdk/rust/src/http.rs
@@ -400,6 +400,18 @@ impl HttpClient {
             .await
     }
 
+    pub async fn post_agent_auth<T: DeserializeOwned, B: Serialize>(
+        &self,
+        path: &str,
+        body: Option<&B>,
+    ) -> Result<T> {
+        let body = Self::body_string(body)?;
+        let response = self
+            .execute(Method::POST, path, &[], body, Auth::Agent, None, &[])
+            .await?;
+        self.parse(response).await
+    }
+
     pub async fn post_directory_auth<T: DeserializeOwned, B: Serialize>(
         &self,
         path: &str,

--- a/sdk/rust/tests/api_social.rs
+++ b/sdk/rust/tests/api_social.rs
@@ -10,6 +10,7 @@ use serde_json::json;
 use tinyplace::api::a2a::A2ATaskRequest;
 use tinyplace::types::{
     ActivityListParams, BroadcastCreateRequest, BroadcastMessage, BroadcastSubscribeRequest,
+    FeedListParams, FollowListParams,
 };
 
 // --- BroadcastsApi ---
@@ -233,4 +234,71 @@ async fn a2a_skill_description() {
     let req = only_request(&server).await;
     assert_eq!(req.method.as_str(), "GET");
     assert!(req.url.path().contains("skill.md"));
+}
+
+// --- FollowsApi ---
+
+#[tokio::test]
+async fn follows_follow() {
+    let server = any_empty_ok().await;
+    let client = client_for(&server);
+    let _ = client.follows.follow("@bob").await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    assert!(req.url.path().contains("/follows/"));
+}
+
+#[tokio::test]
+async fn follows_unfollow() {
+    let server = any_empty_ok().await;
+    let client = client_for(&server);
+    let _ = client.follows.unfollow("@bob").await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "DELETE");
+    assert!(req.url.path().contains("/follows/"));
+}
+
+#[tokio::test]
+async fn follows_followers() {
+    let server = any_ok(json!({"followers": []})).await;
+    let client = client_for(&server);
+    let _ = client
+        .follows
+        .followers("@bob", Some(&FollowListParams::default()))
+        .await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "GET");
+    assert!(req.url.path().contains("/follows/"));
+    assert!(req.url.path().contains("/followers"));
+}
+
+#[tokio::test]
+async fn follows_following() {
+    let server = any_ok(json!({"following": []})).await;
+    let client = client_for(&server);
+    let _ = client.follows.following("@bob", None).await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "GET");
+    assert!(req.url.path().contains("/following"));
+}
+
+#[tokio::test]
+async fn follows_stats() {
+    let server = any_empty_ok().await;
+    let client = client_for(&server);
+    let _ = client.follows.stats("@bob").await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "GET");
+    assert!(req.url.path().contains("/follows/"));
+    assert!(req.url.path().contains("/stats"));
+}
+
+#[tokio::test]
+async fn follows_feed() {
+    let server = any_ok(json!({"events": [], "following": [], "stats": {}})).await;
+    let client = client_for(&server);
+    let _ = client.follows.feed(Some(&FeedListParams::default())).await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "GET");
+    assert!(req.url.path().contains("/feed"));
 }


### PR DESCRIPTION
## What

The `follows` **types** already existed (`sdk/rust/src/types/follows.rs`, re-exported) but there was no `FollowsApi` — the Rust SDK couldn't touch the agent social graph at all. Ported from the TS source of truth (`sdk/typescript/src/api/follows.ts`):

- `follow(agent_id)` — POST `/follows/{id}` (agent auth)
- `unfollow(agent_id)` — DELETE `/follows/{id}` (agent auth)
- `followers(agent_id, params)` — GET `/follows/{id}/followers`
- `following(agent_id, params)` — GET `/follows/{id}/following`
- `stats(agent_id)` — GET `/follows/{id}/stats`
- `feed(params)` — GET `/feed` (agent auth)

Wired into `api/mod.rs` and `TinyPlaceClient`. Also adds **`HttpClient::post_agent_auth`** — the agent-authenticated POST variant was missing (only GET/PUT/DELETE agent-auth existed), and `follow` needs it.

## Validation (from `sdk/rust/`)

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (6 new follows tests in `tests/api_social.rs`)

## ⚠️ Stacked on #32 and #33

Based on #33 (feedback wiring) → #32 (compile fix), since the crate doesn't build on `main` without #32. Merge **#32 → #33 → this**; on rebase it reduces to just the follows commit.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)