### PR TITLE
feat(sdk/python): Signal session store (interface + in-memory) (#43)

### DIFF
--- a/sdk/python/src/tinyplace/signal/__init__.py
+++ b/sdk/python/src/tinyplace/signal/__init__.py
@@ -1,0 +1,31 @@
+"""Signal Protocol primitives for the tiny.place Python SDK.
+
+This package is a work-in-progress port of the TypeScript SDK's
+``signal/`` module. This slice provides the session-store contract and an
+in-memory implementation; the crypto, key, X3DH, ratchet, session and
+sender-key layers land in later slices.
+"""
+
+from __future__ import annotations
+
+from .memory_store import MemorySessionStore
+from .store import (
+    PreKeyPair,
+    SenderKeyState,
+    SessionState,
+    SessionStore,
+    SignedPreKeyPair,
+    X25519KeyPair,
+    skipped_key_id,
+)
+
+__all__ = [
+    "MemorySessionStore",
+    "PreKeyPair",
+    "SenderKeyState",
+    "SessionState",
+    "SessionStore",
+    "SignedPreKeyPair",
+    "X25519KeyPair",
+    "skipped_key_id",
+]

--- a/sdk/python/src/tinyplace/signal/memory_store.py
+++ b/sdk/python/src/tinyplace/signal/memory_store.py
@@ -8,6 +8,8 @@ the same :class:`~tinyplace.signal.store.SessionStore` contract.
 
 from __future__ import annotations
 
+from copy import deepcopy
+
 from .store import (
     PreKeyPair,
     SenderKeyState,
@@ -22,7 +24,10 @@ class MemorySessionStore(SessionStore):
     """A non-durable, in-process :class:`SessionStore`."""
 
     def __init__(self, identity_key_pair: X25519KeyPair) -> None:
-        self._identity_key_pair = identity_key_pair
+        # deepcopy on store/get so callers can never mutate in-store state by
+        # holding a reference — matching how a durable (serializing) backend
+        # behaves.
+        self._identity_key_pair = deepcopy(identity_key_pair)
         self._signed_pre_keys: dict[str, SignedPreKeyPair] = {}
         self._pre_keys: dict[str, PreKeyPair] = {}
         self._sessions: dict[str, SessionState] = {}
@@ -32,12 +37,12 @@ class MemorySessionStore(SessionStore):
     # --- Identity -----------------------------------------------------------
 
     async def get_identity_x25519_key_pair(self) -> X25519KeyPair:
-        return self._identity_key_pair
+        return deepcopy(self._identity_key_pair)
 
     # --- Signed pre-keys ----------------------------------------------------
 
     async def get_signed_pre_key(self, key_id: str) -> SignedPreKeyPair | None:
-        return self._signed_pre_keys.get(key_id)
+        return deepcopy(self._signed_pre_keys.get(key_id))
 
     async def get_active_signed_pre_key(self) -> SignedPreKeyPair:
         if self._active_signed_pre_key_id is None:
@@ -45,33 +50,33 @@ class MemorySessionStore(SessionStore):
         key = self._signed_pre_keys.get(self._active_signed_pre_key_id)
         if key is None:
             raise LookupError("Active signed pre-key not found")
-        return key
+        return deepcopy(key)
 
     async def store_signed_pre_key(self, pre_key: SignedPreKeyPair) -> None:
-        self._signed_pre_keys[pre_key.key_id] = pre_key
+        self._signed_pre_keys[pre_key.key_id] = deepcopy(pre_key)
         self._active_signed_pre_key_id = pre_key.key_id
 
     # --- One-time pre-keys --------------------------------------------------
 
     async def get_pre_key(self, key_id: str) -> PreKeyPair | None:
-        return self._pre_keys.get(key_id)
+        return deepcopy(self._pre_keys.get(key_id))
 
     async def store_pre_key(self, pre_key: PreKeyPair) -> None:
-        self._pre_keys[pre_key.key_id] = pre_key
+        self._pre_keys[pre_key.key_id] = deepcopy(pre_key)
 
     async def remove_pre_key(self, key_id: str) -> None:
         self._pre_keys.pop(key_id, None)
 
     async def get_all_pre_keys(self) -> list[PreKeyPair]:
-        return list(self._pre_keys.values())
+        return [deepcopy(pre_key) for pre_key in self._pre_keys.values()]
 
     # --- Sessions -----------------------------------------------------------
 
     async def get_session(self, address: str) -> SessionState | None:
-        return self._sessions.get(address)
+        return deepcopy(self._sessions.get(address))
 
     async def store_session(self, address: str, session: SessionState) -> None:
-        self._sessions[address] = session
+        self._sessions[address] = deepcopy(session)
 
     async def remove_session(self, address: str) -> None:
         self._sessions.pop(address, None)
@@ -79,10 +84,10 @@ class MemorySessionStore(SessionStore):
     # --- Sender keys (groups) ----------------------------------------------
 
     async def get_sender_key(self, distribution_id: str) -> SenderKeyState | None:
-        return self._sender_keys.get(distribution_id)
+        return deepcopy(self._sender_keys.get(distribution_id))
 
     async def store_sender_key(self, sender_key: SenderKeyState) -> None:
-        self._sender_keys[sender_key.distribution_id] = sender_key
+        self._sender_keys[sender_key.distribution_id] = deepcopy(sender_key)
 
     async def remove_sender_key(self, distribution_id: str) -> None:
         self._sender_keys.pop(distribution_id, None)

--- a/sdk/python/src/tinyplace/signal/memory_store.py
+++ b/sdk/python/src/tinyplace/signal/memory_store.py
@@ -1,0 +1,88 @@
+"""In-memory implementation of :class:`SessionStore`.
+
+Mirrors ``sdk/typescript/src/signal/memory-store.ts``. Holds all session
+material in process-local dicts; nothing is persisted across restarts. Useful
+for tests and short-lived agents. A durable backend (e.g. Hermes) implements
+the same :class:`~tinyplace.signal.store.SessionStore` contract.
+"""
+
+from __future__ import annotations
+
+from .store import (
+    PreKeyPair,
+    SenderKeyState,
+    SessionState,
+    SessionStore,
+    SignedPreKeyPair,
+    X25519KeyPair,
+)
+
+
+class MemorySessionStore(SessionStore):
+    """A non-durable, in-process :class:`SessionStore`."""
+
+    def __init__(self, identity_key_pair: X25519KeyPair) -> None:
+        self._identity_key_pair = identity_key_pair
+        self._signed_pre_keys: dict[str, SignedPreKeyPair] = {}
+        self._pre_keys: dict[str, PreKeyPair] = {}
+        self._sessions: dict[str, SessionState] = {}
+        self._sender_keys: dict[str, SenderKeyState] = {}
+        self._active_signed_pre_key_id: str | None = None
+
+    # --- Identity -----------------------------------------------------------
+
+    async def get_identity_x25519_key_pair(self) -> X25519KeyPair:
+        return self._identity_key_pair
+
+    # --- Signed pre-keys ----------------------------------------------------
+
+    async def get_signed_pre_key(self, key_id: str) -> SignedPreKeyPair | None:
+        return self._signed_pre_keys.get(key_id)
+
+    async def get_active_signed_pre_key(self) -> SignedPreKeyPair:
+        if self._active_signed_pre_key_id is None:
+            raise LookupError("No active signed pre-key")
+        key = self._signed_pre_keys.get(self._active_signed_pre_key_id)
+        if key is None:
+            raise LookupError("Active signed pre-key not found")
+        return key
+
+    async def store_signed_pre_key(self, pre_key: SignedPreKeyPair) -> None:
+        self._signed_pre_keys[pre_key.key_id] = pre_key
+        self._active_signed_pre_key_id = pre_key.key_id
+
+    # --- One-time pre-keys --------------------------------------------------
+
+    async def get_pre_key(self, key_id: str) -> PreKeyPair | None:
+        return self._pre_keys.get(key_id)
+
+    async def store_pre_key(self, pre_key: PreKeyPair) -> None:
+        self._pre_keys[pre_key.key_id] = pre_key
+
+    async def remove_pre_key(self, key_id: str) -> None:
+        self._pre_keys.pop(key_id, None)
+
+    async def get_all_pre_keys(self) -> list[PreKeyPair]:
+        return list(self._pre_keys.values())
+
+    # --- Sessions -----------------------------------------------------------
+
+    async def get_session(self, address: str) -> SessionState | None:
+        return self._sessions.get(address)
+
+    async def store_session(self, address: str, session: SessionState) -> None:
+        self._sessions[address] = session
+
+    async def remove_session(self, address: str) -> None:
+        self._sessions.pop(address, None)
+
+    # --- Sender keys (groups) ----------------------------------------------
+
+    async def get_sender_key(self, distribution_id: str) -> SenderKeyState | None:
+        return self._sender_keys.get(distribution_id)
+
+    async def store_sender_key(self, sender_key: SenderKeyState) -> None:
+        self._sender_keys[sender_key.distribution_id] = sender_key
+
+    async def remove_sender_key(self, distribution_id: str) -> None:
+        self._sender_keys.pop(distribution_id, None)

--- a/sdk/python/src/tinyplace/signal/store.py
+++ b/sdk/python/src/tinyplace/signal/store.py
@@ -1,0 +1,188 @@
+"""Session-store contract for the Signal Protocol session/ratchet layers.
+
+This mirrors ``sdk/typescript/src/signal/store.ts``. It defines the record
+types the session, Double Ratchet and Sender Key layers persist (identity,
+sessions, one-time pre-keys, signed pre-keys, sender keys) plus the abstract
+:class:`SessionStore` interface that ties them together.
+
+The contract is intentionally storage-agnostic so it can be backed by an
+in-memory map (see :mod:`tinyplace.signal.memory_store`) or a durable store
+(e.g. Hermes) later. Only the in-memory implementation ships in this slice.
+
+This module is self-contained: it does not import the (in-flight) crypto or
+key modules. Key material is represented by the lightweight
+:class:`X25519KeyPair` dataclass defined here; later slices may re-export a
+richer type, but the field shape (``public_key`` / ``private_key`` bytes)
+matches the TypeScript ``X25519KeyPair``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+
+@dataclass
+class X25519KeyPair:
+    """An X25519 key pair (raw 32-byte public/private keys).
+
+    Mirrors the TypeScript ``X25519KeyPair``. Defined locally so the store
+    layer does not depend on the crypto module, which lands in a later slice.
+    """
+
+    public_key: bytes
+    private_key: bytes
+
+
+@dataclass
+class SessionState:
+    """Double Ratchet session state for a single conversation.
+
+    Mirrors the TypeScript ``SessionState`` interface. ``skipped_keys`` maps a
+    :func:`skipped_key_id` string to the derived message key bytes for
+    out-of-order / skipped messages.
+    """
+
+    dh_send_key_pair: X25519KeyPair
+    dh_recv_public_key: bytes | None
+    root_key: bytes
+    send_chain_key: bytes | None
+    recv_chain_key: bytes | None
+    send_message_number: int
+    recv_message_number: int
+    previous_chain_length: int
+    skipped_keys: dict[str, bytes] = field(default_factory=dict)
+
+
+@dataclass
+class PreKeyPair:
+    """A one-time pre-key: its server key id, key pair and signature.
+
+    Mirrors the TypeScript ``PreKeyPair`` interface.
+    """
+
+    key_id: str
+    key_pair: X25519KeyPair
+    signature: bytes
+
+
+@dataclass
+class SignedPreKeyPair:
+    """A signed pre-key: its server key id, key pair and signature.
+
+    Mirrors the TypeScript ``SignedPreKeyPair`` interface.
+    """
+
+    key_id: str
+    key_pair: X25519KeyPair
+    signature: bytes
+
+
+@dataclass
+class SenderKeyState:
+    """Sender-key state for a group distribution id.
+
+    Group (Sender Key) messaging persists a symmetric chain key plus the
+    signing key pair used to authenticate sender-key messages. This has no
+    direct one-to-one TypeScript ``store.ts`` analogue (the TS sender-key
+    state lives in ``sender-key.ts``), but the durable contract needs a place
+    to persist it, so the interface covers it here.
+    """
+
+    distribution_id: str
+    chain_key: bytes
+    message_number: int
+    signing_key_pair: X25519KeyPair
+
+
+class SessionStore(ABC):
+    """Abstract persistence contract for Signal Protocol session material.
+
+    Covers the four record families the session, ratchet and sender-key
+    layers need: the long-term identity key pair, Double Ratchet sessions
+    (keyed by peer address), one-time and signed pre-keys (keyed by server key
+    id), and group sender keys (keyed by distribution id).
+
+    All methods are async so a durable backend (network / disk) can implement
+    the same contract as the in-memory store without changing call sites.
+    """
+
+    # --- Identity -----------------------------------------------------------
+
+    @abstractmethod
+    async def get_identity_x25519_key_pair(self) -> X25519KeyPair:
+        """Return the agent's long-term identity X25519 key pair."""
+
+    # --- Signed pre-keys ----------------------------------------------------
+
+    @abstractmethod
+    async def get_signed_pre_key(self, key_id: str) -> SignedPreKeyPair | None:
+        """Return the signed pre-key with ``key_id``, or ``None`` if absent."""
+
+    @abstractmethod
+    async def get_active_signed_pre_key(self) -> SignedPreKeyPair:
+        """Return the currently active signed pre-key.
+
+        Raises:
+            LookupError: if no signed pre-key has been stored / activated.
+        """
+
+    @abstractmethod
+    async def store_signed_pre_key(self, pre_key: SignedPreKeyPair) -> None:
+        """Persist ``pre_key`` and make it the active signed pre-key."""
+
+    # --- One-time pre-keys --------------------------------------------------
+
+    @abstractmethod
+    async def get_pre_key(self, key_id: str) -> PreKeyPair | None:
+        """Return the one-time pre-key with ``key_id``, or ``None``."""
+
+    @abstractmethod
+    async def store_pre_key(self, pre_key: PreKeyPair) -> None:
+        """Persist a one-time ``pre_key``."""
+
+    @abstractmethod
+    async def remove_pre_key(self, key_id: str) -> None:
+        """Delete the one-time pre-key with ``key_id`` (no-op if absent)."""
+
+    @abstractmethod
+    async def get_all_pre_keys(self) -> list[PreKeyPair]:
+        """Return every stored one-time pre-key."""
+
+    # --- Sessions -----------------------------------------------------------
+
+    @abstractmethod
+    async def get_session(self, address: str) -> SessionState | None:
+        """Return the session for ``address``, or ``None`` if none exists."""
+
+    @abstractmethod
+    async def store_session(self, address: str, session: SessionState) -> None:
+        """Persist ``session`` for the peer ``address``."""
+
+    @abstractmethod
+    async def remove_session(self, address: str) -> None:
+        """Delete the session for ``address`` (no-op if absent)."""
+
+    # --- Sender keys (groups) ----------------------------------------------
+
+    @abstractmethod
+    async def get_sender_key(self, distribution_id: str) -> SenderKeyState | None:
+        """Return the sender-key state for ``distribution_id``, or ``None``."""
+
+    @abstractmethod
+    async def store_sender_key(self, sender_key: SenderKeyState) -> None:
+        """Persist ``sender_key`` keyed by its distribution id."""
+
+    @abstractmethod
+    async def remove_sender_key(self, distribution_id: str) -> None:
+        """Delete the sender key for ``distribution_id`` (no-op if absent)."""
+
+
+def skipped_key_id(ratchet_public_key: bytes, message_number: int) -> str:
+    """Build the map key for a skipped/out-of-order message key.
+
+    Mirrors the TypeScript ``skippedKeyId``: lower-case hex of the ratchet
+    public key, a colon, then the message number (e.g. ``"00ff:3"``).
+    """
+
+    return f"{ratchet_public_key.hex()}:{message_number}"

--- a/sdk/python/src/tinyplace/signal/store.py
+++ b/sdk/python/src/tinyplace/signal/store.py
@@ -82,17 +82,22 @@ class SignedPreKeyPair:
 class SenderKeyState:
     """Sender-key state for a group distribution id.
 
-    Group (Sender Key) messaging persists a symmetric chain key plus the
-    signing key pair used to authenticate sender-key messages. This has no
-    direct one-to-one TypeScript ``store.ts`` analogue (the TS sender-key
-    state lives in ``sender-key.ts``), but the durable contract needs a place
-    to persist it, so the interface covers it here.
+    Persists both halves of the TypeScript sender-key model
+    (``SenderKeyOwnState`` / ``SenderKeyReceiverState`` in ``sender-key.ts``).
+    Group messages are authenticated with an **Ed25519** signing key (not
+    X25519): ``signing_public_key`` is always present so receivers can verify a
+    sender's messages, while ``signing_private_key`` is set only for our *own*
+    sending key — a receiver never holds a remote sender's private key.
+    ``skipped_keys`` caches message keys (by iteration) for out-of-order group
+    messages on the receiver side.
     """
 
     distribution_id: str
     chain_key: bytes
-    message_number: int
-    signing_key_pair: X25519KeyPair
+    iteration: int
+    signing_public_key: bytes
+    signing_private_key: bytes | None = None
+    skipped_keys: dict[int, bytes] = field(default_factory=dict)
 
 
 class SessionStore(ABC):

--- a/sdk/python/tests/test_signal_store.py
+++ b/sdk/python/tests/test_signal_store.py
@@ -55,7 +55,11 @@ def test_skipped_key_id_matches_typescript_format() -> None:
 async def test_identity_round_trips() -> None:
     identity = _key_pair(0)
     store = MemorySessionStore(identity)
-    assert await store.get_identity_x25519_key_pair() is identity
+    fetched = await store.get_identity_x25519_key_pair()
+    assert fetched == identity
+    # The store returns a copy, not the caller's object, so external mutation
+    # cannot reach in-store state.
+    assert fetched is not identity
 
 
 async def test_signed_pre_key_round_trip_and_active() -> None:
@@ -128,17 +132,56 @@ async def test_sender_key_put_get_delete() -> None:
     store = _store()
     assert await store.get_sender_key("group-1") is None
 
-    sender_key = SenderKeyState(
+    # Own sending key: has the Ed25519 signing private key.
+    own = SenderKeyState(
         distribution_id="group-1",
         chain_key=bytes([0x11]) * 32,
-        message_number=5,
-        signing_key_pair=_key_pair(60),
+        iteration=5,
+        signing_public_key=bytes([0x22]) * 32,
+        signing_private_key=bytes([0x33]) * 32,
     )
-    await store.store_sender_key(sender_key)
-    assert await store.get_sender_key("group-1") == sender_key
+    await store.store_sender_key(own)
+    assert await store.get_sender_key("group-1") == own
 
     await store.remove_sender_key("group-1")
     assert await store.get_sender_key("group-1") is None
 
     # Deleting an absent sender key is a no-op.
     await store.remove_sender_key("group-missing")
+
+
+async def test_receiver_sender_key_has_no_private_key() -> None:
+    store = _store()
+    # A remote member's sender key: only the signing public key, plus a skipped
+    # message-key cache; no private key is fabricated.
+    receiver = SenderKeyState(
+        distribution_id="group-1:@alice",
+        chain_key=bytes([0x44]) * 32,
+        iteration=3,
+        signing_public_key=bytes([0x55]) * 32,
+        skipped_keys={2: b"skipped-message-key"},
+    )
+    await store.store_sender_key(receiver)
+    fetched = await store.get_sender_key("group-1:@alice")
+    assert fetched == receiver
+    assert fetched is not None
+    assert fetched.signing_private_key is None
+    assert fetched.skipped_keys[2] == b"skipped-message-key"
+
+
+async def test_stored_record_is_isolated_from_caller_mutation() -> None:
+    store = _store()
+    session = _session(70)
+    await store.store_session("@peer", session)
+
+    # Mutating the original object after storing must not affect the store.
+    session.skipped_keys[skipped_key_id(bytes([0x01]), 9)] = b"leak"
+    fetched = await store.get_session("@peer")
+    assert fetched is not None
+    assert skipped_key_id(bytes([0x01]), 9) not in fetched.skipped_keys
+
+    # Mutating a fetched copy must not affect the store either.
+    fetched.skipped_keys[skipped_key_id(bytes([0x02]), 9)] = b"leak2"
+    again = await store.get_session("@peer")
+    assert again is not None
+    assert skipped_key_id(bytes([0x02]), 9) not in again.skipped_keys

--- a/sdk/python/tests/test_signal_store.py
+++ b/sdk/python/tests/test_signal_store.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import pytest
+
+from tinyplace.signal import (
+    MemorySessionStore,
+    PreKeyPair,
+    SenderKeyState,
+    SessionState,
+    SignedPreKeyPair,
+    X25519KeyPair,
+    skipped_key_id,
+)
+from tinyplace.signal.store import SessionStore
+
+
+def _key_pair(seed: int) -> X25519KeyPair:
+    return X25519KeyPair(
+        public_key=bytes([seed]) * 32,
+        private_key=bytes([seed + 1]) * 32,
+    )
+
+
+def _session(seed: int) -> SessionState:
+    return SessionState(
+        dh_send_key_pair=_key_pair(seed),
+        dh_recv_public_key=bytes([seed + 2]) * 32,
+        root_key=bytes([seed + 3]) * 32,
+        send_chain_key=bytes([seed + 4]) * 32,
+        recv_chain_key=None,
+        send_message_number=1,
+        recv_message_number=2,
+        previous_chain_length=3,
+        skipped_keys={skipped_key_id(bytes([0xAB, 0xCD]), 7): b"messagekey"},
+    )
+
+
+def _store() -> MemorySessionStore:
+    return MemorySessionStore(_key_pair(0))
+
+
+def test_memory_store_is_a_session_store() -> None:
+    assert isinstance(_store(), SessionStore)
+
+
+def test_session_store_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        SessionStore()  # type: ignore[abstract]
+
+
+def test_skipped_key_id_matches_typescript_format() -> None:
+    assert skipped_key_id(bytes([0x00, 0xFF]), 3) == "00ff:3"
+
+
+async def test_identity_round_trips() -> None:
+    identity = _key_pair(0)
+    store = MemorySessionStore(identity)
+    assert await store.get_identity_x25519_key_pair() is identity
+
+
+async def test_signed_pre_key_round_trip_and_active() -> None:
+    store = _store()
+    assert await store.get_signed_pre_key("spk-1") is None
+
+    with pytest.raises(LookupError):
+        await store.get_active_signed_pre_key()
+
+    first = SignedPreKeyPair(key_id="spk-1", key_pair=_key_pair(10), signature=b"s1")
+    second = SignedPreKeyPair(key_id="spk-2", key_pair=_key_pair(20), signature=b"s2")
+    await store.store_signed_pre_key(first)
+    assert await store.get_signed_pre_key("spk-1") == first
+    assert await store.get_active_signed_pre_key() == first
+
+    # Storing a newer signed pre-key makes it the active one.
+    await store.store_signed_pre_key(second)
+    assert await store.get_active_signed_pre_key() == second
+    assert await store.get_signed_pre_key("spk-1") == first
+
+
+async def test_active_signed_pre_key_missing_record_raises() -> None:
+    store = _store()
+    store._active_signed_pre_key_id = "ghost"
+    with pytest.raises(LookupError):
+        await store.get_active_signed_pre_key()
+
+
+async def test_pre_key_put_get_list_delete() -> None:
+    store = _store()
+    assert await store.get_pre_key("otp-1") is None
+    assert await store.get_all_pre_keys() == []
+
+    one = PreKeyPair(key_id="otp-1", key_pair=_key_pair(30), signature=b"o1")
+    two = PreKeyPair(key_id="otp-2", key_pair=_key_pair(40), signature=b"o2")
+    await store.store_pre_key(one)
+    await store.store_pre_key(two)
+
+    assert await store.get_pre_key("otp-1") == one
+    listed = await store.get_all_pre_keys()
+    assert {pk.key_id for pk in listed} == {"otp-1", "otp-2"}
+
+    await store.remove_pre_key("otp-1")
+    assert await store.get_pre_key("otp-1") is None
+    assert {pk.key_id for pk in await store.get_all_pre_keys()} == {"otp-2"}
+
+    # Deleting an absent pre-key is a no-op.
+    await store.remove_pre_key("does-not-exist")
+
+
+async def test_session_put_get_delete() -> None:
+    store = _store()
+    assert await store.get_session("@peer") is None
+
+    session = _session(50)
+    await store.store_session("@peer", session)
+    fetched = await store.get_session("@peer")
+    assert fetched == session
+    assert fetched is not None
+    assert fetched.skipped_keys[skipped_key_id(bytes([0xAB, 0xCD]), 7)] == b"messagekey"
+
+    await store.remove_session("@peer")
+    assert await store.get_session("@peer") is None
+
+    # Deleting an absent session is a no-op.
+    await store.remove_session("@missing")
+
+
+async def test_sender_key_put_get_delete() -> None:
+    store = _store()
+    assert await store.get_sender_key("group-1") is None
+
+    sender_key = SenderKeyState(
+        distribution_id="group-1",
+        chain_key=bytes([0x11]) * 32,
+        message_number=5,
+        signing_key_pair=_key_pair(60),
+    )
+    await store.store_sender_key(sender_key)
+    assert await store.get_sender_key("group-1") == sender_key
+
+    await store.remove_sender_key("group-1")
+    assert await store.get_sender_key("group-1") is None
+
+    # Deleting an absent sender key is a no-op.
+    await store.remove_sender_key("group-missing")


### PR DESCRIPTION
## What this ports

Slice 3/8 of the Signal Protocol Python port: the **session-store layer**, mirrored from the TypeScript SDK (`sdk/typescript/src/signal/store.ts` + `memory-store.ts`). Pure data structures + an interface — no crypto, X3DH, ratchet, session, or sender-key logic (those land in other slices). Self-contained: does not import the in-flight `crypto.py` / `keys.py`.

- **`store.py`** — record dataclasses (`X25519KeyPair`, `SessionState`, `PreKeyPair`, `SignedPreKeyPair`, `SenderKeyState`), the abstract async `SessionStore` contract covering identity, Double Ratchet sessions, one-time + signed pre-keys, and group sender keys, plus the `skipped_key_id` helper. The async + pluggable shape lets a durable backend (e.g. Hermes) implement the same contract later.
- **`memory_store.py`** — `MemorySessionStore`, an in-process implementation.
- **`signal/__init__.py`** — package skeleton exporting the above.
- **`tests/test_signal_store.py`** — round-trips every record type (put/get/delete, list where applicable) through the in-memory store; checks the interface is abstract and `skipped_key_id` matches the TS format.

## Files

- `sdk/python/src/tinyplace/signal/__init__.py`
- `sdk/python/src/tinyplace/signal/store.py`
- `sdk/python/src/tinyplace/signal/memory_store.py`
- `sdk/python/tests/test_signal_store.py`

## Tests

`.venv-sig/bin/python -m pytest -p no:cacheprovider -q` (Python 3.14):

```
45 passed, 2 skipped in 0.45s
Required test coverage of 80% reached. Total coverage: 89.11%
```

New signal modules are at 100% coverage.

Closes #43
Part of #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Signal Protocol session and key storage infrastructure to the Python SDK, enabling session management and cryptographic key handling.
  * Implemented a process-local in-memory store for identity material, pre-keys, per-peer sessions, and group sender key state.
* **Tests**
  * Added comprehensive test coverage validating round-trip storage behavior, record immutability, skipped-key ID formatting, and expected error handling for missing active signed pre-keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->