### PR TITLE
feat(sdk/rust): WebSocket streaming parity (`stream()` / `live()`)

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -22,6 +22,8 @@ rand = "0.8"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 thiserror = "2"
 async-trait = "0.1"
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/sdk/rust/src/api/a2a.rs
+++ b/sdk/rust/src/api/a2a.rs
@@ -1,6 +1,5 @@
 //! Agent-to-agent (A2A) JSON-RPC task surface. Mirrors
-//! `sdk/typescript/src/api/a2a.ts` (REST methods only; the WebSocket `stream()`
-//! is intentionally omitted).
+//! `sdk/typescript/src/api/a2a.ts`.
 
 use serde::{Deserialize, Serialize};
 
@@ -88,5 +87,11 @@ impl A2AApi {
         self.http
             .get_text(&format!("/a2a/{}/skill.md", encode(agent_id)), &[])
             .await
+    }
+
+    /// Stream an agent's A2A channel over WebSocket (directory-authenticated).
+    pub fn stream(&self, agent_id: &str) -> crate::websocket::TinyPlaceWebSocket {
+        let path = format!("/a2a/{}/stream", encode(agent_id));
+        self.http.websocket(&path, true)
     }
 }

--- a/sdk/rust/src/api/activity.rs
+++ b/sdk/rust/src/api/activity.rs
@@ -1,9 +1,11 @@
 //! Global activity livestream. Mirrors `sdk/typescript/src/api/activity.ts`
-//! (REST backfill only; the WebSocket `stream()` is intentionally omitted).
+//! (REST backfill plus a WebSocket `stream()`).
 
 use crate::error::Result;
 use crate::http::HttpClient;
 use crate::types::{ActivityListParams, ActivityListResponse};
+use crate::util::append_query;
+use crate::websocket::TinyPlaceWebSocket;
 
 /// Reads the global activity livestream — a public, normalized cross-domain feed
 /// of network actions (purchases, registrations, game wins/losses, …). The REST
@@ -39,5 +41,29 @@ impl ActivityApi {
             }
         }
         self.http.get("/activity", &query).await
+    }
+
+    /// Open the public activity livestream over WebSocket.
+    pub fn stream(&self, params: Option<&ActivityListParams>) -> TinyPlaceWebSocket {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(params) = params {
+            if let Some(limit) = params.limit {
+                query.push(("limit", limit.to_string()));
+            }
+            if let Some(offset) = params.offset {
+                query.push(("offset", offset.to_string()));
+            }
+            if let Some(kind) = &params.kind {
+                query.push(("kind", kind.clone()));
+            }
+            if let Some(category) = &params.category {
+                query.push(("category", category.clone()));
+            }
+            if let Some(since) = &params.since {
+                query.push(("since", since.clone()));
+            }
+        }
+        self.http
+            .websocket(&append_query("/activity/stream", &query), false)
     }
 }

--- a/sdk/rust/src/api/broadcasts.rs
+++ b/sdk/rust/src/api/broadcasts.rs
@@ -1,6 +1,5 @@
 //! Broadcast channels — one-to-many publisher feeds. Mirrors
-//! `sdk/typescript/src/api/broadcasts.ts` (REST methods only; the WebSocket
-//! `stream()` is intentionally omitted).
+//! `sdk/typescript/src/api/broadcasts.ts`.
 
 use rand::RngCore as _;
 use serde::Deserialize;
@@ -275,6 +274,32 @@ impl BroadcastsApi {
         self.http
             .delete_directory_auth(&path, None::<&serde_json::Value>)
             .await
+    }
+
+    /// Stream a broadcast over WebSocket. Signed with directory auth when an
+    /// `agent_id` is supplied.
+    pub fn stream(
+        &self,
+        broadcast_id: &str,
+        agent_id: Option<&str>,
+        limit: Option<i64>,
+        payment_authorization: Option<&str>,
+    ) -> crate::websocket::TinyPlaceWebSocket {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(agent_id) = agent_id {
+            query.push(("X-Agent-ID", agent_id.to_string()));
+        }
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        if let Some(payment_authorization) = payment_authorization {
+            query.push(("paymentAuthorization", payment_authorization.to_string()));
+        }
+        let path = format!("/broadcasts/{}/stream", crate::util::encode(broadcast_id));
+        self.http.websocket(
+            &crate::util::append_query(&path, &query),
+            agent_id.is_some(),
+        )
     }
 }
 

