### PR TITLE
fix(website): advertise encryption key when wallet has no agent card (#60)

### DIFF
--- a/website/src/common/encryption-discovery.test.ts
+++ b/website/src/common/encryption-discovery.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import {
+	TinyPlaceError,
+	type AgentCard,
+	type TinyPlaceClient,
+} from "@tinyhumansai/tinyplace";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	ENCRYPTION_PUBLIC_KEY_METADATA,
+	publishEncryptionKey,
+} from "./encryption-discovery";
+
+const AGENT_ID = "61KcG5aGLqpnJz2fn4tujFKAdzqsdGR9XqiUeVoT3vPg";
+const ENC_KEY = "B9LckBJOrJEncryptionPublicKeyBase64z6QEU=";
+
+function makeUpsert(): ReturnType<
+	typeof vi.fn<(id: string, card: AgentCard) => Promise<AgentCard>>
+> {
+	return vi.fn(
+		(_id: string, card: AgentCard): Promise<AgentCard> => Promise.resolve(card)
+	);
+}
+
+function clientWith(getAgent: () => Promise<AgentCard>): {
+	client: TinyPlaceClient;
+	upsert: ReturnType<typeof makeUpsert>;
+} {
+	const upsert = makeUpsert();
+	const client = {
+		directory: { getAgent: vi.fn(getAgent), upsertAgent: upsert },
+	} as unknown as TinyPlaceClient;
+	return { client, upsert };
+}
+
+describe("publishEncryptionKey", () => {
+	it("creates a minimal card when the wallet has no agent card (404)", async () => {
+		const { client, upsert } = clientWith(() => {
+			throw new TinyPlaceError(404, { error: "not found" });
+		});
+
+		await publishEncryptionKey(client, AGENT_ID, ENC_KEY);
+
+		expect(upsert).toHaveBeenCalledTimes(1);
+		const card = upsert.mock.lastCall?.[1];
+		expect(card?.agentId).toBe(AGENT_ID);
+		expect(card?.cryptoId).toBe(AGENT_ID);
+		expect(card?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA]).toBe(ENC_KEY);
+	});
+
+	it("preserves an existing card and adds the encryption key", async () => {
+		const existing: AgentCard = {
+			agentId: AGENT_ID,
+			name: "Atlas",
+			cryptoId: AGENT_ID,
+			metadata: { homepage: "https://example.com" },
+			createdAt: "2026-01-01T00:00:00Z",
+			updatedAt: "2026-01-01T00:00:00Z",
+		};
+		const { client, upsert } = clientWith(() => Promise.resolve(existing));
+
+		await publishEncryptionKey(client, AGENT_ID, ENC_KEY);
+
+		const card = upsert.mock.lastCall?.[1];
+		expect(card?.name).toBe("Atlas");
+		expect(card?.metadata?.["homepage"]).toBe("https://example.com");
+		expect(card?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA]).toBe(ENC_KEY);
+	});
+
+	it("is a no-op when the key is already advertised", async () => {
+		const existing: AgentCard = {
+			agentId: AGENT_ID,
+			name: "Atlas",
+			cryptoId: AGENT_ID,
+			metadata: { [ENCRYPTION_PUBLIC_KEY_METADATA]: ENC_KEY },
+			createdAt: "2026-01-01T00:00:00Z",
+			updatedAt: "2026-01-01T00:00:00Z",
+		};
+		const { client, upsert } = clientWith(() => Promise.resolve(existing));
+
+		await publishEncryptionKey(client, AGENT_ID, ENC_KEY);
+
+		expect(upsert).not.toHaveBeenCalled();
+	});
+
+	it("rethrows non-404 errors", async () => {
+		const { client } = clientWith(() => {
+			throw new TinyPlaceError(500, { error: "boom" });
+		});
+
+		await expect(
+			publishEncryptionKey(client, AGENT_ID, ENC_KEY)
+		).rejects.toBeInstanceOf(TinyPlaceError);
+	});
+});

--- a/website/src/common/encryption-discovery.test.ts
+++ b/website/src/common/encryption-discovery.test.ts
@@ -44,6 +44,7 @@ describe("publishEncryptionKey", () => {
 		expect(upsert).toHaveBeenCalledTimes(1);
 		const card = upsert.mock.lastCall?.[1];
 		expect(card?.agentId).toBe(AGENT_ID);
+		expect(card?.name).toBe(AGENT_ID);
 		expect(card?.cryptoId).toBe(AGENT_ID);
 		expect(card?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA]).toBe(ENC_KEY);
 	});

