### PR TITLE
feat(sdk/rust): users email verification + registry.export_identity (#54, #55)

### DIFF
--- a/sdk/rust/src/api/registry.rs
+++ b/sdk/rust/src/api/registry.rs
@@ -86,6 +86,11 @@ impl RegistryApi {
             .await
     }
 
+    /// Alias for [`export`]. Mirrors the TS SDK's `exportIdentity`.
+    pub async fn export_identity(&self, name: &str) -> Result<IdentityExport> {
+        self.export(name).await
+    }
+
     /// Update a name's profile visibility flags.
     pub async fn update_profile_visibility(
         &self,

--- a/sdk/rust/src/api/users.rs
+++ b/sdk/rust/src/api/users.rs
@@ -7,7 +7,9 @@ use crate::auth::sign_fresh_canonical_payload;
 use crate::crypto::canonical_payload;
 use crate::error::Result;
 use crate::http::HttpClient;
-use crate::types::{User, UserProfileUpdate};
+use crate::types::{
+    User, UserEmailVerificationConfirmRequest, UserEmailVerificationRequest, UserProfileUpdate,
+};
 use crate::util::encode;
 
 #[derive(Clone)]
@@ -46,6 +48,54 @@ impl UsersApi {
             )
             .await
     }
+
+    /// Start email verification for a wallet. The backend stores the normalized
+    /// email, marks it unverified, and sends a short-lived code. Signs the
+    /// canonical `user.email.start` payload when a signer is configured.
+    pub async fn start_email_verification(
+        &self,
+        crypto_id: &str,
+        request: UserEmailVerificationRequest,
+    ) -> Result<User> {
+        let mut request = request;
+        if request.signature.is_none() {
+            if let Some(signer) = self.http.signer() {
+                let payload = user_email_start_signature_payload(crypto_id, &request);
+                request.signature =
+                    Some(sign_fresh_canonical_payload(signer.as_ref(), &payload).await?);
+            }
+        }
+        self.http
+            .post_directory_auth(
+                &format!("/users/{}/email/verification", encode(crypto_id)),
+                Some(&request),
+            )
+            .await
+    }
+
+    /// Confirm a wallet email verification code. Verification is scoped to the
+    /// signed wallet `cryptoId` (emails are not unique across wallets). Signs the
+    /// canonical `user.email.confirm` payload when a signer is configured.
+    pub async fn confirm_email_verification(
+        &self,
+        crypto_id: &str,
+        request: UserEmailVerificationConfirmRequest,
+    ) -> Result<User> {
+        let mut request = request;
+        if request.signature.is_none() {
+            if let Some(signer) = self.http.signer() {
+                let payload = user_email_confirm_signature_payload(crypto_id, &request);
+                request.signature =
+                    Some(sign_fresh_canonical_payload(signer.as_ref(), &payload).await?);
+            }
+        }
+        self.http
+            .post_directory_auth(
+                &format!("/users/{}/email/verification/confirm", encode(crypto_id)),
+                Some(&request),
+            )
+            .await
+    }
 }
 
 /// Builds the canonical `user.profile` payload signed for a profile update. The
@@ -80,6 +130,46 @@ fn user_profile_signature_payload(crypto_id: &str, update: &UserProfileUpdate) -
             "harnessKey": or_null(&update.harness_key),
             "link": or_null(&update.link),
             "tags": arr_or_null(&update.tags),