--- a/sdk/rust/src/api/channels.rs
+++ b/sdk/rust/src/api/channels.rs
@@ -1,5 +1,4 @@
-//! Public channels. Mirrors `sdk/typescript/src/api/channels.ts`. REST only —
-//! the `stream()` WebSocket method is intentionally omitted.
+//! Public channels. Mirrors `sdk/typescript/src/api/channels.ts`.
 
 use rand::RngCore as _;
 use serde::{Deserialize, Serialize};
@@ -408,6 +407,28 @@ impl ChannelsApi {
 
     pub async fn categories(&self) -> Result<ChannelCategoriesResponse> {
         self.http.get("/channels/categories", &[]).await
+    }
+
+    /// Stream a channel over WebSocket. Signed with directory auth when an
+    /// `agent_id` is supplied.
+    pub fn stream(
+        &self,
+        channel_id: &str,
+        agent_id: Option<&str>,
+        limit: Option<i64>,
+    ) -> crate::websocket::TinyPlaceWebSocket {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(agent_id) = agent_id {
+            query.push(("X-Agent-ID", agent_id.to_string()));
+        }
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        let path = format!("/channels/{}/stream", crate::util::encode(channel_id));
+        self.http.websocket(
+            &crate::util::append_query(&path, &query),
+            agent_id.is_some(),
+        )
     }
 }
 

--- a/sdk/rust/src/api/conversations.rs
+++ b/sdk/rust/src/api/conversations.rs
@@ -1,6 +1,5 @@
 //! Conversations (chats / groups / broadcasts). Mirrors
-//! `sdk/typescript/src/api/conversations.ts`. REST only — the `stream()`
-//! WebSocket method is intentionally omitted.
+//! `sdk/typescript/src/api/conversations.ts`.
 
 use rand::RngCore as _;
 use serde::{Deserialize, Serialize};
@@ -377,6 +376,31 @@ impl ConversationsApi {
                 .delete_directory_auth::<(), serde_json::Value>(&path, None)
                 .await
         }
+    }
+
+    /// Stream a conversation over WebSocket. Signed with directory auth when an
+    /// `agent_id` is supplied.
+    pub fn stream(
+        &self,
+        conversation_id: &str,
+        agent_id: Option<&str>,
+        limit: Option<i64>,
+    ) -> crate::websocket::TinyPlaceWebSocket {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(agent_id) = agent_id {
+            query.push(("X-Agent-ID", agent_id.to_string()));
+        }
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        let path = format!(
+            "/conversations/{}/stream",
+            crate::util::encode(conversation_id)
+        );
+        self.http.websocket(
+            &crate::util::append_query(&path, &query),
+            agent_id.is_some(),
+        )
     }
 }
 

--- a/sdk/rust/src/api/escrow.rs
+++ b/sdk/rust/src/api/escrow.rs
@@ -1,5 +1,5 @@
 //! Escrow contracts: custody, delivery, disputes, and milestones. Mirrors
-//! `sdk/typescript/src/api/escrow.ts`. WebSocket `stream()` is omitted.
+//! `sdk/typescript/src/api/escrow.ts`.
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
@@ -401,6 +401,24 @@ impl EscrowApi {
                 None => self.http.post(path, None::<&Value>).await,
             },
         }
+    }
+
+    /// Stream an escrow over WebSocket. Signed with directory auth when an
+    /// `agent_id` is supplied.
+    pub fn stream(
+        &self,
+        escrow_id: &str,
+        agent_id: Option<&str>,
+    ) -> crate::websocket::TinyPlaceWebSocket {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(agent_id) = agent_id {
+            query.push(("X-Agent-ID", agent_id.to_string()));
+        }
+        let path = format!("/escrow/{}/stream", crate::util::encode(escrow_id));
+        self.http.websocket(
+            &crate::util::append_query(&path, &query),
+            agent_id.is_some(),
+        )
     }
 }
 

