### PR TITLE
feat(sdk/rust): add lottery.stream() and rooms.stream() (complete WS parity, #53)

### DIFF
--- a/sdk/rust/src/api/lottery.rs
+++ b/sdk/rust/src/api/lottery.rs
@@ -117,4 +117,9 @@ impl LotteryApi {
             None => self.http.post_directory_auth(&path, request).await,
         }
     }
+
+    /// Open the lottery's real-time WebSocket stream (snapshot + `pot_update`).
+    pub fn stream(&self) -> crate::websocket::TinyPlaceWebSocket {
+        self.http.websocket("/lottery/stream", false)
+    }
 }

--- a/sdk/rust/src/api/rooms.rs
+++ b/sdk/rust/src/api/rooms.rs
@@ -270,4 +270,10 @@ impl RoomsApi {
             None => self.http.post_directory_auth(&path, Some(body)).await,
         }
     }
+
+    /// Open a room's real-time WebSocket stream (snapshots + action events).
+    pub fn stream(&self, room_id: &str) -> crate::websocket::TinyPlaceWebSocket {
+        let path = format!("/rooms/{}/stream", crate::util::encode(room_id));
+        self.http.websocket(&path, false)
+    }
 }

--- a/sdk/rust/tests/websocket.rs
+++ b/sdk/rust/tests/websocket.rs
@@ -72,6 +72,20 @@ async fn ws_stream_query_params_are_included() {
 }
 
 #[tokio::test]
+async fn ws_lottery_stream_url() {
+    let client = client("https://api.example.com", false);
+    let url = client.lottery.stream().signed_url().await.unwrap();
+    assert_eq!(url, "wss://api.example.com/lottery/stream");
+}
+
+#[tokio::test]
+async fn ws_rooms_stream_url() {
+    let client = client("https://api.example.com", false);
+    let url = client.rooms.stream("r1").signed_url().await.unwrap();
+    assert_eq!(url, "wss://api.example.com/rooms/r1/stream");
+}
+
+#[tokio::test]
 async fn ws_connect_recv_send_close_round_trip() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/sdk/rust/tests/websocket.rs
+++ b/sdk/rust/tests/websocket.rs
@@ -86,6 +86,13 @@ async fn ws_rooms_stream_url() {
 }
 
 #[tokio::test]
+async fn ws_rooms_stream_encodes_id() {
+    let client = client("https://api.example.com", false);
+    let url = client.rooms.stream("a b/c").signed_url().await.unwrap();
+    assert_eq!(url, "wss://api.example.com/rooms/a%20b%2Fc/stream");
+}
+
+#[tokio::test]
 async fn ws_connect_recv_send_close_round_trip() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
Completes WebSocket streaming parity. #16 ported 11 of the TS SDK's 13 `stream()` methods and missed two:

- `LotteryApi::stream()` → `/lottery/stream`
- `RoomsApi::stream(room_id)` → `/rooms/{id}/stream`

Both are public streams, added via the existing `HttpClient::websocket(..., false)` plumbing, with signed-URL tests in `tests/websocket.rs`.

## Validation (`sdk/rust/`)
- `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test` ✅ (9 websocket tests)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time WebSocket streaming for lottery updates, including snapshot and pot updates
  * Added real-time WebSocket streaming for room-specific updates via a room stream endpoint
* **Tests**
  * Added WebSocket URL construction tests for lottery and room streaming, including URL-encoding of room identifiers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->