### PR TITLE
feat(sdk/python): Signal X3DH key agreement (#44)

### DIFF
--- a/sdk/python/src/tinyplace/signal/__init__.py
+++ b/sdk/python/src/tinyplace/signal/__init__.py
@@ -48,6 +48,14 @@ from .keys import (
 from .memory_store import MemorySessionStore
 from .store import SenderKeyState, SessionState, SessionStore, skipped_key_id
 from .types import PreKeyPair, SignedPreKeyPair, X25519KeyPair
+from .x3dh import (
+    X3DHBundle,
+    X3DHInitResult,
+    build_associated_data,
+    verify_pre_key_signature_raw,
+    x3dh_initiate,
+    x3dh_respond,
+)
 
 __all__ = [
     # key material types
@@ -90,4 +98,11 @@ __all__ = [
     "SessionState",
     "SessionStore",
     "skipped_key_id",
+    # X3DH key agreement
+    "X3DHBundle",
+    "X3DHInitResult",
+    "x3dh_initiate",
+    "x3dh_respond",
+    "build_associated_data",
+    "verify_pre_key_signature_raw",
 ]

--- a/sdk/python/src/tinyplace/signal/x3dh.py
+++ b/sdk/python/src/tinyplace/signal/x3dh.py
@@ -1,0 +1,258 @@
+"""X3DH key agreement for the Signal Protocol port (issue #44).
+
+A byte-compatible Python port of the TypeScript SDK's
+``sdk/typescript/src/signal/x3dh.ts``. X3DH ("Extended Triple Diffie-Hellman")
+derives the initial shared secret that seeds the Double Ratchet's root key from
+a fetched pre-key bundle.
+
+The DH order, the HKDF salt/info strings and the leading 32-byte 0xFF padding
+all mirror the reference implementation exactly so an initial message produced
+by one SDK can be consumed by the other:
+
+* DH: X25519, via :func:`tinyplace.signal.crypto.x25519_shared_secret`
+* KDF: HKDF-SHA256 with a 32-byte zero salt and the ``"WhisperText"`` info,
+  prefixed by 32 bytes of ``0xFF`` cryptographic-domain padding.
+
+This slice covers *only* the X3DH agreement (initiator + responder) and the
+associated-data construction. The Double Ratchet, session and sender-key layers
+land in later slices; the :class:`SessionState` returned here is the handoff to
+the ratchet's root key.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .crypto import (
+    ed25519_verify,
+    from_base64,
+    generate_x25519_keypair,
+    hkdf,
+    x25519_shared_secret,
+)
+from .store import SessionState
+from .store import X25519KeyPair as SessionKeyPair
+from .types import X25519KeyPair
+
+__all__ = [
+    "X3DHBundle",
+    "X3DHInitResult",
+    "x3dh_initiate",
+    "x3dh_respond",
+    "build_associated_data",
+    "verify_pre_key_signature_raw",
+]
+
+# Domain-separation constants — must match x3dh.ts byte-for-byte.
+_X3DH_INFO = b"WhisperText"
+# 32 bytes of 0xFF prepended to the concatenated DH outputs, per the X3DH spec
+# ("a byte sequence of F[i]" of the curve type), mirroring the reference SDK.
+_PADDING = b"\xff" * 32
+# HKDF salt: 32 zero bytes (the noble default; crypto.hkdf maps b"" to this too,
+# but we pass it explicitly for clarity / parity with x3dh.ts).
+_SALT = b"\x00" * 32
+
+
+@dataclass(frozen=True)
+class X3DHBundle:
+    """A fetched, signature-verified pre-key bundle for an X3DH initiation.
+
+    Mirrors the TypeScript ``X3DHBundle`` interface. ``identity_key``,
+    ``signed_pre_key`` and the optional ``one_time_pre_key`` are raw 32-byte
+    X25519 public keys (the peer's identity key is its *X25519* form, already
+    converted from the Ed25519 addressing key by the caller / session layer).
+    """
+
+    identity_key: bytes
+    signed_pre_key_id: str
+    signed_pre_key: bytes
+    one_time_pre_key_id: str | None = None
+    one_time_pre_key: bytes | None = None
+
+
+@dataclass(frozen=True)
+class X3DHInitResult:
+    """The result of an X3DH initiation.
+
+    ``session`` carries the derived root key into the (future) Double Ratchet.
+    ``ephemeral_public_key`` plus the pre-key ids must be sent to the responder
+    in the initial ``PREKEY_BUNDLE`` message so it can reproduce the agreement.
+    """
+
+    session: SessionState
+    ephemeral_public_key: bytes
+    signed_pre_key_id: str
+    one_time_pre_key_id: str | None = None
+
+
+def x3dh_initiate(
+    our_identity_key_pair: X25519KeyPair,
+    their_bundle: X3DHBundle,
+) -> X3DHInitResult:
+    """Run X3DH as the initiator (Alice) against a fetched pre-key bundle.
+
+    Generates a fresh ephemeral key, performs the three (or four) Diffie-Hellman
+    operations in the exact order the reference SDK uses, and derives the shared
+    secret that becomes the initial root key. Mirrors ``x3dhInitiate`` in
+    ``x3dh.ts``.
+
+    Args:
+        our_identity_key_pair: Our long-term X25519 identity key pair.
+        their_bundle: The peer's verified :class:`X3DHBundle`.
+
+    Returns:
+        An :class:`X3DHInitResult` whose ``session`` holds the derived root key
+        and whose public material must be relayed to the responder.
+    """
+    ephemeral = generate_x25519_keypair()
+
+    # DH1: our identity <-> their signed pre-key
+    dh1 = x25519_shared_secret(our_identity_key_pair.private_key, their_bundle.signed_pre_key)
+    # DH2: our ephemeral <-> their identity
+    dh2 = x25519_shared_secret(ephemeral.private_key, their_bundle.identity_key)
+    # DH3: our ephemeral <-> their signed pre-key
+    dh3 = x25519_shared_secret(ephemeral.private_key, their_bundle.signed_pre_key)
+
+    if their_bundle.one_time_pre_key is not None:
+        # DH4: our ephemeral <-> their one-time pre-key
+        dh4 = x25519_shared_secret(ephemeral.private_key, their_bundle.one_time_pre_key)
+        dh_concat = _PADDING + dh1 + dh2 + dh3 + dh4
+    else:
+        dh_concat = _PADDING + dh1 + dh2 + dh3
+
+    shared_secret = hkdf(dh_concat, _SALT, _X3DH_INFO, 32)
+
+    send_key_pair = generate_x25519_keypair()
+    session = SessionState(
+        dh_send_key_pair=SessionKeyPair(
+            public_key=send_key_pair.public_key,
+            private_key=send_key_pair.private_key,
+        ),
+        dh_recv_public_key=their_bundle.signed_pre_key,
+        root_key=shared_secret,
+        send_chain_key=None,
+        recv_chain_key=None,
+        send_message_number=0,
+        recv_message_number=0,
+        previous_chain_length=0,
+    )
+
+    return X3DHInitResult(
+        session=session,
+        ephemeral_public_key=ephemeral.public_key,
+        signed_pre_key_id=their_bundle.signed_pre_key_id,
+        one_time_pre_key_id=their_bundle.one_time_pre_key_id,
+    )
+
+
+def x3dh_respond(
+    our_identity_key_pair: X25519KeyPair,
+    our_signed_pre_key_pair: X25519KeyPair,
+    their_identity_key: bytes,
+    their_ephemeral_key: bytes,
+    our_one_time_pre_key_pair: X25519KeyPair | None = None,
+) -> SessionState:
+    """Run X3DH as the responder (Bob) given the initiator's public material.
+
+    Reproduces the same DH outputs as :func:`x3dh_initiate` (with the roles of
+    each key swapped so both sides reach the *same* shared secret) and derives
+    the initial root key. Mirrors ``x3dhRespond`` in ``x3dh.ts``.
+
+    Args:
+        our_identity_key_pair: Our long-term X25519 identity key pair.
+        our_signed_pre_key_pair: The signed pre-key the initiator selected.
+        their_identity_key: The initiator's raw X25519 identity public key.
+        their_ephemeral_key: The initiator's raw X25519 ephemeral public key.
+        our_one_time_pre_key_pair: The one-time pre-key the initiator consumed,
+            if any. Must be supplied iff the initiator's bundle carried one.
+
+    Returns:
+        A :class:`SessionState` holding the derived root key.
+    """
+    # DH1: their identity <-> our signed pre-key
+    dh1 = x25519_shared_secret(our_signed_pre_key_pair.private_key, their_identity_key)
+    # DH2: their ephemeral <-> our identity
+    dh2 = x25519_shared_secret(our_identity_key_pair.private_key, their_ephemeral_key)
+    # DH3: their ephemeral <-> our signed pre-key
+    dh3 = x25519_shared_secret(our_signed_pre_key_pair.private_key, their_ephemeral_key)
+
+    if our_one_time_pre_key_pair is not None:
+        # DH4: their ephemeral <-> our one-time pre-key
+        dh4 = x25519_shared_secret(our_one_time_pre_key_pair.private_key, their_ephemeral_key)
+        dh_concat = _PADDING + dh1 + dh2 + dh3 + dh4
+    else:
+        dh_concat = _PADDING + dh1 + dh2 + dh3
+
+    shared_secret = hkdf(dh_concat, _SALT, _X3DH_INFO, 32)
+
+    return SessionState(
+        dh_send_key_pair=SessionKeyPair(
+            public_key=our_signed_pre_key_pair.public_key,
+            private_key=our_signed_pre_key_pair.private_key,
+        ),
+        dh_recv_public_key=None,
+        root_key=shared_secret,
+        send_chain_key=None,
+        recv_chain_key=None,
+        send_message_number=0,
+        recv_message_number=0,
+        previous_chain_length=0,
+    )
+
+
+def build_associated_data(
+    sender_identity_key: bytes,
+    recipient_identity_key: bytes,
+) -> bytes:
+    """Build the AEAD associated data binding sender and recipient identities.
+
+    The associated data is ``sender_identity_key || recipient_identity_key``,
+    matching ``buildAssociatedData`` in ``x3dh.ts``. It binds each ciphertext to
+    the two long-term identities so a relay cannot replay it into a different
+    conversation.
+    """
+    return sender_identity_key + recipient_identity_key
+
+
+def verify_pre_key_signature_raw(
+    identity_ed25519_public_key: bytes,
+    pre_key_public_key_base64: str,
+    signature_base64: str | None,
+    label: str,
+) -> None:
+    """Verify a fetched pre-key was signed by the peer's Ed25519 identity key.
+
+    Raw-bytes port of ``verifyPreKeySignature`` in ``x3dh.ts`` (the
+    :func:`tinyplace.signal.keys.verify_pre_key_signature` variant works on the
+    backend's dict wire shape; this one mirrors the x3dh.ts signature for the
+    session layer). The signed message is the UTF-8 bytes of the base64-encoded
+    X25519 public key, exactly as the Go backend verifies
+    (``ed25519.Verify(identityPubKey, []byte(base64(preKey)), signature)``).
+
+    The Ed25519 identity key MUST come from the caller's trusted addressing of
+    the peer, never from the served bundle, so a malicious relay cannot
+    substitute attacker-controlled pre-keys (MITM / unknown-key-share).
+
+    Args:
+        identity_ed25519_public_key: The peer's long-term Ed25519 identity
+            public key (the addressing key), NOT its derived X25519 key.
+        pre_key_public_key_base64: The base64 X25519 pre-key public key, carried
+            verbatim in the fetched bundle.
+        signature_base64: The base64 Ed25519 signature over the pre-key.
+        label: A human-readable label for the pre-key (for error messages).
+
+    Raises:
+        ValueError: if the signature is missing or invalid.
+    """
+    if not signature_base64:
+        raise ValueError(
+            f"Key bundle rejected: {label} is missing its Ed25519 signature"
+        )
+    signed_message = pre_key_public_key_base64.encode("utf-8")
+    try:
+        signature = from_base64(signature_base64)
+        valid = ed25519_verify(identity_ed25519_public_key, signed_message, signature)
+    except Exception:
+        valid = False
+    if not valid:
+        raise ValueError(f"Key bundle rejected: invalid Ed25519 signature on {label}")

--- a/sdk/python/tests/test_signal_x3dh.py
+++ b/sdk/python/tests/test_signal_x3dh.py
@@ -1,0 +1,318 @@
+"""Tests for the X3DH key agreement slice (issue #44).
+
+Covers initiator/responder agreement (both sides derive the *same* shared
+secret), the with/without one-time-pre-key code paths, the associated-data
+construction, the raw pre-key signature verification, and a pinned
+known-answer vector for byte-level interop.
+
+The known-answer vector is computed independently from this implementation via
+Node's built-in ``node:crypto`` (X25519 + HKDF-SHA256), reproducing the exact
+DH order / padding / salt / info of ``sdk/typescript/src/signal/x3dh.ts``. See
+``EXPECTED_*`` below for provenance.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from nacl.bindings import crypto_scalarmult_base
+
+from tinyplace.signal import generate_x25519_keypair
+from tinyplace.signal.crypto import (
+    ed25519_keypair_from_seed,
+    ed25519_sign,
+    to_base64,
+)
+from tinyplace.signal.store import SessionState
+from tinyplace.signal.types import X25519KeyPair
+from tinyplace.signal.x3dh import (
+    X3DHBundle,
+    X3DHInitResult,
+    build_associated_data,
+    verify_pre_key_signature_raw,
+    x3dh_initiate,
+    x3dh_respond,
+)
+
+# ---------------------------------------------------------------------------
+# Known-answer vector (provenance)
+# ---------------------------------------------------------------------------
+#
+# Fixed raw 32-byte X25519 private scalars (filled with a constant byte). The
+# expected public keys and shared secrets below were produced by an INDEPENDENT
+# Node script using only `node:crypto` (no @noble, no PyNaCl):
+#
+#   import crypto from "node:crypto";
+#   // X25519 keypairs from raw scalars via PKCS8/SPKI DER wrapping,
+#   // crypto.diffieHellman(...) for each DH, crypto.hkdfSync("sha256", ikm,
+#   // salt=32x0x00, info="WhisperText", 32) over PADDING||DH1||DH2||DH3[||DH4],
+#   // with PADDING = 32 bytes of 0xFF. DH order matches x3dh.ts exactly.
+#
+# Roles (initiator "Alice" derives these): our identity = ID_PRIV, ephemeral =
+# EPH_PRIV; their bundle = {identity: THEIR_ID, signedPreKey: SPK, oneTimePreKey
+# OTP}. Because node:crypto and libsodium both clamp per RFC 7748, the raw
+# constant scalars yield identical results in both runtimes.
+ID_PRIV = bytes([1]) * 32
+EPH_PRIV = bytes([2]) * 32
+SPK_PRIV = bytes([3]) * 32
+OTP_PRIV = bytes([4]) * 32
+THEIR_ID_PRIV = bytes([5]) * 32
+
+EXPECTED_ID_PUB = "a4e09292b651c278b9772c569f5fa9bb13d906b46ab68c9df9dc2b4409f8a209"
+EXPECTED_EPH_PUB = "ce8d3ad1ccb633ec7b70c17814a5c76ecd029685050d344745ba05870e587d59"
+EXPECTED_SPK_PUB = "5dfedd3b6bd47f6fa28ee15d969d5bb0ea53774d488bdaf9df1c6e0124b3ef22"
+EXPECTED_OTP_PUB = "ac01b2209e86354fb853237b5de0f4fab13c7fcbf433a61c019369617fecf10b"
+EXPECTED_THEIR_ID_PUB = "50a61409b1ddd0325e9b16b700e719e9772c07000b1bd7786e907c653d20495d"
+EXPECTED_SS_WITH_OTP = "47c75718c86c89e9d9ade14ef19144e7846f83e5a7ab13424f235ce909bd8c39"
+EXPECTED_SS_NO_OTP = "1d926cba2a6c7ae50370697f285334214d92753ee913d17b9448dbdb2e117d82"
+
+
+def _pub(priv: bytes) -> bytes:
+    return crypto_scalarmult_base(priv)
+
+
+def _kp(priv: bytes) -> X25519KeyPair:
+    return X25519KeyPair(public_key=_pub(priv), private_key=priv)
+
+
+# ---------------------------------------------------------------------------
+# Known-answer vectors
+# ---------------------------------------------------------------------------
+
+
+def test_public_keys_match_known_answer_vector() -> None:
+    assert _pub(ID_PRIV).hex() == EXPECTED_ID_PUB
+    assert _pub(EPH_PRIV).hex() == EXPECTED_EPH_PUB
+    assert _pub(SPK_PRIV).hex() == EXPECTED_SPK_PUB
+    assert _pub(OTP_PRIV).hex() == EXPECTED_OTP_PUB
+    assert _pub(THEIR_ID_PRIV).hex() == EXPECTED_THEIR_ID_PUB
+
+
+def _initiate_with_fixed_ephemeral(*, with_otp: bool) -> X3DHInitResult:
+    """Initiate with the pinned ephemeral key (monkeypatched generator)."""
+    import tinyplace.signal.x3dh as x3dh_mod
+
+    fixed_eph = _kp(EPH_PRIV)
+    # The send key pair is also generated; its value does not affect the root
+    # key, so any deterministic stand-in is fine for the KAT.
+    real_generate = x3dh_mod.generate_x25519_keypair
+    calls = {"n": 0}
+
+    def fake_generate() -> X25519KeyPair:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return fixed_eph
+        return real_generate()
+
+    x3dh_mod.generate_x25519_keypair = fake_generate  # type: ignore[assignment]
+    try:
+        bundle = X3DHBundle(
+            identity_key=_pub(THEIR_ID_PRIV),
+            signed_pre_key_id="spk_1",
+            signed_pre_key=_pub(SPK_PRIV),
+            one_time_pre_key_id="pk_1" if with_otp else None,
+            one_time_pre_key=_pub(OTP_PRIV) if with_otp else None,
+        )
+        return x3dh_initiate(_kp(ID_PRIV), bundle)
+    finally:
+        x3dh_mod.generate_x25519_keypair = real_generate  # type: ignore[assignment]
+
+
+def test_initiate_shared_secret_matches_known_answer_with_otp() -> None:
+    result = _initiate_with_fixed_ephemeral(with_otp=True)
+    assert result.ephemeral_public_key.hex() == EXPECTED_EPH_PUB
+    assert result.session.root_key.hex() == EXPECTED_SS_WITH_OTP
+    assert result.signed_pre_key_id == "spk_1"
+    assert result.one_time_pre_key_id == "pk_1"
+
+
+def test_initiate_shared_secret_matches_known_answer_without_otp() -> None:
+    result = _initiate_with_fixed_ephemeral(with_otp=False)
+    assert result.session.root_key.hex() == EXPECTED_SS_NO_OTP
+    assert result.one_time_pre_key_id is None
+
+
+def test_respond_shared_secret_matches_known_answer_with_otp() -> None:
+    session = x3dh_respond(
+        our_identity_key_pair=_kp(THEIR_ID_PRIV),
+        our_signed_pre_key_pair=_kp(SPK_PRIV),
+        their_identity_key=_pub(ID_PRIV),
+        their_ephemeral_key=_pub(EPH_PRIV),
+        our_one_time_pre_key_pair=_kp(OTP_PRIV),
+    )
+    assert session.root_key.hex() == EXPECTED_SS_WITH_OTP
+
+
+def test_respond_shared_secret_matches_known_answer_without_otp() -> None:
+    session = x3dh_respond(
+        our_identity_key_pair=_kp(THEIR_ID_PRIV),
+        our_signed_pre_key_pair=_kp(SPK_PRIV),
+        their_identity_key=_pub(ID_PRIV),
+        their_ephemeral_key=_pub(EPH_PRIV),
+        our_one_time_pre_key_pair=None,
+    )
+    assert session.root_key.hex() == EXPECTED_SS_NO_OTP
+
+
+# ---------------------------------------------------------------------------
+# Initiator <-> responder agreement (fresh random keys)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("with_otp", [True, False])
+def test_initiator_and_responder_derive_same_secret(with_otp: bool) -> None:
+    alice_identity = generate_x25519_keypair()
+    bob_identity = generate_x25519_keypair()
+    bob_signed_pre_key = generate_x25519_keypair()
+    bob_one_time_pre_key = generate_x25519_keypair() if with_otp else None
+
+    bundle = X3DHBundle(
+        identity_key=bob_identity.public_key,
+        signed_pre_key_id="spk_99",
+        signed_pre_key=bob_signed_pre_key.public_key,
+        one_time_pre_key_id="pk_7" if with_otp else None,
+        one_time_pre_key=bob_one_time_pre_key.public_key if with_otp else None,
+    )
+
+    init = x3dh_initiate(alice_identity, bundle)
+
+    session = x3dh_respond(
+        our_identity_key_pair=bob_identity,
+        our_signed_pre_key_pair=bob_signed_pre_key,
+        their_identity_key=alice_identity.public_key,
+        their_ephemeral_key=init.ephemeral_public_key,
+        our_one_time_pre_key_pair=bob_one_time_pre_key,
+    )
+
+    assert init.session.root_key == session.root_key
+    assert len(init.session.root_key) == 32
+
+
+def test_otp_mismatch_yields_different_secret() -> None:
+    """Dropping the one-time pre-key on one side breaks agreement (as expected)."""
+    alice = generate_x25519_keypair()
+    bob = generate_x25519_keypair()
+    spk = generate_x25519_keypair()
+    otp = generate_x25519_keypair()
+
+    bundle = X3DHBundle(
+        identity_key=bob.public_key,
+        signed_pre_key_id="spk_1",
+        signed_pre_key=spk.public_key,
+        one_time_pre_key_id="pk_1",
+        one_time_pre_key=otp.public_key,
+    )
+    init = x3dh_initiate(alice, bundle)
+
+    # Responder forgets to supply the one-time pre-key -> different secret.
+    session = x3dh_respond(
+        our_identity_key_pair=bob,
+        our_signed_pre_key_pair=spk,
+        their_identity_key=alice.public_key,
+        their_ephemeral_key=init.ephemeral_public_key,
+        our_one_time_pre_key_pair=None,
+    )
+    assert init.session.root_key != session.root_key
+
+
+# ---------------------------------------------------------------------------
+# Session-state handoff shape
+# ---------------------------------------------------------------------------
+
+
+def test_initiate_session_state_shape() -> None:
+    alice = generate_x25519_keypair()
+    bob = generate_x25519_keypair()
+    spk = generate_x25519_keypair()
+    bundle = X3DHBundle(
+        identity_key=bob.public_key,
+        signed_pre_key_id="spk_1",
+        signed_pre_key=spk.public_key,
+    )
+    init = x3dh_initiate(alice, bundle)
+    s = init.session
+    assert isinstance(s, SessionState)
+    assert s.dh_recv_public_key == spk.public_key
+    assert s.send_chain_key is None
+    assert s.recv_chain_key is None
+    assert s.send_message_number == 0
+    assert s.recv_message_number == 0
+    assert s.previous_chain_length == 0
+    assert s.skipped_keys == {}
+    assert len(s.dh_send_key_pair.public_key) == 32
+
+
+def test_respond_session_state_shape() -> None:
+    session = x3dh_respond(
+        our_identity_key_pair=_kp(THEIR_ID_PRIV),
+        our_signed_pre_key_pair=_kp(SPK_PRIV),
+        their_identity_key=_pub(ID_PRIV),
+        their_ephemeral_key=_pub(EPH_PRIV),
+    )
+    assert session.dh_recv_public_key is None
+    assert session.dh_send_key_pair.public_key == _pub(SPK_PRIV)
+    assert session.dh_send_key_pair.private_key == SPK_PRIV
+
+
+# ---------------------------------------------------------------------------
+# Associated data
+# ---------------------------------------------------------------------------
+
+
+def test_build_associated_data_is_sender_then_recipient() -> None:
+    sender = bytes([0xAA]) * 32
+    recipient = bytes([0xBB]) * 32
+    ad = build_associated_data(sender, recipient)
+    assert ad == sender + recipient
+    assert ad[:32] == sender
+    assert ad[32:] == recipient
+
+
+# ---------------------------------------------------------------------------
+# Raw pre-key signature verification (x3dh.ts parity)
+# ---------------------------------------------------------------------------
+
+
+def _signed_pre_key_b64_and_sig(seed: bytes) -> tuple[bytes, str, str]:
+    """Return (ed_pub, prekey_pub_b64, signature_b64) for a freshly signed key."""
+    ed_pub, ed_secret = ed25519_keypair_from_seed(seed)
+    prekey = generate_x25519_keypair()
+    prekey_b64 = to_base64(prekey.public_key)
+    # Backend/keys.py sign the UTF-8 bytes of the base64 public key string.
+    sig = ed25519_sign(ed_secret, prekey_b64.encode("utf-8"))
+    return ed_pub, prekey_b64, to_base64(sig)
+
+
+def test_verify_pre_key_signature_raw_accepts_valid() -> None:
+    ed_pub, prekey_b64, sig_b64 = _signed_pre_key_b64_and_sig(b"\x07" * 32)
+    # Should not raise.
+    verify_pre_key_signature_raw(ed_pub, prekey_b64, sig_b64, "signed pre-key")
+
+
+def test_verify_pre_key_signature_raw_rejects_missing_signature() -> None:
+    ed_pub, prekey_b64, _ = _signed_pre_key_b64_and_sig(b"\x08" * 32)
+    with pytest.raises(ValueError, match="missing its Ed25519 signature"):
+        verify_pre_key_signature_raw(ed_pub, prekey_b64, None, "signed pre-key")
+    with pytest.raises(ValueError, match="missing its Ed25519 signature"):
+        verify_pre_key_signature_raw(ed_pub, prekey_b64, "", "one-time pre-key")
+
+
+def test_verify_pre_key_signature_raw_rejects_wrong_identity() -> None:
+    _, prekey_b64, sig_b64 = _signed_pre_key_b64_and_sig(b"\x09" * 32)
+    other_ed_pub, _ = ed25519_keypair_from_seed(b"\x0a" * 32)
+    with pytest.raises(ValueError, match="invalid Ed25519 signature"):
+        verify_pre_key_signature_raw(other_ed_pub, prekey_b64, sig_b64, "signed pre-key")
+
+
+def test_verify_pre_key_signature_raw_rejects_tampered_prekey() -> None:
+    ed_pub, prekey_b64, sig_b64 = _signed_pre_key_b64_and_sig(b"\x0b" * 32)
+    tampered = to_base64(bytes([(prekey_b64.encode()[0] ^ 0xFF)]) + base64.b64decode(prekey_b64)[1:])
+    with pytest.raises(ValueError, match="invalid Ed25519 signature"):
+        verify_pre_key_signature_raw(ed_pub, tampered, sig_b64, "signed pre-key")
+
+
+def test_verify_pre_key_signature_raw_rejects_malformed_signature() -> None:
+    ed_pub, prekey_b64, _ = _signed_pre_key_b64_and_sig(b"\x0c" * 32)
+    with pytest.raises(ValueError, match="invalid Ed25519 signature"):
+        verify_pre_key_signature_raw(ed_pub, prekey_b64, "not!base64!!", "signed pre-key")


### PR DESCRIPTION
## What

Ports X3DH ("Extended Triple Diffie-Hellman") key agreement from the TypeScript SDK (`sdk/typescript/src/signal/x3dh.ts`) into the Python SDK. X3DH derives the initial shared secret that seeds the Double Ratchet's root key from a fetched pre-key bundle, producing the `PREKEY_BUNDLE` material. This is slice 4/8 of the Signal port; it does **not** implement the ratchet, session, or sender-keys layers.

### Byte-compatibility

The DH order, the `0xFF`*32 padding, the 32-byte zero HKDF salt and the `"WhisperText"` info string all mirror the reference SDK exactly, so an initial message produced by either SDK can be consumed by the other:

- `x3dh_initiate` (initiator): DH1 = id↔SPK, DH2 = eph↔id, DH3 = eph↔SPK, DH4 = eph↔OTP (when present), then HKDF-SHA256 over `PADDING || DH1..DHn`.
- `x3dh_respond` (responder): the same outputs with roles swapped, reaching the identical secret.

Reuses the existing `crypto` / `types` / `store` primitives (no new `X25519KeyPair` definition — the unification is #46's job).

## Files

- `sdk/python/src/tinyplace/signal/x3dh.py` — `X3DHBundle`, `X3DHInitResult`, `x3dh_initiate`, `x3dh_respond`, `build_associated_data`, `verify_pre_key_signature_raw`.
- `sdk/python/tests/test_signal_x3dh.py` — agreement + known-answer vectors.
- `sdk/python/src/tinyplace/signal/__init__.py` — re-exports the new symbols.

## Tests

- Initiator and responder derive the **same** shared secret (parametrized with and without a one-time pre-key).
- A **pinned known-answer vector** for the derived shared secret, the public keys, and the with/without-OTP code paths. The expected hex was computed **independently** of this implementation via Node's built-in `node:crypto` (X25519 + `hkdfSync`), reproducing the exact DH order/padding/salt/info — provenance is documented in a comment in the test. (Full TS-runtime interop is deferred to #48.)
- Raw pre-key signature verification: accepts a valid signature, rejects missing/wrong-identity/tampered/malformed cases.

Result: `113 passed, 2 skipped` — total coverage 92.58% (gate ≥80%); `x3dh.py` at 100%.

Closes #44
Part of #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)