--- a/sdk/rust/src/api/events.rs
+++ b/sdk/rust/src/api/events.rs
@@ -1,6 +1,4 @@
 //! Events API. Mirrors `sdk/typescript/src/api/events.ts`.
-//!
-//! WebSocket `stream()` is intentionally omitted (no streaming in the Rust SDK).
 
 use rand::RngCore as _;
 use serde::{Deserialize, Serialize};
@@ -715,6 +713,24 @@ impl EventsApi {
             }
             None => self.http.post_directory_auth(path, body.as_ref()).await,
         }
+    }
+
+    /// Stream an event's live stage over WebSocket. Signed with directory auth
+    /// when an `agent_id` is supplied.
+    pub fn stream(
+        &self,
+        event_id: &str,
+        agent_id: Option<&str>,
+    ) -> crate::websocket::TinyPlaceWebSocket {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(agent_id) = agent_id {
+            query.push(("X-Agent-ID", agent_id.to_string()));
+        }
+        let path = format!("/events/{}/stream", crate::util::encode(event_id));
+        self.http.websocket(
+            &crate::util::append_query(&path, &query),
+            agent_id.is_some(),
+        )
     }
 }
 

--- a/sdk/rust/src/api/explorer.rs
+++ b/sdk/rust/src/api/explorer.rs
@@ -75,4 +75,9 @@ impl ExplorerApi {
         let path = format!("/explorer/agents/{}", encode(agent_id));
         self.http.get(&path, &[]).await
     }
+
+    /// Open the public explorer live feed over WebSocket.
+    pub fn live(&self) -> crate::websocket::TinyPlaceWebSocket {
+        self.http.websocket("/explorer/live", false)
+    }
 }

--- a/sdk/rust/src/api/inbox.rs
+++ b/sdk/rust/src/api/inbox.rs
@@ -1,5 +1,4 @@
-//! Per-agent inbox. Mirrors `sdk/typescript/src/api/inbox.ts`. REST only —
-//! the `stream()` WebSocket method is intentionally omitted.
+//! Per-agent inbox. Mirrors `sdk/typescript/src/api/inbox.ts`.
 
 use std::collections::HashMap;
 
@@ -319,6 +318,11 @@ impl InboxApi {
                 .delete_agent_auth("/inbox/clear", Some(&body))
                 .await
         }
+    }
+
+    /// Stream the inbox over WebSocket.
+    pub fn stream(&self) -> crate::websocket::TinyPlaceWebSocket {
+        self.http.websocket("/inbox/stream", false)
     }
 }
 

--- a/sdk/rust/src/api/ledger.rs
+++ b/sdk/rust/src/api/ledger.rs
@@ -41,6 +41,27 @@ impl LedgerApi {
     pub async fn verify(&self, request: &LedgerVerifyRequest) -> Result<LedgerVerifyResult> {
         self.http.post_public("/ledger/verify", Some(request)).await
     }
+
+    /// Stream the ledger over WebSocket.
+    pub fn stream(
+        &self,
+        agent: Option<&str>,
+        limit: Option<i64>,
+        r#type: Option<&str>,
+    ) -> crate::websocket::TinyPlaceWebSocket {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(agent) = agent {
+            query.push(("agent", agent.to_string()));
+        }
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        if let Some(kind) = r#type {
+            query.push(("type", kind.to_string()));
+        }
+        self.http
+            .websocket(&crate::util::append_query("/ledger/stream", &query), false)
+    }
 }
 
 fn ledger_list_query(params: &LedgerListParams) -> Vec<(String, String)> {

--- a/sdk/rust/src/api/marketplace.rs
+++ b/sdk/rust/src/api/marketplace.rs
@@ -758,6 +758,22 @@ impl MarketplaceApi {
                 Error::InvalidArgument(format!("Identity listing not found: {listing_id}"))
             })
     }
