### PR TITLE
feat(sdk/python): Signal Double Ratchet (#45)

### DIFF
--- a/sdk/python/src/tinyplace/signal/__init__.py
+++ b/sdk/python/src/tinyplace/signal/__init__.py
@@ -46,6 +46,14 @@ from .keys import (
     verify_pre_key_signature,
 )
 from .memory_store import MemorySessionStore
+from .ratchet import (
+    MAX_SKIP,
+    RatchetHeader,
+    RatchetMessage,
+    encode_header,
+    ratchet_decrypt,
+    ratchet_encrypt,
+)
 from .store import SenderKeyState, SessionState, SessionStore, skipped_key_id
 from .types import PreKeyPair, SignedPreKeyPair, X25519KeyPair
 
@@ -90,4 +98,11 @@ __all__ = [
     "SessionState",
     "SessionStore",
     "skipped_key_id",
+    # double ratchet
+    "MAX_SKIP",
+    "RatchetHeader",
+    "RatchetMessage",
+    "encode_header",
+    "ratchet_encrypt",
+    "ratchet_decrypt",
 ]

--- a/sdk/python/src/tinyplace/signal/ratchet.py
+++ b/sdk/python/src/tinyplace/signal/ratchet.py
@@ -24,7 +24,8 @@ The crypto primitives are reused verbatim from
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from copy import deepcopy
+from dataclasses import dataclass, fields
 
 from .crypto import (
     decrypt,
@@ -121,9 +122,33 @@ def ratchet_decrypt(
     3. Otherwise the next receiving message key from the current chain is used,
        skipping any intervening keys up to ``message.header.message_number``.
 
-    Mutates ``state`` in place. Raises ``ValueError`` if the AEAD MAC fails
-    (via :func:`~tinyplace.signal.crypto.decrypt`) or if more than
-    :data:`MAX_SKIP` keys would have to be skipped.
+    All ratchet mutations are **staged on a copy and committed only after the
+    AEAD MAC authenticates the message**. Otherwise a tampered ciphertext
+    carrying a fresh ratchet public key would advance the caller's live
+    ``SessionState`` to attacker-controlled key material before the MAC check,
+    permanently breaking decryption of later legitimate messages. On success
+    ``state`` is updated atomically; on any failure it is left untouched.
+
+    Raises ``ValueError`` if the AEAD MAC fails (via
+    :func:`~tinyplace.signal.crypto.decrypt`) or if more than :data:`MAX_SKIP`
+    keys would have to be skipped.
+    """
+    working = deepcopy(state)
+    plaintext = _ratchet_decrypt_into(working, message, associated_data)
+    # Authentication succeeded — commit the staged state atomically, preserving
+    # the caller's object identity.
+    for field in fields(state):
+        setattr(state, field.name, getattr(working, field.name))
+    return plaintext
+
+
+def _ratchet_decrypt_into(
+    state: SessionState, message: RatchetMessage, associated_data: bytes
+) -> bytes:
+    """Run the ratchet decrypt over ``state`` in place (see :func:`ratchet_decrypt`).
+
+    Operates on a throwaway working copy so a MAC failure cannot corrupt the
+    caller's session; callers should use :func:`ratchet_decrypt`.
     """
     header = message.header
     sk_id = skipped_key_id(header.public_key, header.message_number)

--- a/sdk/python/src/tinyplace/signal/ratchet.py
+++ b/sdk/python/src/tinyplace/signal/ratchet.py
@@ -1,0 +1,251 @@
+"""Double Ratchet for the tiny.place Signal Protocol port.
+
+A byte-compatible Python port of the TypeScript SDK's
+``sdk/typescript/src/signal/ratchet.ts``. It implements the symmetric and
+Diffie-Hellman ratchets, message-key derivation, ratchet-header construction
+and skipped / out-of-order message-key handling, operating over the
+:class:`~tinyplace.signal.store.SessionState` record.
+
+Every algorithmic choice mirrors the reference so a message produced by one
+SDK can be consumed by the other:
+
+* DH ratchet: X25519, root-key advance via HKDF-SHA256
+  (:func:`~tinyplace.signal.crypto.kdf_root_key`).
+* Symmetric ratchet: HMAC-SHA256 chain ratchet
+  (:func:`~tinyplace.signal.crypto.kdf_chain_key`).
+* Message AEAD: AES-256-CBC + HMAC-SHA256
+  (:func:`~tinyplace.signal.crypto.encrypt` / :func:`decrypt`).
+* Header wire format: ``publicKey(32) || previousChainLength(u32 BE) ||
+  messageNumber(u32 BE)`` (40 bytes), matching ``encodeHeader`` in ratchet.ts.
+
+The crypto primitives are reused verbatim from
+:mod:`tinyplace.signal.crypto`; this module never reimplements crypto.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .crypto import (
+    decrypt,
+    encrypt,
+    generate_x25519_keypair,
+    kdf_chain_key,
+    kdf_root_key,
+    x25519_shared_secret,
+)
+from .store import SessionState, X25519KeyPair, skipped_key_id
+
+__all__ = [
+    "MAX_SKIP",
+    "RatchetHeader",
+    "RatchetMessage",
+    "encode_header",
+    "ratchet_encrypt",
+    "ratchet_decrypt",
+]
+
+# Maximum number of message keys we are willing to skip in a single chain.
+# Mirrors ``MAX_SKIP`` in ratchet.ts; guards against a malicious counterparty
+# sending a huge ``messageNumber`` to exhaust memory/CPU.
+MAX_SKIP = 1000
+
+# Ratchet header layout, matching ``encodeHeader`` in ratchet.ts.
+_PUBLIC_KEY_LEN = 32
+_HEADER_LEN = _PUBLIC_KEY_LEN + 4 + 4
+
+
+@dataclass
+class RatchetHeader:
+    """Plaintext header that travels with every ratchet message.
+
+    Mirrors the TypeScript ``RatchetHeader``. ``public_key`` is the sender's
+    current ratchet (DH) public key; ``previous_chain_length`` is the number of
+    messages in the sender's previous sending chain; ``message_number`` is the
+    index of this message within the current sending chain.
+    """
+
+    public_key: bytes
+    previous_chain_length: int
+    message_number: int
+
+
+@dataclass
+class RatchetMessage:
+    """A ratchet header plus the AEAD ciphertext for one message."""
+
+    header: RatchetHeader
+    ciphertext: bytes
+
+
+def ratchet_encrypt(
+    state: SessionState, plaintext: bytes, associated_data: bytes
+) -> RatchetMessage:
+    """Encrypt ``plaintext`` under the next sending message key.
+
+    Mutates ``state`` in place: advances the sending chain (performing the
+    initial sending-side DH ratchet step if no sending chain exists yet) and
+    increments the send counter. ``associated_data`` is bound into the AEAD
+    together with the encoded header.
+    """
+    if state.send_chain_key is None:
+        _dh_ratchet_step(state)
+
+    # ``send_chain_key`` is guaranteed non-None after the step above.
+    chain_key, message_key = kdf_chain_key(state.send_chain_key)  # type: ignore[arg-type]
+    state.send_chain_key = chain_key
+
+    header = RatchetHeader(
+        public_key=state.dh_send_key_pair.public_key,
+        previous_chain_length=state.previous_chain_length,
+        message_number=state.send_message_number,
+    )
+    state.send_message_number += 1
+
+    ad = associated_data + encode_header(header)
+    ciphertext = encrypt(message_key, plaintext, ad)
+    return RatchetMessage(header=header, ciphertext=ciphertext)
+
+
+def ratchet_decrypt(
+    state: SessionState, message: RatchetMessage, associated_data: bytes
+) -> bytes:
+    """Decrypt ``message`` and return the plaintext.
+
+    Handles three cases, exactly like ratchet.ts:
+
+    1. A previously skipped / out-of-order key cached in ``state.skipped_keys``
+       is used (and consumed) if it matches the header.
+    2. A new ratchet public key triggers a receiving-side DH ratchet step
+       (skipping any remaining keys of the previous receiving chain first).
+    3. Otherwise the next receiving message key from the current chain is used,
+       skipping any intervening keys up to ``message.header.message_number``.
+
+    Mutates ``state`` in place. Raises ``ValueError`` if the AEAD MAC fails
+    (via :func:`~tinyplace.signal.crypto.decrypt`) or if more than
+    :data:`MAX_SKIP` keys would have to be skipped.
+    """
+    header = message.header
+    sk_id = skipped_key_id(header.public_key, header.message_number)
+    skipped_mk = state.skipped_keys.get(sk_id)
+    if skipped_mk is not None:
+        del state.skipped_keys[sk_id]
+        ad = associated_data + encode_header(header)
+        return decrypt(skipped_mk, message.ciphertext, ad)
+
+    header_key_changed = (
+        state.dh_recv_public_key is None
+        or state.dh_recv_public_key != header.public_key
+    )
+
+    if header_key_changed:
+        if state.recv_chain_key is not None:
+            _skip_message_keys(state, header.previous_chain_length)
+        _dh_ratchet_step_with_recv(state, header.public_key)
+
+    _skip_message_keys(state, header.message_number)
+
+    # ``recv_chain_key`` is guaranteed non-None after a DH ratchet step.
+    chain_key, message_key = kdf_chain_key(state.recv_chain_key)  # type: ignore[arg-type]
+    state.recv_chain_key = chain_key
+    state.recv_message_number += 1
+
+    ad = associated_data + encode_header(header)
+    return decrypt(message_key, message.ciphertext, ad)
+
+
+def _dh_ratchet_step(state: SessionState) -> None:
+    """Initial sending-side ratchet: derive the first sending chain key.
+
+    Used the first time we send before having received anything (e.g. right
+    after X3DH). Requires the recipient's ratchet public key.
+    """
+    if state.dh_recv_public_key is None:
+        raise ValueError("Cannot perform DH ratchet without recipient public key")
+    dh_output = x25519_shared_secret(
+        state.dh_send_key_pair.private_key, state.dh_recv_public_key
+    )
+    root_key, chain_key = kdf_root_key(state.root_key, dh_output)
+    state.root_key = root_key
+    state.send_chain_key = chain_key
+
+
+def _dh_ratchet_step_with_recv(
+    state: SessionState, new_recv_public_key: bytes
+) -> None:
+    """Full DH ratchet step on receipt of a new ratchet public key.
+
+    Advances the root key twice: once with the peer's new public key to derive
+    the new *receiving* chain, then with a freshly generated local key pair to
+    derive the new *sending* chain. Resets the per-chain counters and records
+    the length of the just-closed sending chain.
+    """
+    state.previous_chain_length = state.send_message_number
+    state.send_message_number = 0
+    state.recv_message_number = 0
+    state.dh_recv_public_key = new_recv_public_key
+
+    dh_recv = x25519_shared_secret(
+        state.dh_send_key_pair.private_key, state.dh_recv_public_key
+    )
+    recv_root_key, recv_chain_key = kdf_root_key(state.root_key, dh_recv)
+    state.root_key = recv_root_key
+    state.recv_chain_key = recv_chain_key
+
+    state.dh_send_key_pair = _to_store_key_pair(generate_x25519_keypair())
+    dh_send = x25519_shared_secret(
+        state.dh_send_key_pair.private_key, state.dh_recv_public_key
+    )
+    send_root_key, send_chain_key = kdf_root_key(state.root_key, dh_send)
+    state.root_key = send_root_key
+    state.send_chain_key = send_chain_key
+
+
+def _skip_message_keys(state: SessionState, until: int) -> None:
+    """Advance the receiving chain to ``until``, caching skipped message keys.
+
+    Caches each skipped key in ``state.skipped_keys`` (keyed by current ratchet
+    public key + message number) so out-of-order messages can be decrypted
+    later. Raises ``ValueError`` if more than :data:`MAX_SKIP` keys would be
+    skipped.
+    """
+    if state.recv_chain_key is None:
+        return
+    if until - state.recv_message_number > MAX_SKIP:
+        raise ValueError("Too many skipped messages")
+    while state.recv_message_number < until:
+        chain_key, message_key = kdf_chain_key(state.recv_chain_key)
+        state.recv_chain_key = chain_key
+        # ``dh_recv_public_key`` is set whenever a receiving chain exists.
+        sk_id = skipped_key_id(
+            state.dh_recv_public_key,  # type: ignore[arg-type]
+            state.recv_message_number,
+        )
+        state.skipped_keys[sk_id] = message_key
+        state.recv_message_number += 1
+
+
+def encode_header(header: RatchetHeader) -> bytes:
+    """Serialize a :class:`RatchetHeader` to its 40-byte wire form.
+
+    Layout matches ``encodeHeader`` in ratchet.ts: the 32-byte public key
+    followed by ``previous_chain_length`` and ``message_number`` as big-endian
+    unsigned 32-bit integers.
+    """
+    return (
+        header.public_key
+        + header.previous_chain_length.to_bytes(4, "big")
+        + header.message_number.to_bytes(4, "big")
+    )
+
+
+def _to_store_key_pair(key_pair: X25519KeyPair) -> X25519KeyPair:
+    """Coerce a crypto ``X25519KeyPair`` into the store's dataclass.
+
+    ``crypto`` and ``store`` currently define distinct (but field-identical)
+    ``X25519KeyPair`` types; unifying them is #46's job. Until then we re-wrap
+    so ``SessionState.dh_send_key_pair`` always holds the store flavour.
+    """
+    return X25519KeyPair(
+        public_key=key_pair.public_key, private_key=key_pair.private_key
+    )

--- a/sdk/python/tests/test_signal_ratchet.py
+++ b/sdk/python/tests/test_signal_ratchet.py
@@ -11,6 +11,8 @@ independently from the crypto primitives (see ``test_known_answer_vector``).
 
 from __future__ import annotations
 
+from copy import deepcopy
+
 import pytest
 from nacl.bindings import crypto_scalarmult_base
 
@@ -139,6 +141,27 @@ def test_tampered_ciphertext_fails() -> None:
     bad = RatchetMessage(header=msg.header, ciphertext=bytes(tampered))
     with pytest.raises(ValueError):
         ratchet_decrypt(bob, bad, AD)
+
+
+def test_failed_decrypt_does_not_mutate_session() -> None:
+    # A tampered message carrying a NEW ratchet public key would, without
+    # staging, advance Bob's session (root key, recv chain, counters, send key)
+    # before the MAC check — corrupting it so the legitimate message can no
+    # longer be decrypted. Verify the session is rolled back on failure.
+    alice, bob = _fresh_sessions()
+    msg = ratchet_encrypt(alice, b"hi bob", AD)  # fresh ratchet key, triggers DH step
+
+    before = deepcopy(bob)
+    tampered = bytearray(msg.ciphertext)
+    tampered[0] ^= 0xFF
+    bad = RatchetMessage(header=msg.header, ciphertext=bytes(tampered))
+    with pytest.raises(ValueError):
+        ratchet_decrypt(bob, bad, AD)
+
+    # Bob's session is byte-for-byte unchanged after the failed decrypt...
+    assert bob == before
+    # ...so the genuine message still decrypts correctly.
+    assert ratchet_decrypt(bob, msg, AD) == b"hi bob"
 
 
 # --------------------------------------------------------------------------

--- a/sdk/python/tests/test_signal_ratchet.py
+++ b/sdk/python/tests/test_signal_ratchet.py
@@ -1,0 +1,324 @@
+"""Tests for the Signal Double Ratchet port (:mod:`tinyplace.signal.ratchet`).
+
+Covers in-order encrypt/decrypt round-trips, a DH-ratchet (reply) step, and
+out-of-order / skipped-message-key delivery, plus a fixed known-answer (KAT)
+interop vector that pins the exact ciphertext bytes for a deterministic
+ratchet step.
+
+Full TS-runtime interop is tracked separately (#48); the KAT here is derived
+independently from the crypto primitives (see ``test_known_answer_vector``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from nacl.bindings import crypto_scalarmult_base
+
+from tinyplace.signal import crypto as c
+from tinyplace.signal.ratchet import (
+    MAX_SKIP,
+    RatchetHeader,
+    RatchetMessage,
+    _skip_message_keys,
+    encode_header,
+    ratchet_decrypt,
+    ratchet_encrypt,
+)
+from tinyplace.signal.store import SessionState, X25519KeyPair, skipped_key_id
+
+
+# --------------------------------------------------------------------------
+# Helpers — build a fresh, deterministic-but-handshaken Alice/Bob pair.
+# --------------------------------------------------------------------------
+
+
+def _clamp(raw: bytes) -> bytes:
+    scalar = bytearray(raw)
+    scalar[0] &= 248
+    scalar[31] &= 127
+    scalar[31] |= 64
+    return bytes(scalar)
+
+
+def _key_pair(raw_private: bytes) -> X25519KeyPair:
+    private_key = _clamp(raw_private)
+    return X25519KeyPair(
+        public_key=crypto_scalarmult_base(private_key),
+        private_key=private_key,
+    )
+
+
+def _fresh_sessions(
+    shared_root: bytes = b"\xAA" * 32,
+) -> tuple[SessionState, SessionState]:
+    """Return ``(alice, bob)`` sessions sharing a root key.
+
+    Models the post-X3DH state: Alice (initiator) knows Bob's ratchet public
+    key and has no chains yet; Bob holds the matching key pair and the same
+    root key. This is exactly the seam X3DH (#44) hands the ratchet.
+    """
+    bob_key = _key_pair(bytes(range(32, 64)))
+    alice_key = _key_pair(bytes(range(32)))
+
+    alice = SessionState(
+        dh_send_key_pair=alice_key,
+        dh_recv_public_key=bob_key.public_key,
+        root_key=shared_root,
+        send_chain_key=None,
+        recv_chain_key=None,
+        send_message_number=0,
+        recv_message_number=0,
+        previous_chain_length=0,
+    )
+    bob = SessionState(
+        dh_send_key_pair=bob_key,
+        dh_recv_public_key=None,
+        root_key=shared_root,
+        send_chain_key=None,
+        recv_chain_key=None,
+        send_message_number=0,
+        recv_message_number=0,
+        previous_chain_length=0,
+    )
+    return alice, bob
+
+
+AD = b"associated-data"
+
+
+# --------------------------------------------------------------------------
+# Header encoding
+# --------------------------------------------------------------------------
+
+
+def test_encode_header_layout() -> None:
+    pub = bytes(range(32))
+    header = RatchetHeader(
+        public_key=pub, previous_chain_length=0x01020304, message_number=0x0A0B0C0D
+    )
+    encoded = encode_header(header)
+    assert len(encoded) == 40
+    assert encoded[:32] == pub
+    # Big-endian u32 fields, matching ratchet.ts encodeHeader.
+    assert encoded[32:36] == bytes([0x01, 0x02, 0x03, 0x04])
+    assert encoded[36:40] == bytes([0x0A, 0x0B, 0x0C, 0x0D])
+
+
+# --------------------------------------------------------------------------
+# In-order round trip
+# --------------------------------------------------------------------------
+
+
+def test_in_order_round_trip() -> None:
+    alice, bob = _fresh_sessions()
+    for i in range(5):
+        plaintext = f"message {i}".encode()
+        msg = ratchet_encrypt(alice, plaintext, AD)
+        assert msg.header.message_number == i
+        assert ratchet_decrypt(bob, msg, AD) == plaintext
+
+    # Alice advanced her sending chain once per message.
+    assert alice.send_message_number == 5
+    assert bob.recv_message_number == 5
+    # No skipping happened on the in-order path.
+    assert bob.skipped_keys == {}
+
+
+def test_wrong_associated_data_fails() -> None:
+    alice, bob = _fresh_sessions()
+    msg = ratchet_encrypt(alice, b"secret", AD)
+    with pytest.raises(ValueError):
+        ratchet_decrypt(bob, msg, b"different-ad")
+
+
+def test_tampered_ciphertext_fails() -> None:
+    alice, bob = _fresh_sessions()
+    msg = ratchet_encrypt(alice, b"secret", AD)
+    tampered = bytearray(msg.ciphertext)
+    tampered[0] ^= 0xFF
+    bad = RatchetMessage(header=msg.header, ciphertext=bytes(tampered))
+    with pytest.raises(ValueError):
+        ratchet_decrypt(bob, bad, AD)
+
+
+# --------------------------------------------------------------------------
+# DH ratchet step (reply path)
+# --------------------------------------------------------------------------
+
+
+def test_dh_ratchet_reply_path() -> None:
+    alice, bob = _fresh_sessions()
+
+    # Alice -> Bob (Bob performs his first receiving DH ratchet).
+    a1 = ratchet_encrypt(alice, b"hi bob", AD)
+    assert ratchet_decrypt(bob, a1, AD) == b"hi bob"
+    # Bob adopted Alice's ratchet key and derived his own sending key pair.
+    assert bob.dh_recv_public_key == alice.dh_send_key_pair.public_key
+
+    bob_send_key_after_first = bob.dh_send_key_pair.public_key
+
+    # Bob -> Alice (reply triggers Alice's receiving DH ratchet).
+    b1 = ratchet_encrypt(bob, b"hi alice", AD)
+    assert b1.header.public_key == bob_send_key_after_first
+    # previous_chain_length reflects Bob's (empty) prior sending chain.
+    assert b1.header.previous_chain_length == 0
+    assert ratchet_decrypt(alice, b1, AD) == b"hi alice"
+    assert alice.dh_recv_public_key == bob_send_key_after_first
+
+    # Alice replies again; this is a second DH ratchet round-trip.
+    a2 = ratchet_encrypt(alice, b"how are you", AD)
+    # Alice generated a new sending ratchet key during her recv ratchet step.
+    assert a2.header.public_key != a1.header.public_key
+    assert a2.header.previous_chain_length == 1  # she sent 1 msg before ratcheting
+    assert ratchet_decrypt(bob, a2, AD) == b"how are you"
+
+
+# --------------------------------------------------------------------------
+# Out-of-order / skipped message keys
+# --------------------------------------------------------------------------
+
+
+def test_out_of_order_within_chain() -> None:
+    alice, bob = _fresh_sessions()
+    m0 = ratchet_encrypt(alice, b"zero", AD)
+    m1 = ratchet_encrypt(alice, b"one", AD)
+    m2 = ratchet_encrypt(alice, b"two", AD)
+
+    # Deliver out of order: 2, 0, 1.
+    assert ratchet_decrypt(bob, m2, AD) == b"two"
+    # Keys for 0 and 1 were cached while skipping ahead to 2.
+    assert len(bob.skipped_keys) == 2
+    assert ratchet_decrypt(bob, m0, AD) == b"zero"
+    assert ratchet_decrypt(bob, m1, AD) == b"one"
+    # Both cached keys were consumed exactly once.
+    assert bob.skipped_keys == {}
+
+
+def test_skipped_across_dh_ratchet() -> None:
+    alice, bob = _fresh_sessions()
+
+    # Alice sends 3 in her first chain; only the last is delivered first.
+    a0 = ratchet_encrypt(alice, b"a0", AD)
+    a1 = ratchet_encrypt(alice, b"a1", AD)
+    a2 = ratchet_encrypt(alice, b"a2", AD)
+    assert ratchet_decrypt(bob, a2, AD) == b"a2"
+
+    # Bob replies, then Alice ratchets and sends in a new chain.
+    b0 = ratchet_encrypt(bob, b"b0", AD)
+    assert ratchet_decrypt(alice, b0, AD) == b"b0"
+    a3 = ratchet_encrypt(alice, b"a3", AD)  # new sending chain after ratchet
+
+    # The new-chain message arrives before the stragglers from the old chain.
+    assert ratchet_decrypt(bob, a3, AD) == b"a3"
+    # The old chain's skipped keys (a0, a1) are still recoverable.
+    assert ratchet_decrypt(bob, a0, AD) == b"a0"
+    assert ratchet_decrypt(bob, a1, AD) == b"a1"
+
+
+def test_too_many_skipped_raises() -> None:
+    alice, bob = _fresh_sessions()
+    # Bob must first establish a receiving chain.
+    first = ratchet_encrypt(alice, b"first", AD)
+    assert ratchet_decrypt(bob, first, AD) == b"first"
+
+    # Forge a header far beyond MAX_SKIP in the same chain.
+    forged_header = RatchetHeader(
+        public_key=alice.dh_send_key_pair.public_key,
+        previous_chain_length=0,
+        message_number=MAX_SKIP + 5,
+    )
+    forged = RatchetMessage(header=forged_header, ciphertext=b"\x00" * 24)
+    with pytest.raises(ValueError, match="Too many skipped messages"):
+        ratchet_decrypt(bob, forged, AD)
+
+
+def test_skip_message_keys_noop_without_recv_chain() -> None:
+    # Guard path: skipping is a no-op before any receiving chain exists.
+    _alice, bob = _fresh_sessions()
+    assert bob.recv_chain_key is None
+    _skip_message_keys(bob, 5)
+    assert bob.skipped_keys == {}
+    assert bob.recv_message_number == 0
+
+
+def test_initial_send_requires_recv_public_key() -> None:
+    alice, _ = _fresh_sessions()
+    alice.dh_recv_public_key = None
+    with pytest.raises(ValueError, match="without recipient public key"):
+        ratchet_encrypt(alice, b"oops", AD)
+
+
+# --------------------------------------------------------------------------
+# Known-answer / interop vector (pinned bytes)
+# --------------------------------------------------------------------------
+#
+# These bytes were derived independently from the crypto primitives
+# (x25519_shared_secret -> kdf_root_key -> kdf_chain_key -> encrypt) for a
+# fully deterministic first ratchet step, then cross-checked against
+# ratchet_encrypt below. Provenance: fixed clamped private scalars
+# 0x00..0x1f (Alice) and 0x20..0x3f (Bob), root key 0xAA*32, plaintext
+# b"hello ratchet", associated data b"AD". The encrypt IV is HKDF-derived
+# from the message key, so the ciphertext is deterministic. This pins
+# byte-compatibility with the TS SDK ahead of full TS-runtime interop (#48).
+
+_KAT_ALICE_PUB = bytes.fromhex(
+    "8f40c5adb68f25624ae5b214ea767a6ec94d829d3d7b5e1ad1ba6f3e2138285f"
+)
+_KAT_ROOT = b"\xAA" * 32
+_KAT_PLAINTEXT = b"hello ratchet"
+_KAT_AD = b"AD"
+_KAT_NEW_ROOT = bytes.fromhex(
+    "e1bdd18cce97a925b11f6d516a991e15952aa6a02f078f551c48740e7a597f30"
+)
+_KAT_SEND_CHAIN = bytes.fromhex(
+    "73322a962b06be7ed11f8f63d67a1dd151aac4fbe3a467e420a31dac1c451a21"
+)
+_KAT_CIPHERTEXT = bytes.fromhex(
+    "b6df0eb6ef4061fa86d9768d642581026c5bf6443c7d0031"
+)
+
+
+def test_known_answer_vector() -> None:
+    # Independent derivation using only crypto primitives.
+    alice = _key_pair(bytes(range(32)))
+    bob = _key_pair(bytes(range(32, 64)))
+    assert alice.public_key == _KAT_ALICE_PUB
+
+    dh = c.x25519_shared_secret(alice.private_key, bob.public_key)
+    new_root, send_chain = c.kdf_root_key(_KAT_ROOT, dh)
+    assert new_root == _KAT_NEW_ROOT
+    assert send_chain == _KAT_SEND_CHAIN
+
+    _chain, mk = c.kdf_chain_key(send_chain)
+    header = encode_header(
+        RatchetHeader(public_key=alice.public_key, previous_chain_length=0, message_number=0)
+    )
+    ct = c.encrypt(mk, _KAT_PLAINTEXT, _KAT_AD + header)
+    assert ct == _KAT_CIPHERTEXT
+
+
+def test_known_answer_matches_ratchet_encrypt() -> None:
+    # The high-level ratchet API must produce the same pinned ciphertext.
+    alice = SessionState(
+        dh_send_key_pair=_key_pair(bytes(range(32))),
+        dh_recv_public_key=_key_pair(bytes(range(32, 64))).public_key,
+        root_key=_KAT_ROOT,
+        send_chain_key=None,
+        recv_chain_key=None,
+        send_message_number=0,
+        recv_message_number=0,
+        previous_chain_length=0,
+    )
+    msg = ratchet_encrypt(alice, _KAT_PLAINTEXT, _KAT_AD)
+    assert msg.header.public_key == _KAT_ALICE_PUB
+    assert msg.header.message_number == 0
+    assert msg.header.previous_chain_length == 0
+    assert msg.ciphertext == _KAT_CIPHERTEXT
+    # State advanced exactly as the independent derivation predicts.
+    assert alice.root_key == _KAT_NEW_ROOT
+
+
+def test_skipped_key_id_consistency() -> None:
+    # The ratchet caches under the same id the store helper builds.
+    pub = bytes(range(32))
+    assert skipped_key_id(pub, 7) == f"{pub.hex()}:7"


### PR DESCRIPTION
## What this ports

The Double Ratchet, ported from the flagship TypeScript SDK (`sdk/typescript/src/signal/ratchet.ts`) to the Python SDK, byte-compatible with it:

- **Symmetric ratchet** — HMAC-SHA256 chain ratchet via `kdf_chain_key`, message-key derivation per message.
- **Diffie-Hellman ratchet** — X25519 DH + HKDF-SHA256 root-key advance via `kdf_root_key`; initial sending step and full receive-then-send step on a new ratchet key.
- **Ratchet header** — 40-byte wire format `publicKey(32) || previousChainLength(u32 BE) || messageNumber(u32 BE)`, matching `encodeHeader`.
- **Skipped / out-of-order keys** — caches skipped message keys in `SessionState.skipped_keys` (keyed by `skipped_key_id`), consumed on later delivery; `MAX_SKIP=1000` guard.

Operates over the existing `SessionState`. Reuses the existing `crypto.py` primitives verbatim — no crypto is reimplemented. X3DH, the session/message-wiring layer, and sender-keys are out of scope (separate slices).

## Files

- `sdk/python/src/tinyplace/signal/ratchet.py` (new) — the Double Ratchet.
- `sdk/python/tests/test_signal_ratchet.py` (new) — tests.
- `sdk/python/src/tinyplace/signal/__init__.py` — export the new public API.

## Tests & coverage

`110 passed, 2 skipped` on Python 3.14; total coverage **92.72%** (gate ≥80%), `ratchet.py` at **100%**. Tests cover: in-order encrypt/decrypt round-trip, a DH-ratchet reply path, out-of-order + skipped-key delivery (within a chain and across a DH ratchet), MAC/AD-tamper rejection, `MAX_SKIP` enforcement, and header layout.

Includes a pinned **known-answer interop vector**: fixed clamped scalars (`0x00..1f` / `0x20..3f`), root `0xAA*32`, plaintext `b"hello ratchet"` — the expected ciphertext bytes are derived independently from the crypto primitives and cross-checked against `ratchet_encrypt`. Full TS-runtime interop is tracked in #48.

Closes #45
Part of #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added double-ratchet encryption protocol support to the Signal SDK with forward secrecy.
  * Enabled out-of-order message handling with automatic key caching and recovery.
  * Introduced encryption/decryption functions with authenticated data support.

* **Tests**
  * Added comprehensive test suite covering encryption, decryption, and edge cases including message tampering and protocol compliance validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->