### PR TITLE
docs(sdk/rust): fix stale "stream not ported" headers (ledger, pricing)

### DIFF
--- a/sdk/rust/src/api/ledger.rs
+++ b/sdk/rust/src/api/ledger.rs
@@ -1,6 +1,5 @@
 //! Ledger queries and on-chain verification. Mirrors
-//! `sdk/typescript/src/api/ledger.ts` (REST surface only; the WebSocket
-//! `stream()` method is intentionally NOT ported).
+//! `sdk/typescript/src/api/ledger.ts`.
 
 use serde::Deserialize;
 

--- a/sdk/rust/src/api/pricing.rs
+++ b/sdk/rust/src/api/pricing.rs
@@ -1,5 +1,4 @@
-//! Pricing. Mirrors `sdk/typescript/src/api/pricing.ts`
-//! (REST surface only; WebSocket `priceStream()` is NOT ported).
+//! Pricing. Mirrors `sdk/typescript/src/api/pricing.ts`.
 
 use serde::Deserialize;
 


### PR DESCRIPTION
Follow-up to the WebSocket streaming work (#16/#36), addressing a CodeRabbit finding.

- **`ledger.rs`** — header still said the WebSocket `stream()` was "intentionally NOT ported", but `LedgerApi::stream` now exists. (CodeRabbit flagged this on #36.)
- **`pricing.rs`** — header referenced a `priceStream()` WebSocket that doesn't exist in the TS SDK either; removed the inaccurate note.

Doc-comment only; `cargo fmt --check` clean, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)