+
+    /// Stream the marketplace over WebSocket (directory-authenticated).
+    pub fn stream(
+        &self,
+        agent_id: &str,
+        limit: Option<i64>,
+    ) -> crate::websocket::TinyPlaceWebSocket {
+        let mut query: Vec<(&str, String)> = vec![("X-Agent-ID", agent_id.to_string())];
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        self.http.websocket(
+            &crate::util::append_query("/marketplace/stream", &query),
+            true,
+        )
+    }
 }
 
 // --- response wrappers ------------------------------------------------------

--- a/sdk/rust/src/auth.rs
+++ b/sdk/rust/src/auth.rs
@@ -10,6 +10,7 @@ use rand::RngCore as _;
 use crate::crypto::{sha256_hex, to_base64, to_base64_url};
 use crate::error::Result;
 use crate::signer::Signer;
+use crate::util::encode;
 
 /// A list of HTTP header name/value pairs.
 pub type Headers = Vec<(String, String)>;
@@ -111,6 +112,119 @@ pub async fn sign_directory_write(
         ),
         ("X-TinyPlace-Signature".to_string(), to_base64(&signature)),
     ])
+}
+
+/// Sign a directory-write request as query parameters, returning the signed
+/// request URI (path + query). Used for WebSocket upgrades, where custom headers
+/// can't be set, so the `X-TinyPlace-*` credentials travel as query params.
+/// Mirrors `signDirectoryWriteQuery` in `sdk/typescript/src/auth.ts`.
+pub async fn sign_directory_write_query(
+    signer: &dyn Signer,
+    public_key_base64: &str,
+    method: &str,
+    request_uri: &str,
+    body: &str,
+) -> Result<String> {
+    let ts = timestamp();
+    let nonce = generate_nonce();
+    let unsigned_uri = with_query_params(
+        request_uri,
+        &[
+            ("X-TinyPlace-Date", &ts),
+            ("X-TinyPlace-Nonce", &nonce),
+            ("X-TinyPlace-Public-Key", public_key_base64),
+        ],
+    );
+    let body_hash = sha256_hex(body.as_bytes());
+    let payload = format!("{method}\n{unsigned_uri}\n{ts}\n{nonce}\n{body_hash}");
+    let signature = signer.sign(payload.as_bytes()).await?;
+    Ok(with_query_params(
+        &unsigned_uri,
+        &[("X-TinyPlace-Signature", &to_base64(&signature))],
+    ))
+}
+
+/// Build the query string the agent `Authorization` header is carried in for
+/// WebSocket upgrades (`?authorization=<urlencoded>`), since headers can't be
+/// set on a browser/standard WS handshake.
+pub async fn sign_request_query(signer: &dyn Signer, request_uri: &str) -> Result<String> {
+    let headers = sign_request(signer, "").await?;
+    let authorization = headers
+        .into_iter()
+        .find(|(name, _)| name == "Authorization")
+        .map(|(_, value)| value)
+        .unwrap_or_default();
+    Ok(with_query_params(
+        request_uri,
+        &[("authorization", &authorization)],
+    ))
+}
+
+/// Add query parameters to a request URI and return `path?sorted-encoded-query`.
+/// Params (existing + added) are sorted by key and `encodeURIComponent`-encoded,
+/// matching the TS `withQueryParams` so signed URIs are reproducible.
+fn with_query_params(request_uri: &str, params: &[(&str, &str)]) -> String {
+    let (path, existing) = match request_uri.split_once('?') {
+        Some((path, query)) => (path, query),
+        None => (request_uri, ""),
+    };
+
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    for pair in existing.split('&').filter(|s| !s.is_empty()) {
+        let (key, value) = match pair.split_once('=') {
+            Some((key, value)) => (key, value),
+            None => (pair, ""),
+        };
+        pairs.push((decode_component(key), decode_component(value)));
+    }
+    for (key, value) in params {
+        // `URLSearchParams.set` replaces any existing entry with the same key.
+        pairs.retain(|(existing_key, _)| existing_key != key);
+        pairs.push((key.to_string(), value.to_string()));
+    }
+
+    pairs.sort_by(|(left, _), (right, _)| left.cmp(right));
+    let query = pairs
+        .iter()
+        .map(|(key, value)| format!("{}={}", encode(key), encode(value)))
+        .collect::<Vec<_>>()
+        .join("&");
+
+    if query.is_empty() {
+        path.to_string()
+    } else {
+        format!("{path}?{query}")
+    }
+}
+
+/// Percent-decode a query component (reverse of `encodeURIComponent`) so an
+/// already-encoded incoming URI is re-encoded consistently after sorting.
+fn decode_component(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' if index + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).unwrap_or("");
+                match u8::from_str_radix(hex, 16) {
+                    Ok(byte) => {
+                        out.push(byte);
+                        index += 3;
+                    }
+                    Err(_) => {
+                        out.push(b'%');
+                        index += 1;
+                    }
+                }
+            }
+            byte => {
+                out.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 /// Sign a bare canonical payload, returning the base64 signature.

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -24,6 +24,10 @@ pub enum Error {
     /// Invalid input supplied by the caller.
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
+
+    /// A WebSocket connection or protocol error.
+    #[error("websocket error: {0}")]
+    WebSocket(String),
 }
 
 /// Details of a non-2xx HTTP response.

--- a/sdk/rust/src/http.rs
+++ b/sdk/rust/src/http.rs
@@ -15,6 +15,7 @@ use crate::auth::{
 };
 use crate::error::{Error, PaymentChallenge, PaymentRequiredChallenge, Result};
 use crate::signer::Signer;
+use crate::websocket::{TinyPlaceWebSocket, WsAuth};
 
 /// A list of query parameters. Arrays are expressed as repeated keys.
 pub type Query = [(String, String)];
@@ -93,6 +94,29 @@ impl HttpClient {
     /// canonical-payload signatures bound into request bodies.
     pub fn signer(&self) -> Option<Arc<dyn Signer>> {
         self.inner.signer.clone()
+    }
+
+    /// Build an un-connected [`TinyPlaceWebSocket`] for `request_uri` (a
+    /// `path?query`). The base URL's scheme is mapped `http(s)` → `ws(s)`. When
+    /// `directory_auth` is set the upgrade is signed with directory-write query
+    /// params; otherwise the agent `Authorization` is carried as a query param
+    /// (both fall back to no auth when no signer is configured).
+    pub fn websocket(&self, request_uri: &str, directory_auth: bool) -> TinyPlaceWebSocket {
+        let origin = self.inner.base_url.replacen("http", "ws", 1);
+        let auth = if directory_auth {
+            WsAuth::Directory
+        } else if self.inner.signer.is_some() {
+            WsAuth::Agent
+        } else {
+            WsAuth::None
+        };
+        TinyPlaceWebSocket::new(
+            origin,
+            request_uri.to_string(),
+            self.inner.signer.clone(),
+            self.inner.public_key_base64.clone(),
+            auth,
+        )
     }
 
     // --- core request pipeline -------------------------------------------------

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -29,6 +29,7 @@ pub mod error;
 pub mod http;
 pub mod signer;
 pub mod util;
+pub mod websocket;
 pub mod x402;
 
 pub mod api;
@@ -42,6 +43,7 @@ pub use client::{TinyPlaceClient, TinyPlaceClientOptions};
 pub use error::{Error, PaymentChallenge, PaymentRequiredChallenge, Result};
 pub use http::{HttpClient, HttpClientOptions};
 pub use signer::{LocalSigner, Signer};
+pub use websocket::{TinyPlaceWebSocket, WebSocketConnection, WsAuth};
 
 pub use auth::AdminSigningOptions;
 pub use x402::{

--- a/sdk/rust/src/util.rs
+++ b/sdk/rust/src/util.rs
@@ -22,3 +22,17 @@ pub fn encode(value: &str) -> String {
     }
     out
 }
+
+/// Append query parameters to a path as `path?k1=v1&k2=v2`, with each key and
+/// value `encodeURIComponent`-encoded. Returns just `path` when `params` is empty.
+pub fn append_query(path: &str, params: &[(&str, String)]) -> String {
+    if params.is_empty() {
+        return path.to_string();
+    }
+    let query = params
+        .iter()
+        .map(|(key, value)| format!("{}={}", encode(key), encode(value)))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{path}?{query}")
+}

--- a/sdk/rust/src/websocket.rs
+++ b/sdk/rust/src/websocket.rs
@@ -1,0 +1,135 @@
+//! WebSocket streaming. Mirrors `sdk/typescript/src/websocket.ts`.
+//!
+//! API namespaces hand back a [`TinyPlaceWebSocket`] (an un-connected handle) from
+//! their `stream()` methods. Call [`TinyPlaceWebSocket::connect`] to open the
+//! socket and obtain a [`WebSocketConnection`], then `recv()` messages in a loop.
+//!
+//! Auth travels in the URL (a WebSocket upgrade can't carry the usual custom
+//! headers): directory-write credentials as signed query params, or the agent
+//! `Authorization` header as a single `authorization=` query param.
+
+use std::sync::Arc;
+
+use futures_util::{SinkExt as _, StreamExt as _};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+use crate::auth::{sign_directory_write_query, sign_request_query};
+use crate::error::{Error, Result};
+use crate::signer::Signer;
+
+/// How a WebSocket upgrade is authenticated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WsAuth {
+    /// No auth (public stream, or no signer configured).
+    None,
+    /// Agent `Authorization` carried as an `authorization=` query param.
+    Agent,
+    /// Directory-write credentials carried as signed `X-TinyPlace-*` query params.
+    Directory,
+}
+
+/// An un-connected WebSocket handle. Cheap to build; opens the socket on
+/// [`connect`](TinyPlaceWebSocket::connect).
+pub struct TinyPlaceWebSocket {
+    origin: String,
+    request_uri: String,
+    signer: Option<Arc<dyn Signer>>,
+    public_key: Option<String>,
+    auth: WsAuth,
+}
+
+impl TinyPlaceWebSocket {
+    /// Build a handle. `origin` is the `ws(s)://host` prefix; `request_uri` is the
+    /// `path?query` to open.
+    pub(crate) fn new(
+        origin: String,
+        request_uri: String,
+        signer: Option<Arc<dyn Signer>>,
+        public_key: Option<String>,
+        auth: WsAuth,
+    ) -> Self {
+        Self {
+            origin,
+            request_uri,
+            signer,
+            public_key,
+            auth,
+        }
+    }
+
+    /// The fully-qualified WebSocket URL that would be opened, with auth applied.
+    /// Exposed for testing and diagnostics.
+    pub async fn signed_url(&self) -> Result<String> {
+        let uri = match (self.auth, &self.signer, &self.public_key) {
+            (WsAuth::Directory, Some(signer), Some(public_key)) => {
+                sign_directory_write_query(
+                    signer.as_ref(),
+                    public_key,
+                    "GET",
+                    &self.request_uri,
+                    "",
+                )
+                .await?
+            }
+            (WsAuth::Agent, Some(signer), _) => {
+                sign_request_query(signer.as_ref(), &self.request_uri).await?
+            }
+            _ => self.request_uri.clone(),
+        };
+        Ok(format!("{}{}", self.origin, uri))
+    }
+
+    /// Open the WebSocket and return a connection to read/write messages.
+    pub async fn connect(&self) -> Result<WebSocketConnection> {
+        let url = self.signed_url().await?;
+        let (stream, _response) = connect_async(&url)
+            .await
+            .map_err(|error| Error::WebSocket(error.to_string()))?;
+        Ok(WebSocketConnection { inner: stream })
+    }
+}
+
+/// An open WebSocket connection. Read JSON messages with [`recv`](Self::recv),
+/// push with [`send`](Self::send), and shut down with [`close`](Self::close).
+pub struct WebSocketConnection {
+    inner: WebSocketStream<MaybeTlsStream<TcpStream>>,
+}
+
+impl WebSocketConnection {
+    /// Await the next message, parsed as JSON. Returns `None` when the stream
+    /// closes. Ping/pong control frames are handled transparently and skipped.
+    pub async fn recv(&mut self) -> Option<Result<serde_json::Value>> {
+        loop {
+            match self.inner.next().await {
+                Some(Ok(Message::Text(text))) => {
+                    return Some(serde_json::from_str(&text).map_err(Error::from));
+                }
+                Some(Ok(Message::Binary(bytes))) => {
+                    return Some(serde_json::from_slice(&bytes).map_err(Error::from));
+                }
+                Some(Ok(Message::Close(_))) | None => return None,
+                Some(Ok(_)) => continue,
+                Some(Err(error)) => return Some(Err(Error::WebSocket(error.to_string()))),
+            }
+        }
+    }
+
+    /// Send a JSON message to the server.
+    pub async fn send(&mut self, value: &serde_json::Value) -> Result<()> {
+        let text = serde_json::to_string(value)?;
+        self.inner
+            .send(Message::Text(text))
+            .await
+            .map_err(|error| Error::WebSocket(error.to_string()))
+    }
+
+    /// Close the connection.
+    pub async fn close(mut self) -> Result<()> {
+        self.inner
+            .close(None)
+            .await
+            .map_err(|error| Error::WebSocket(error.to_string()))
+    }
+}

--- a/sdk/rust/tests/websocket.rs
+++ b/sdk/rust/tests/websocket.rs
@@ -1,0 +1,107 @@
+//! WebSocket streaming tests: signed-URL construction (public API) and a live
+//! connect/recv/send/close round-trip against a local `tokio-tungstenite` server.
+
+use std::sync::Arc;
+
+use futures_util::{SinkExt as _, StreamExt as _};
+use tinyplace::{LocalSigner, TinyPlaceClient, TinyPlaceClientOptions};
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
+
+fn client(base_url: &str, with_signer: bool) -> TinyPlaceClient {
+    let signer = with_signer.then(|| {
+        Arc::new(LocalSigner::from_seed(&[1u8; 32]).unwrap()) as Arc<dyn tinyplace::Signer>
+    });
+    TinyPlaceClient::new(TinyPlaceClientOptions {
+        base_url: base_url.to_string(),
+        signer,
+        ..Default::default()
+    })
+}
+
+#[tokio::test]
+async fn ws_url_maps_https_to_wss() {
+    let client = client("https://api.example.com", false);
+    let url = client.inbox.stream().signed_url().await.unwrap();
+    assert_eq!(url, "wss://api.example.com/inbox/stream");
+}
+
+#[tokio::test]
+async fn ws_url_maps_http_to_ws() {
+    let client = client("http://localhost:8080", false);
+    let url = client.inbox.stream().signed_url().await.unwrap();
+    assert_eq!(url, "ws://localhost:8080/inbox/stream");
+}
+
+#[tokio::test]
+async fn ws_agent_auth_appends_authorization_param() {
+    let client = client("https://api.example.com", true);
+    let url = client.activity.stream(None).signed_url().await.unwrap();
+    assert!(url.contains("authorization="), "got: {url}");
+    assert!(!url.contains("X-TinyPlace-Signature="), "got: {url}");
+}
+
+#[tokio::test]
+async fn ws_directory_auth_signs_query_params() {
+    let client = client("https://api.example.com", true);
+    let url = client.a2a.stream("@alice").signed_url().await.unwrap();
+    assert!(url.contains("X-TinyPlace-Public-Key="), "got: {url}");
+    assert!(url.contains("X-TinyPlace-Signature="), "got: {url}");
+    assert!(url.contains("X-TinyPlace-Date="), "got: {url}");
+    assert!(url.contains("X-TinyPlace-Nonce="), "got: {url}");
+}
+
+#[tokio::test]
+async fn ws_no_signer_no_auth_params() {
+    let client = client("https://api.example.com", false);
+    let url = client.activity.stream(None).signed_url().await.unwrap();
+    assert_eq!(url, "wss://api.example.com/activity/stream");
+}
+
+#[tokio::test]
+async fn ws_stream_query_params_are_included() {
+    let client = client("https://api.example.com", false);
+    let url = client
+        .channels
+        .stream("c1", None, Some(50))
+        .signed_url()
+        .await
+        .unwrap();
+    assert!(url.starts_with("wss://api.example.com/channels/c1/stream?"));
+    assert!(url.contains("limit=50"), "got: {url}");
+}
+
+#[tokio::test]
+async fn ws_connect_recv_send_close_round_trip() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (tcp, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        ws.send(Message::Text("{\"type\":\"hello\",\"n\":1}".to_string()))
+            .await
+            .unwrap();
+        // Echo back whatever the client sends, then close.
+        if let Some(Ok(incoming)) = ws.next().await {
+            if incoming.is_text() {
+                ws.send(incoming).await.unwrap();
+            }
+        }
+        let _ = ws.close(None).await;
+    });
+
+    let client = client(&format!("http://{addr}"), false);
+    let mut conn = client.inbox.stream().connect().await.unwrap();
+
+    let first = conn.recv().await.expect("a message").expect("valid json");
+    assert_eq!(first["type"], "hello");
+    assert_eq!(first["n"], 1);
+
+    conn.send(&serde_json::json!({"ack": true})).await.unwrap();
+    let echoed = conn.recv().await.expect("echo").expect("valid json");
+    assert_eq!(echoed["ack"], true);
+
+    conn.close().await.unwrap();
+    server.await.unwrap();
+}


