### PR TITLE
ci: gate the Rust SDK on PRs (fmt, clippy, build, test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This job executes repo code (cargo build/test); don't persist the
+          # token in git config.
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,33 @@ jobs:
           name: website-dist
           path: website/.next
           retention-days: 7
+
+  rust-sdk:
+    name: Rust SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: sdk/rust
+
+      - name: Check formatting
+        run: cargo fmt --check
+        working-directory: sdk/rust
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+        working-directory: sdk/rust
+
+      - name: Build
+        run: cargo build --all-targets
+        working-directory: sdk/rust
+
+      - name: Test
+        run: cargo test
+        working-directory: sdk/rust


### PR DESCRIPTION
## What

Adds a `rust-sdk` job to `ci.yml` that runs on every PR (and push to `main`):

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --all-targets`
- `cargo test`

against `sdk/rust/`, with a Rust toolchain (`dtolnay/rust-toolchain@stable` + rustfmt/clippy) and `Swatinem/rust-cache`.

## Why

The Rust crate was **never built or tested on PRs** — `ci.yml` covered only the TS SDK + website. `publish-rust-sdk.yml` runs the Rust checks, but only on push to `main` (post-merge), so regressions land undetected. This is exactly what happened: the crate is currently broken on `main` (#30 / fixed in #32). A PR gate would have blocked it.

## Merge ordering

This should merge **after #32** (the compile fix). Until the crate compiles on `main`, this job will (correctly) fail. Once #32 is in, this goes green and keeps the Rust SDK honest going forward.

> Note: I validated the four commands locally (all green on the #32 branch). Because this PR comes from a fork, GitHub runs the *base* repo's workflow for `pull_request`, so the new job won't execute on this PR itself — it takes effect once merged.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration with automated Rust SDK validation and testing to maintain code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->