+        }),
+    )
+}
+
+/// Maps `Option<&str>` to a JSON string or `null`, matching the TS SDK's
+/// `harnessKey ?? null`.
+fn or_null(value: Option<&str>) -> serde_json::Value {
+    value.map_or(serde_json::Value::Null, |v| {
+        serde_json::Value::String(v.to_string())
+    })
+}
+
+/// Canonical `user.email.start` payload (key order is normalized by
+/// `canonical_payload`, so it matches the TS SDK regardless of field order).
+fn user_email_start_signature_payload(
+    crypto_id: &str,
+    request: &UserEmailVerificationRequest,
+) -> String {
+    canonical_payload(
+        "user.email.start",
+        serde_json::json!({
+            "cryptoId": crypto_id,
+            "email": request.email,
+            "harnessKey": or_null(request.harness_key.as_deref()),
+        }),
+    )
+}
+
+/// Canonical `user.email.confirm` payload.
+fn user_email_confirm_signature_payload(
+    crypto_id: &str,
+    request: &UserEmailVerificationConfirmRequest,
+) -> String {
+    canonical_payload(
+        "user.email.confirm",
+        serde_json::json!({
+            "code": request.code,
+            "cryptoId": crypto_id,
+            "email": request.email,
+            "harnessKey": or_null(request.harness_key.as_deref()),
         }),
     )
 }

--- a/sdk/rust/tests/api_directory_users.rs
+++ b/sdk/rust/tests/api_directory_users.rs
@@ -10,7 +10,8 @@ use common::*;
 use serde_json::json;
 use tinyplace::api::directory::DirectorySkillsParams;
 use tinyplace::types::{
-    AgentCard, AgentQueryParams, ExtendedAgentCard, IdentityListingQueryParams, UserProfileUpdate,
+    AgentCard, AgentQueryParams, ExtendedAgentCard, IdentityListingQueryParams,
+    UserEmailVerificationConfirmRequest, UserEmailVerificationRequest, UserProfileUpdate,
 };
 
 // --- UsersApi ---
@@ -38,6 +39,45 @@ async fn users_update_profile() {
     assert_eq!(req.method.as_str(), "PUT");
     assert!(req.url.path().contains("users"));
     assert!(req.url.path().ends_with("/profile"));
+}
+
+#[tokio::test]
+async fn users_start_email_verification() {
+    let server = any_empty_ok().await;
+    let client = client_for(&server);
+    let _ = client
+        .users
+        .start_email_verification(
+            "cid123",
+            UserEmailVerificationRequest {
+                email: "a@example.com".into(),
+                ..Default::default()
+            },
+        )
+        .await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    assert!(req.url.path().ends_with("/email/verification"));
+}
+
+#[tokio::test]
+async fn users_confirm_email_verification() {
+    let server = any_empty_ok().await;
+    let client = client_for(&server);
+    let _ = client
+        .users
+        .confirm_email_verification(
+            "cid123",
+            UserEmailVerificationConfirmRequest {
+                email: "a@example.com".into(),
+                code: "123456".into(),
+                ..Default::default()
+            },
+        )
+        .await;
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    assert!(req.url.path().ends_with("/email/verification/confirm"));
 }
 
 // --- ProfilesApi ---

--- a/sdk/rust/tests/api_registry.rs
+++ b/sdk/rust/tests/api_registry.rs
@@ -55,6 +55,15 @@ async fn registry_export() {
 }
 
 #[tokio::test]
+async fn registry_export_identity() {
+    let server = any_empty_ok().await;
+    let client = client_for(&server);
+    let _ = client.registry.export_identity("@alice").await;
+    let req = only_request(&server).await;
+    assert!(req.url.path().ends_with("/export"));
+}
+
+#[tokio::test]
 async fn registry_update_profile_visibility() {
     let server = any_empty_ok().await;
     let client = client_for(&server);


### PR DESCRIPTION
Two TS-parity gaps found in the re-audit:

- **#54** — `UsersApi::start_email_verification` / `confirm_email_verification`. POSTs the signed `user.email.start` / `user.email.confirm` canonical payloads (the request types already existed; mirrors the TS signing flow via `sign_fresh_canonical_payload`).
- **#55** — `RegistryApi::export_identity`, the alias the TS SDK exposes alongside `export`.

Wiremock tests added for all three (method + path).

## Validation (`sdk/rust/`)
- `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test` ✅

Closes #54
Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)