### PR DESCRIPTION
## What

Brings real-time streaming to the Rust SDK. The TS SDK exposes a WebSocket `stream()` on ~10 namespaces plus `explorer.live()`; the Rust SDK had none. (Note: the title of #16 said "SSE", but the mechanism is WebSocket — corrected on the issue.)

**New `websocket` module**
- `TinyPlaceWebSocket` — an un-connected handle returned by `stream()`/`live()`.
- `WebSocketConnection` — `recv()` (parses text/binary frames as JSON), `send()`, `close()` over an async `tokio-tungstenite` socket.

**Wiring**
- `HttpClient::websocket(request_uri, directory_auth)` builds the handle off the shared `HttpClient` every module already holds (`http(s)` → `ws(s)`), so **no module-constructor churn**.
- `stream()` added to: activity, events, inbox, channels, conversations, broadcasts, ledger, escrow, marketplace, a2a; `explorer.live()`. (`mcp.stream()` is an HTTP streaming response, not WS — left as-is.)

**Auth** (a WS upgrade can't carry custom headers, so credentials go in the URL)
- `sign_directory_write_query` — signed `X-TinyPlace-*` query params, mirroring TS `signDirectoryWriteQuery`.
- `sign_request_query` — `authorization=<encoded>`.
- shared `with_query_params` sorts + `encodeURIComponent`-encodes params so signed URIs match the TS SDK byte-for-byte.

**Deps / misc**: `tokio-tungstenite` (rustls) + `futures-util`; new `Error::WebSocket` variant.

## Validation (from `sdk/rust/`)

- `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ — **403 passing** (7 new WS tests: scheme mapping, agent/directory/no-auth URL signing, query params, and a **live connect → recv → send → close round-trip** against a local `tokio-tungstenite` server).

## Honest caveats

- Live behavior **against staging** (does the backend accept the signed WS upgrade?) is not exercised in CI — there's no WS server to hit there. The directory-auth query signing mirrors the TS algorithm exactly and is unit-tested for structure.
- v1 is a clean async `recv()`/`send()`/`close()` connection. It does **not** auto-reconnect (the TS client does); a caller can reconnect by calling `stream().connect()` again. Worth a follow-up if needed.

## ⚠️ Stacked on #32

Based on #32 (the compile fix) since the crate doesn't build on `main` without it. Merge **#32 first**; this then reduces to just the WebSocket commit on rebase.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Rust SDK Release Notes

* **New Features**
  * Added WebSocket streaming support across 11 API endpoints (A2A, Activity, Broadcasts, Channels, Conversations, Escrow, Events, Explorer, Inbox, Ledger, Marketplace) enabling real-time data streaming.
  * Introduced full WebSocket connection lifecycle with message sending, receiving, and graceful closure.

* **Bug Fixes**
  * Updated user profile signature payload to use corrected profile fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->