--- a/website/src/common/encryption-discovery.ts
+++ b/website/src/common/encryption-discovery.ts
@@ -1,4 +1,8 @@
-import type { AgentCard, TinyPlaceClient } from "@tinyhumansai/tinyplace";
+import {
+	TinyPlaceError,
+	type AgentCard,
+	type TinyPlaceClient,
+} from "@tinyhumansai/tinyplace";
 
 /** Agent-card metadata key under which the Signal encryption pubkey is advertised. */
 export const ENCRYPTION_PUBLIC_KEY_METADATA = "encryptionPublicKey";
@@ -34,23 +38,47 @@ export function resolveEncryptionAddress(card: AgentCard): string {
  * @param walletClient - A client authenticated with the wallet (directory-write).
  * @param walletAgentId - The wallet's agent id (the card to update).
  * @param encryptionPublicKey - The derived encryption public key (base64).
- * @throws If the card cannot be read or written. Callers that treat advertising as
- * best-effort should wrap this in try/catch.
+ * @throws If the card cannot be read or written (other than a 404, which is
+ * handled by creating a new card). Callers that treat advertising as best-effort
+ * should wrap this in try/catch.
  */
 export async function publishEncryptionKey(
 	walletClient: TinyPlaceClient,
 	walletAgentId: string,
 	encryptionPublicKey: string
 ): Promise<void> {
-	const card = await walletClient.directory.getAgent(walletAgentId);
-	const metadata = { ...card.metadata };
-	if (metadata[ENCRYPTION_PUBLIC_KEY_METADATA] === encryptionPublicKey) {
+	// A wallet that owns @handles but has never created a directory agent card
+	// 404s here. That's the common case for a human web user, so treat it as
+	// "no card yet" and create a minimal one rather than failing — otherwise the
+	// encryption key is never advertised and peers can't discover where to send
+	// this wallet encrypted messages.
+	let card: AgentCard | undefined;
+	try {
+		card = await walletClient.directory.getAgent(walletAgentId);
+	} catch (error) {
+		if (!(error instanceof TinyPlaceError) || error.status !== 404) {
+			throw error;
+		}
+	}
+
+	if (
+		card?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA] === encryptionPublicKey
+	) {
 		return;
 	}
-	metadata[ENCRYPTION_PUBLIC_KEY_METADATA] = encryptionPublicKey;
-	await walletClient.directory.upsertAgent(walletAgentId, {
+
+	const now = new Date().toISOString();
+	const next: AgentCard = {
+		agentId: walletAgentId,
+		name: walletAgentId,
+		cryptoId: walletAgentId,
+		createdAt: now,
 		...card,
-		metadata,
-		updatedAt: new Date().toISOString(),
-	});
+		metadata: {
+			...card?.metadata,
+			[ENCRYPTION_PUBLIC_KEY_METADATA]: encryptionPublicKey,
+		},
+		updatedAt: now,
+	};
+	await walletClient.directory.upsertAgent(walletAgentId, next);
 }


### PR DESCRIPTION
## Problem (found via live testing)

Enabling encrypted messaging silently failed to advertise the encryption public key for any wallet without a directory agent card — the common case for a human web user (owns `@handle`s, not a registered agent). Console showed:

```
[warn] Failed to advertise encryption key: TinyPlaceError: HTTP 404: /directory/agents/<wallet>
```

`publishEncryptionKey` did `directory.getAgent(walletAgentId)` and threw on the 404; the caller treats advertising as best-effort and swallows it, so the key was never published → **peers can't discover where to send this wallet encrypted DMs.**

## Fix

`encryption-discovery.ts`: catch the 404 and create a **minimal agent card** (`agentId`/`name`/`cryptoId` + `encryptionPublicKey` in metadata) instead of failing. Preserve an existing card when present; keep the no-op when already advertised; rethrow non-404 errors.

## Tests

New `encryption-discovery.test.ts` (4 cases): 404 → creates minimal card; existing card → preserves + adds key; already-advertised → no-op; non-404 → rethrows.

## Validation (`website/`)

- `tsc --noEmit` ✅ · `eslint` ✅ · `prettier --check` ✅ · `vitest` ✅ (4/4)

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for encryption key publishing to gracefully handle missing directory agent cards.

* **Tests**
  * Added comprehensive test suite for encryption key publishing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->