### PR TITLE
fix(website): repair Typecheck on main (delegated-payment test indexed access)

### DIFF
--- a/website/src/common/delegated-payment.test.ts
+++ b/website/src/common/delegated-payment.test.ts
@@ -60,8 +60,9 @@ describe("buildDelegatedTransferTx", () => {
 		const tx = Transaction.from(Buffer.from(wire, "base64"));
 		expect(tx.instructions).toHaveLength(3);
 		const approve = tx.instructions[0];
-		expect(approve.programId.toBase58()).toBe(SOLANA_TOKEN_PROGRAM_ID);
-		expect(approve.data[0]).toBe(TOKEN_APPROVE_CHECKED);
+		expect(approve).toBeDefined();
+		expect(approve?.programId.toBase58()).toBe(SOLANA_TOKEN_PROGRAM_ID);
+		expect(approve?.data[0]).toBe(TOKEN_APPROVE_CHECKED);
 		// Owner (payer) is the third required signer for the gasless approve.
 		expect(tx.signatures).toHaveLength(3);
 	});


### PR DESCRIPTION
## Problem

`main` is currently **red**: the `Typecheck` CI job fails (`tsc --noEmit` in `website`):

```
src/common/delegated-payment.test.ts(63,10): error TS18048: 'approve' is possibly 'undefined'.
src/common/delegated-payment.test.ts(64,10): error TS18048: 'approve' is possibly 'undefined'.
```

`website/tsconfig.json` has `noUncheckedIndexedAccess: true`, so `tx.instructions[0]` is typed `TransactionInstruction | undefined`, and the subsequent `.programId` / `.data` accesses don't typecheck.

This blocks the Typecheck check on **every** open PR to `main`, not just this one.

## Fix

Assert the instruction is defined and use optional chaining (no non-null assertion):

```ts
const approve = tx.instructions[0];
expect(approve).toBeDefined();
expect(approve?.programId.toBase58()).toBe(SOLANA_TOKEN_PROGRAM_ID);
expect(approve?.data[0]).toBe(TOKEN_APPROVE_CHECKED);
```

## Validation (from `website/`)

- `tsc --noEmit` ✅ (was failing, now passes)
- `prettier --check` ✅
- `eslint` ✅

Pure test-file fix; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened delegated payment transaction builder tests with enhanced validation checks to ensure instruction properties are safely accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->