### PR TITLE
feat(sdk/python): Signal key management & prekey bundles (#42)

### DIFF
--- a/sdk/python/src/tinyplace/signal/__init__.py
+++ b/sdk/python/src/tinyplace/signal/__init__.py
@@ -1,0 +1,35 @@
+"""Signal Protocol support for the tiny.place Python SDK.
+
+This package is being ported slice-by-slice from the TypeScript SDK. The
+current slice (#42) provides key management and prekey bundles only.
+"""
+
+from __future__ import annotations
+
+from .keys import (
+    build_key_bundle,
+    build_pre_keys_request,
+    build_signed_pre_key_request,
+    generate_pre_keys,
+    generate_signed_pre_key,
+    generate_x25519_key_pair,
+    serialize_pre_key,
+    serialize_signed_key,
+    verify_pre_key_signature,
+)
+from .types import PreKeyPair, SignedPreKeyPair, X25519KeyPair
+
+__all__ = [
+    "PreKeyPair",
+    "SignedPreKeyPair",
+    "X25519KeyPair",
+    "build_key_bundle",
+    "build_pre_keys_request",
+    "build_signed_pre_key_request",
+    "generate_pre_keys",
+    "generate_signed_pre_key",
+    "generate_x25519_key_pair",
+    "serialize_pre_key",
+    "serialize_signed_key",
+    "verify_pre_key_signature",
+]

--- a/sdk/python/src/tinyplace/signal/keys.py
+++ b/sdk/python/src/tinyplace/signal/keys.py
@@ -132,10 +132,14 @@ def build_key_bundle(
     return bundle
 
 
-def _decode_key_bytes(value: str) -> bytes:
+def _decode_key_bytes(value: str, expected_len: int | None = None) -> bytes:
     """Decode a key/signature string the way the backend's ``decodeKeyBytes`` does.
 
-    Supports ``base64:``/``hex:`` prefixes, falling back to bare base64 then hex.
+    Supports ``base64:``/``hex:`` prefixes. For a bare (unprefixed) value the
+    base64 and hex alphabets overlap — a hex string is also valid base64 and
+    decodes to the wrong length — so when an ``expected_len`` is known we return
+    whichever decoding yields it, trying base64 first to match the backend's
+    preference. Without an expected length we keep the base64-first fallback.
     """
     value = value.strip()
     if value == "":
@@ -144,10 +148,22 @@ def _decode_key_bytes(value: str) -> bytes:
         return base64.standard_b64decode(value[len("base64:") :])
     if value.startswith("hex:"):
         return bytes.fromhex(value[len("hex:") :])
+    candidates: list[bytes] = []
     try:
-        return base64.standard_b64decode(value)
+        candidates.append(base64.standard_b64decode(value))
     except (ValueError, base64.binascii.Error):
-        return bytes.fromhex(value)
+        pass
+    try:
+        candidates.append(bytes.fromhex(value))
+    except ValueError:
+        pass
+    if not candidates:
+        raise ValueError("could not decode key value as base64 or hex")
+    if expected_len is not None:
+        for candidate in candidates:
+            if len(candidate) == expected_len:
+                return candidate
+    return candidates[0]
 
 
 def verify_pre_key_signature(identity_key: str, signed_key: dict[str, object]) -> bool:
@@ -160,6 +176,8 @@ def verify_pre_key_signature(identity_key: str, signed_key: dict[str, object]) -
 
     Returns ``False`` on any malformed input or signature mismatch.
     """
+    if not isinstance(signed_key, dict) or not isinstance(identity_key, str):
+        return False
     public_key = signed_key.get("publicKey")
     signature = signed_key.get("signature")
     key_id = signed_key.get("keyId")
@@ -170,10 +188,10 @@ def verify_pre_key_signature(identity_key: str, signed_key: dict[str, object]) -
     if not isinstance(key_id, str) or key_id.strip() == "":
         return False
     try:
-        identity_bytes = _decode_key_bytes(identity_key)
+        identity_bytes = _decode_key_bytes(identity_key, 32)
         if len(identity_bytes) != 32:
             return False
-        signature_bytes = _decode_key_bytes(signature)
+        signature_bytes = _decode_key_bytes(signature, 64)
         if len(signature_bytes) != 64:
             return False
         verify_key = VerifyKey(identity_bytes)

--- a/sdk/python/src/tinyplace/signal/keys.py
+++ b/sdk/python/src/tinyplace/signal/keys.py
@@ -1,0 +1,183 @@
+"""Signal Protocol key management and prekey bundles (issue #42).
+
+Ported from ``sdk/typescript/src/signal/keys.ts``. This module covers only key
+*material*: the X25519 identity / signed-prekey / one-time-prekey key pairs, the
+Ed25519 signatures over them, the publishable prekey-bundle wire shape, and
+signed-prekey signature verification. It performs no network calls and does not
+depend on the in-flight ``signal/crypto`` slice; it builds directly on PyNaCl
+and the existing :class:`tinyplace.signer.Signer`.
+
+Signing scheme (must match the Go backend, ``internal/signal/keys.go``):
+the backend verifies ``ed25519.Verify(identityPubKey, []byte(key.PublicKey),
+signature)`` where ``key.PublicKey`` is the **base64 string** of the X25519
+public key. So we sign the UTF-8 bytes of that base64 string, never the raw
+key bytes.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Optional
+
+from nacl.exceptions import BadSignatureError
+from nacl.public import PrivateKey
+from nacl.signing import VerifyKey
+
+from ..crypto import public_key_to_base64
+from ..signer import Signer
+from .types import PreKeyPair, SignedPreKeyPair, X25519KeyPair
+
+
+def generate_x25519_key_pair() -> X25519KeyPair:
+    """Generate a fresh random X25519 (Curve25519) key pair."""
+    private_key = PrivateKey.generate()
+    return X25519KeyPair(
+        public_key=bytes(private_key.public_key),
+        private_key=bytes(private_key),
+    )
+
+
+async def _sign_public_key(signer: Signer, public_key: bytes) -> bytes:
+    """Sign the base64 representation of an X25519 public key.
+
+    Mirrors ``signPublicKey`` in the TS SDK: the backend verifies the signature
+    against ``[]byte(base64PublicKey)``, so we sign the UTF-8 bytes of the
+    base64 string rather than the raw key.
+    """
+    public_key_b64 = public_key_to_base64(public_key)
+    return await signer.sign(public_key_b64.encode("utf-8"))
+
+
+async def generate_signed_pre_key(signer: Signer, key_id: str) -> SignedPreKeyPair:
+    """Generate a signed pre-key signed by the identity ``signer``."""
+    key_pair = generate_x25519_key_pair()
+    signature = await _sign_public_key(signer, key_pair.public_key)
+    return SignedPreKeyPair(key_id=key_id, key_pair=key_pair, signature=signature)
+
+
+async def generate_pre_keys(
+    signer: Signer,
+    start_id: int,
+    count: int,
+) -> list[PreKeyPair]:
+    """Generate ``count`` one-time pre-keys with ids ``pk_<start_id + i>``."""
+    pre_keys: list[PreKeyPair] = []
+    for i in range(count):
+        key_id = f"pk_{start_id + i}"
+        key_pair = generate_x25519_key_pair()
+        signature = await _sign_public_key(signer, key_pair.public_key)
+        pre_keys.append(PreKeyPair(key_id=key_id, key_pair=key_pair, signature=signature))
+    return pre_keys
+
+
+def serialize_signed_key(pre_key: SignedPreKeyPair) -> dict[str, str]:
+    """Serialize a signed pre-key into the backend ``SignedKey`` wire shape."""
+    return {
+        "keyId": pre_key.key_id,
+        "publicKey": public_key_to_base64(pre_key.key_pair.public_key),
+        "signature": public_key_to_base64(pre_key.signature),
+    }
+
+
+def serialize_pre_key(pre_key: PreKeyPair) -> dict[str, str]:
+    """Serialize a one-time pre-key into the backend ``SignedKey`` wire shape."""
+    return {
+        "keyId": pre_key.key_id,
+        "publicKey": public_key_to_base64(pre_key.key_pair.public_key),
+        "signature": public_key_to_base64(pre_key.signature),
+    }
+
+
+def build_pre_keys_request(
+    pre_keys: list[PreKeyPair],
+    identity_key: Optional[str] = None,
+) -> dict[str, object]:
+    """Build the ``PreKeysRequest`` body for ``KeysApi.upload_pre_keys``."""
+    request: dict[str, object] = {"preKeys": [serialize_pre_key(pk) for pk in pre_keys]}
+    if identity_key is not None:
+        request["identityKey"] = identity_key
+    return request
+
+
+def build_signed_pre_key_request(
+    signed_pre_key: SignedPreKeyPair,
+    identity_key: Optional[str] = None,
+) -> dict[str, object]:
+    """Build the ``SignedPreKeyRequest`` body for ``KeysApi.rotate_signed_pre_key``."""
+    request: dict[str, object] = {"signedPreKey": serialize_signed_key(signed_pre_key)}
+    if identity_key is not None:
+        request["identityKey"] = identity_key
+    return request
+
+
+def build_key_bundle(
+    agent_id: str,
+    identity_key: str,
+    signed_pre_key: SignedPreKeyPair,
+    one_time_pre_key: Optional[PreKeyPair] = None,
+) -> dict[str, object]:
+    """Build a publishable ``KeyBundle`` (the X3DH prekey bundle wire shape).
+
+    ``identity_key`` is the base64 Ed25519 identity public key
+    (``Signer.public_key_base64``). An optional one-time pre-key is included
+    only when present, matching the backend's ``omitempty`` field.
+    """
+    bundle: dict[str, object] = {
+        "agentId": agent_id,
+        "identityKey": identity_key,
+        "signedPreKey": serialize_signed_key(signed_pre_key),
+    }
+    if one_time_pre_key is not None:
+        bundle["oneTimePreKey"] = serialize_pre_key(one_time_pre_key)
+    return bundle
+
+
+def _decode_key_bytes(value: str) -> bytes:
+    """Decode a key/signature string the way the backend's ``decodeKeyBytes`` does.
+
+    Supports ``base64:``/``hex:`` prefixes, falling back to bare base64 then hex.
+    """
+    value = value.strip()
+    if value == "":
+        raise ValueError("empty key value")
+    if value.startswith("base64:"):
+        return base64.standard_b64decode(value[len("base64:") :])
+    if value.startswith("hex:"):
+        return bytes.fromhex(value[len("hex:") :])
+    try:
+        return base64.standard_b64decode(value)
+    except (ValueError, base64.binascii.Error):
+        return bytes.fromhex(value)
+
+
+def verify_pre_key_signature(identity_key: str, signed_key: dict[str, object]) -> bool:
+    """Verify a fetched signed-prekey (or one-time prekey) signature.
+
+    Mirrors the backend's ``validSignedKeyForIdentity``: the ``signature`` must
+    be a valid Ed25519 signature, by the private key behind ``identity_key``,
+    over the UTF-8 bytes of the ``publicKey`` base64 string. ``identity_key`` may
+    be base64- or hex-encoded (optionally with a ``base64:``/``hex:`` prefix).
+
+    Returns ``False`` on any malformed input or signature mismatch.
+    """
+    public_key = signed_key.get("publicKey")
+    signature = signed_key.get("signature")
+    key_id = signed_key.get("keyId")
+    if not isinstance(public_key, str) or public_key.strip() == "":
+        return False
+    if not isinstance(signature, str) or signature.strip() == "":
+        return False
+    if not isinstance(key_id, str) or key_id.strip() == "":
+        return False
+    try:
+        identity_bytes = _decode_key_bytes(identity_key)
+        if len(identity_bytes) != 32:
+            return False
+        signature_bytes = _decode_key_bytes(signature)
+        if len(signature_bytes) != 64:
+            return False
+        verify_key = VerifyKey(identity_bytes)
+        verify_key.verify(public_key.encode("utf-8"), signature_bytes)
+        return True
+    except (ValueError, BadSignatureError):
+        return False

--- a/sdk/python/src/tinyplace/signal/types.py
+++ b/sdk/python/src/tinyplace/signal/types.py
@@ -1,0 +1,36 @@
+"""Key material and prekey-bundle dataclasses for the Signal port.
+
+These mirror the TypeScript SDK's ``signal`` key types (``X25519KeyPair``,
+``PreKeyPair``, ``SignedPreKeyPair``) and the backend wire shape
+(``models.SignedKey`` / ``models.KeyBundle``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class X25519KeyPair:
+    """An X25519 (Curve25519) key pair used for Diffie-Hellman agreement."""
+
+    public_key: bytes
+    private_key: bytes
+
+
+@dataclass(frozen=True)
+class PreKeyPair:
+    """A one-time pre-key: an X25519 key pair plus its identity signature."""
+
+    key_id: str
+    key_pair: X25519KeyPair
+    signature: bytes
+
+
+@dataclass(frozen=True)
+class SignedPreKeyPair:
+    """A signed pre-key: an X25519 key pair plus its identity signature."""
+
+    key_id: str
+    key_pair: X25519KeyPair
+    signature: bytes

--- a/sdk/python/tests/test_signal_keys.py
+++ b/sdk/python/tests/test_signal_keys.py
@@ -124,6 +124,17 @@ async def test_verify_accepts_prefixed_and_hex_identity_keys(signer: LocalSigner
     assert verify_pre_key_signature(hex_prefixed, serialized) is True
     # Bare base64 (the default identity encoding) verifies too.
     assert verify_pre_key_signature(signer.public_key_base64, serialized) is True
+    # Bare (unprefixed) hex also verifies: a 64-char hex key is valid base64
+    # too, so the decoder is length-aware and picks the 32-byte interpretation.
+    assert verify_pre_key_signature(identity_bytes.hex(), serialized) is True
+
+
+def test_verify_fails_closed_on_wrong_types() -> None:
+    # Non-dict signed_key and non-str identity_key must return False, not raise.
+    assert verify_pre_key_signature("identity", None) is False  # type: ignore[arg-type]
+    assert verify_pre_key_signature("identity", ["not", "a", "dict"]) is False  # type: ignore[arg-type]
+    assert verify_pre_key_signature(None, {"keyId": "x"}) is False  # type: ignore[arg-type]
+    assert verify_pre_key_signature(b"bytes-not-str", {"keyId": "x"}) is False  # type: ignore[arg-type]
 
 
 async def test_verify_accepts_hex_prefixed_signature(signer: LocalSigner) -> None:

--- a/sdk/python/tests/test_signal_keys.py
+++ b/sdk/python/tests/test_signal_keys.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from tinyplace.signal import (
+    PreKeyPair,
+    SignedPreKeyPair,
+    X25519KeyPair,
+    build_key_bundle,
+    build_pre_keys_request,
+    build_signed_pre_key_request,
+    generate_pre_keys,
+    generate_signed_pre_key,
+    generate_x25519_key_pair,
+    serialize_pre_key,
+    serialize_signed_key,
+    verify_pre_key_signature,
+)
+from tinyplace.signer import LocalSigner
+
+
+@pytest.fixture
+def signer() -> LocalSigner:
+    return LocalSigner.from_seed(b"\x01" * 32)
+
+
+def test_generate_x25519_key_pair_is_random_and_well_formed() -> None:
+    a = generate_x25519_key_pair()
+    b = generate_x25519_key_pair()
+    assert isinstance(a, X25519KeyPair)
+    assert len(a.public_key) == 32
+    assert len(a.private_key) == 32
+    assert a.private_key != b.private_key
+    assert a.public_key != b.public_key
+
+
+async def test_generate_signed_pre_key_round_trips(signer: LocalSigner) -> None:
+    signed = await generate_signed_pre_key(signer, "spk_1")
+    assert isinstance(signed, SignedPreKeyPair)
+    assert signed.key_id == "spk_1"
+    assert len(signed.signature) == 64
+
+    serialized = serialize_signed_key(signed)
+    # generate -> verify round trip against the identity public key.
+    assert verify_pre_key_signature(signer.public_key_base64, serialized) is True
+
+
+async def test_generate_pre_keys_ids_and_signatures(signer: LocalSigner) -> None:
+    pre_keys = await generate_pre_keys(signer, start_id=5, count=3)
+    assert [pk.key_id for pk in pre_keys] == ["pk_5", "pk_6", "pk_7"]
+    for pk in pre_keys:
+        assert isinstance(pk, PreKeyPair)
+        assert verify_pre_key_signature(signer.public_key_base64, serialize_pre_key(pk)) is True
+
+
+async def test_serialized_signed_key_matches_backend_shape(signer: LocalSigner) -> None:
+    signed = await generate_signed_pre_key(signer, "spk_42")
+    serialized = serialize_signed_key(signed)
+    # Backend models.SignedKey: keyId / publicKey / signature, all base64.
+    assert set(serialized.keys()) == {"keyId", "publicKey", "signature"}
+    assert serialized["keyId"] == "spk_42"
+    assert base64.standard_b64decode(serialized["publicKey"]) == signed.key_pair.public_key
+    assert base64.standard_b64decode(serialized["signature"]) == signed.signature
+
+
+async def test_build_key_bundle_with_one_time_prekey(signer: LocalSigner) -> None:
+    signed = await generate_signed_pre_key(signer, "spk_1")
+    one_time = (await generate_pre_keys(signer, 1, 1))[0]
+    bundle = build_key_bundle(
+        agent_id=signer.agent_id,
+        identity_key=signer.public_key_base64,
+        signed_pre_key=signed,
+        one_time_pre_key=one_time,
+    )
+    assert bundle["agentId"] == signer.agent_id
+    assert bundle["identityKey"] == signer.public_key_base64
+    assert bundle["signedPreKey"] == serialize_signed_key(signed)
+    assert bundle["oneTimePreKey"] == serialize_pre_key(one_time)
+    # A fetched bundle's signed-prekey signature must verify.
+    assert verify_pre_key_signature(bundle["identityKey"], bundle["signedPreKey"]) is True
+
+
+async def test_build_key_bundle_without_one_time_prekey(signer: LocalSigner) -> None:
+    signed = await generate_signed_pre_key(signer, "spk_1")
+    bundle = build_key_bundle(signer.agent_id, signer.public_key_base64, signed)
+    assert "oneTimePreKey" not in bundle
+
+
+async def test_build_pre_keys_request_matches_upload_shape(signer: LocalSigner) -> None:
+    pre_keys = await generate_pre_keys(signer, 1, 2)
+    request = build_pre_keys_request(pre_keys, identity_key=signer.public_key_base64)
+    # Matches models.PreKeysRequest consumed by KeysApi.upload_pre_keys.
+    assert request["identityKey"] == signer.public_key_base64
+    assert request["preKeys"] == [serialize_pre_key(pk) for pk in pre_keys]
+
+    without_identity = build_pre_keys_request(pre_keys)
+    assert "identityKey" not in without_identity
+    assert without_identity["preKeys"] == [serialize_pre_key(pk) for pk in pre_keys]
+
+
+async def test_build_signed_pre_key_request_matches_rotate_shape(signer: LocalSigner) -> None:
+    signed = await generate_signed_pre_key(signer, "spk_1")
+    request = build_signed_pre_key_request(signed, identity_key=signer.public_key_base64)
+    # Matches models.SignedPreKeyRequest consumed by KeysApi.rotate_signed_pre_key.
+    assert request["identityKey"] == signer.public_key_base64
+    assert request["signedPreKey"] == serialize_signed_key(signed)
+
+    without_identity = build_signed_pre_key_request(signed)
+    assert "identityKey" not in without_identity
+
+
+async def test_verify_accepts_prefixed_and_hex_identity_keys(signer: LocalSigner) -> None:
+    signed = await generate_signed_pre_key(signer, "spk_1")
+    serialized = serialize_signed_key(signed)
+    identity_bytes = signer.public_key
+
+    base64_prefixed = "base64:" + base64.standard_b64encode(identity_bytes).decode()
+    hex_prefixed = "hex:" + identity_bytes.hex()
+
+    # base64:/hex: prefixes are unambiguous (matches backend decodeKeyBytes).
+    assert verify_pre_key_signature(base64_prefixed, serialized) is True
+    assert verify_pre_key_signature(hex_prefixed, serialized) is True
+    # Bare base64 (the default identity encoding) verifies too.
+    assert verify_pre_key_signature(signer.public_key_base64, serialized) is True
+
+
+async def test_verify_accepts_hex_prefixed_signature(signer: LocalSigner) -> None:
+    signed = await generate_signed_pre_key(signer, "spk_1")
+    serialized = serialize_signed_key(signed)
+    # A hex:-prefixed signature exercises the hex decode branch unambiguously.
+    serialized["signature"] = "hex:" + signed.signature.hex()
+    assert verify_pre_key_signature(signer.public_key_base64, serialized) is True
+
+
+def test_verify_handles_non_base64_non_hex_signature(signer: LocalSigner) -> None:
+    # A value that is neither valid base64 nor valid hex falls through the
+    # bare-base64 attempt into the hex fallback, which raises -> False.
+    signed_key = {
+        "keyId": "spk_1",
+        "publicKey": base64.standard_b64encode(b"\x00" * 32).decode(),
+        "signature": "zzz!!!notbase64nothex",
+    }
+    assert verify_pre_key_signature(signer.public_key_base64, signed_key) is False
+
+
+async def test_verify_rejects_tampered_or_malformed(signer: LocalSigner) -> None:
+    signed = await generate_signed_pre_key(signer, "spk_1")
+    serialized = serialize_signed_key(signed)
+
+    # Wrong identity key -> signature does not verify.
+    other = LocalSigner.from_seed(b"\x02" * 32)
+    assert verify_pre_key_signature(other.public_key_base64, serialized) is False
+
+    # Tampered public key.
+    tampered = dict(serialized)
+    tampered["publicKey"] = base64.standard_b64encode(b"\x00" * 32).decode()
+    assert verify_pre_key_signature(signer.public_key_base64, tampered) is False
+
+    # Missing / empty fields.
+    assert verify_pre_key_signature(signer.public_key_base64, {**serialized, "signature": ""}) is False
+    assert verify_pre_key_signature(signer.public_key_base64, {**serialized, "publicKey": ""}) is False
+    assert verify_pre_key_signature(signer.public_key_base64, {**serialized, "keyId": ""}) is False
+    assert verify_pre_key_signature(signer.public_key_base64, {"keyId": "x"}) is False
+
+    # Malformed identity key (wrong length).
+    short_identity = base64.standard_b64encode(b"\x00" * 16).decode()
+    assert verify_pre_key_signature(short_identity, serialized) is False
+    # Non-decodable identity key.
+    assert verify_pre_key_signature("not-valid-key!!", serialized) is False
+    # Empty identity key.
+    assert verify_pre_key_signature("", serialized) is False
+    assert verify_pre_key_signature("   ", serialized) is False
+    # Malformed signature (wrong length).
+    bad_sig = {**serialized, "signature": base64.standard_b64encode(b"\x00" * 10).decode()}
+    assert verify_pre_key_signature(signer.public_key_base64, bad_sig) is False


### PR DESCRIPTION
Ports the Signal key-material layer from the TypeScript SDK (`sdk/typescript/src/signal/keys.ts`) to the Python SDK. Scope is issue #42 only: key material and prekey bundles, no network calls, no X3DH/ratchet/store/session/sender-keys.

Built directly on PyNaCl + the existing `crypto.py` / `signer.py`, with **no** dependency on the in-flight `signal/crypto` slice (#41).

### What was ported
- `generate_x25519_key_pair()` — random X25519 (Curve25519) key pair via PyNaCl.
- `generate_signed_pre_key()` / `generate_pre_keys()` — signed prekey and one-time prekeys, each Ed25519-signed by the identity `Signer`.
- Signing scheme matches the Go backend (`internal/signal/keys.go`): signs the **UTF-8 bytes of the base64 public-key string**, so `ed25519.Verify(identityPubKey, []byte(key.PublicKey), signature)` succeeds.
- `serialize_signed_key()` / `serialize_pre_key()` → backend `models.SignedKey` shape (`keyId` / `publicKey` / `signature`).
- `build_key_bundle()` — publishable `KeyBundle` (with optional `oneTimePreKey`).
- `build_pre_keys_request()` / `build_signed_pre_key_request()` — exact bodies consumed by `KeysApi.upload_pre_keys` / `rotate_signed_pre_key`.
- `verify_pre_key_signature()` — verifies a fetched bundle's signed-prekey signature, mirroring the backend's `decodeKeyBytes` (supports `base64:` / `hex:` prefixes).

### Files
- `sdk/python/src/tinyplace/signal/__init__.py`
- `sdk/python/src/tinyplace/signal/keys.py`
- `sdk/python/src/tinyplace/signal/types.py`
- `sdk/python/tests/test_signal_keys.py`

### Tests
`.venv-sig/bin/python -m pytest -p no:cacheprovider -q` → **48 passed, 2 skipped**. Total coverage **89%** (gate ≥80%); `signal/keys.py` at **100%**. Tests cover the generate→verify round-trip, the backend bundle/request wire shapes, and tamper/malformed rejection.

Closes #42
Part of #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Signal Protocol key management to the Python SDK, including generation of identity-signed prekeys, signed-prekeys, and X25519 key pairs.
  * Provided helpers to serialize key material, build upload/rotation request payloads, and construct publishable key bundles (with optional one-time prekeys).
  * Added robust signature verification for fetched signed/one-time keys, accepting common identity/signature encodings.
* **Tests**
  * Introduced a new test suite covering key generation, serialization/bundle/request shapes, and verification edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->