### PR TITLE
feat(sdk/python): Signal Sender Keys (group messaging) (#47)

### DIFF
--- a/sdk/python/src/tinyplace/signal/__init__.py
+++ b/sdk/python/src/tinyplace/signal/__init__.py
@@ -49,6 +49,12 @@ from .keys import (
     verify_pre_key_signature,
 )
 from .memory_store import MemorySessionStore
+from .sender_key import (
+    GroupSenderKey,
+    GroupSenderKeyReceiver,
+    SenderKeyDistribution,
+    SenderKeyMessage,
+)
 from .ratchet import (
     MAX_SKIP,
     RatchetHeader,
@@ -124,6 +130,11 @@ __all__ = [
     "encode_header",
     "ratchet_encrypt",
     "ratchet_decrypt",
+    # sender keys (group messaging)
+    "GroupSenderKey",
+    "GroupSenderKeyReceiver",
+    "SenderKeyDistribution",
+    "SenderKeyMessage",
     # 1:1 session layer
     "EncryptedMessage",
     "SignalSession",

--- a/sdk/python/src/tinyplace/signal/sender_key.py
+++ b/sdk/python/src/tinyplace/signal/sender_key.py
@@ -1,0 +1,266 @@
+"""Sender Keys (group messaging) for the tiny.place Signal Protocol port.
+
+A byte-compatible Python port of the TypeScript SDK's
+``sdk/typescript/src/signal/sender-key.ts``. Implements both halves of the
+Signal Sender Key construction used for efficient group messaging:
+
+* :class:`GroupSenderKey` — the **sending** half. A symmetric chain key
+  ratcheted once per message (via :func:`~tinyplace.signal.crypto.kdf_chain_key`)
+  plus an Ed25519 signing key pair that signs every ciphertext so receivers can
+  attribute it to this sender. One instance per (group, sender, membership
+  epoch); a membership change means a fresh key (rotation).
+* :class:`GroupSenderKeyReceiver` — the **receiving** half. Holds another
+  member's chain key and their Ed25519 signature public key, derived from a
+  :class:`SenderKeyDistribution`. Verifies the signature first, then decrypts,
+  tolerating out-of-order delivery by caching skipped message keys (capped at
+  :data:`MAX_SKIP`).
+
+Both halves persist through the store's
+:class:`~tinyplace.signal.store.SenderKeyState` record (own = has a
+``signing_private_key``; receiver = ``signing_public_key`` + ``skipped_keys``).
+
+Every algorithmic choice mirrors the reference so a group message produced by
+one SDK can be consumed by the other:
+
+* Chain ratchet: HMAC-SHA256 (:func:`~tinyplace.signal.crypto.kdf_chain_key`).
+* Message AEAD: AES-256-CBC + HMAC-SHA256 with **empty** associated data
+  (:func:`~tinyplace.signal.crypto.encrypt`); the Ed25519 signature over the
+  raw ciphertext bytes authenticates the sender.
+
+The crypto primitives are reused verbatim from
+:mod:`tinyplace.signal.crypto`; this module never reimplements crypto.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from .crypto import (
+    decrypt,
+    ed25519_keypair_from_seed,
+    ed25519_sign,
+    ed25519_verify,
+    encrypt,
+    from_base64,
+    kdf_chain_key,
+    to_base64,
+)
+from .store import SenderKeyState
+
+__all__ = [
+    "MAX_SKIP",
+    "SenderKeyDistribution",
+    "SenderKeyMessage",
+    "GroupSenderKey",
+    "GroupSenderKeyReceiver",
+]
+
+# Cap on how far a receiver will fast-forward to reach an out-of-order message.
+# Mirrors ``MAX_SKIP`` in sender-key.ts.
+MAX_SKIP = 2000
+
+# Group sender-key messages carry no extra associated data; the Ed25519
+# signature authenticates the sender. Mirrors ``EMPTY_AD`` in sender-key.ts.
+_EMPTY_AD = b""
+
+
+@dataclass
+class SenderKeyDistribution:
+    """Public, distributable snapshot of a sender's group key.
+
+    This is what a sender shares — over an already-secure 1:1 channel — so other
+    members can decrypt its group messages. It exposes the chain key at a single
+    iteration; a receiver initialised from it can read messages from that
+    iteration forward (earlier messages stay secret, by forward secrecy).
+
+    Mirrors the TypeScript ``SenderKeyDistribution`` interface (base64 fields).
+    """
+
+    chain_key: str
+    iteration: int
+    signature_public_key: str
+
+
+@dataclass
+class SenderKeyMessage:
+    """A single encrypted group message produced by a :class:`GroupSenderKey`.
+
+    Mirrors the TypeScript ``SenderKeyMessage`` interface (base64 fields).
+    """
+
+    iteration: int
+    ciphertext: str
+    signature: str
+
+
+class GroupSenderKey:
+    """The sending half of a Signal Sender Key.
+
+    A symmetric chain key ratcheted once per message, plus an Ed25519 key pair
+    that signs every message so receivers can attribute it to this sender. One
+    instance per (group, sender, membership epoch); a new epoch (membership
+    change) means a fresh key.
+    """
+
+    def __init__(
+        self,
+        chain_key: bytes,
+        iteration: int,
+        signing_seed: bytes,
+        signing_public_key: bytes,
+    ) -> None:
+        self._chain_key = chain_key
+        self._iteration = iteration
+        # 32-byte Ed25519 seed (libsodium "secret key" produced by
+        # ``randomSecretKey()`` in the reference). ``ed25519_sign`` accepts the
+        # seed directly.
+        self._signing_seed = signing_seed
+        self._signing_public_key = signing_public_key
+
+    @classmethod
+    def create(cls) -> GroupSenderKey:
+        """Generate a brand-new sender key with a random chain key and signing pair."""
+        chain_key = os.urandom(32)
+        signing_seed = os.urandom(32)
+        signing_public_key, _secret = ed25519_keypair_from_seed(signing_seed)
+        return cls(chain_key, 0, signing_seed, signing_public_key)
+
+    @classmethod
+    def restore(cls, state: SenderKeyState) -> GroupSenderKey:
+        """Rebuild a sender key from a :class:`SenderKeyState` (own half).
+
+        Raises:
+            ValueError: if ``state`` carries no ``signing_private_key`` (i.e. it
+                is a receiver record, which cannot sign).
+        """
+        if state.signing_private_key is None:
+            raise ValueError("SenderKeyState has no signing_private_key (not an own key)")
+        return cls(
+            state.chain_key,
+            state.iteration,
+            state.signing_private_key,
+            state.signing_public_key,
+        )
+
+    @property
+    def current_iteration(self) -> int:
+        """The current message number (advances after each :meth:`encrypt`)."""
+        return self._iteration
+
+    def serialize(self, distribution_id: str) -> SenderKeyState:
+        """Persistable snapshot including the private signing seed. Keep secret."""
+        return SenderKeyState(
+            distribution_id=distribution_id,
+            chain_key=self._chain_key,
+            iteration=self._iteration,
+            signing_public_key=self._signing_public_key,
+            signing_private_key=self._signing_seed,
+        )
+
+    def distribution(self) -> SenderKeyDistribution:
+        """Snapshot to hand to other members so they can decrypt from here forward."""
+        return SenderKeyDistribution(
+            chain_key=to_base64(self._chain_key),
+            iteration=self._iteration,
+            signature_public_key=to_base64(self._signing_public_key),
+        )
+
+    def encrypt(self, plaintext: bytes) -> SenderKeyMessage:
+        """Encrypt and sign one group message, ratcheting the chain forward."""
+        iteration = self._iteration
+        chain_key, message_key = kdf_chain_key(self._chain_key)
+        ciphertext = encrypt(message_key, plaintext, _EMPTY_AD)
+        signature = ed25519_sign(self._signing_seed, ciphertext)
+        self._chain_key = chain_key
+        self._iteration = iteration + 1
+        return SenderKeyMessage(
+            iteration=iteration,
+            ciphertext=to_base64(ciphertext),
+            signature=to_base64(signature),
+        )
+
+
+class GroupSenderKeyReceiver:
+    """The receiving half of a Sender Key.
+
+    Holds another member's chain key and their signature public key, derived
+    from a :class:`SenderKeyDistribution`. Verifies and decrypts that sender's
+    group messages, tolerating out-of-order delivery by caching skipped message
+    keys.
+    """
+
+    def __init__(
+        self,
+        chain_key: bytes,
+        iteration: int,
+        signing_public_key: bytes,
+        skipped: dict[int, bytes] | None = None,
+    ) -> None:
+        self._chain_key = chain_key
+        self._iteration = iteration
+        self._signing_public_key = signing_public_key
+        self._skipped: dict[int, bytes] = skipped if skipped is not None else {}
+
+    @classmethod
+    def from_distribution(
+        cls, distribution: SenderKeyDistribution
+    ) -> GroupSenderKeyReceiver:
+        """Initialise a receiver from a sender's distribution snapshot."""
+        return cls(
+            from_base64(distribution.chain_key),
+            distribution.iteration,
+            from_base64(distribution.signature_public_key),
+            {},
+        )
+
+    @classmethod
+    def restore(cls, state: SenderKeyState) -> GroupSenderKeyReceiver:
+        """Rebuild a receiver from a :class:`SenderKeyState` (receiver half)."""
+        return cls(
+            state.chain_key,
+            state.iteration,
+            state.signing_public_key,
+            dict(state.skipped_keys),
+        )
+
+    def serialize(self, distribution_id: str) -> SenderKeyState:
+        """Persistable snapshot of the receiver chain and any cached skipped keys."""
+        return SenderKeyState(
+            distribution_id=distribution_id,
+            chain_key=self._chain_key,
+            iteration=self._iteration,
+            signing_public_key=self._signing_public_key,
+            signing_private_key=None,
+            skipped_keys=dict(self._skipped),
+        )
+
+    def decrypt(self, message: SenderKeyMessage) -> bytes:
+        """Verify the signature, then decrypt the message at its iteration."""
+        ciphertext = from_base64(message.ciphertext)
+        signature = from_base64(message.signature)
+        if not ed25519_verify(self._signing_public_key, ciphertext, signature):
+            raise ValueError("Sender key signature verification failed")
+        message_key = self._message_key_for(message.iteration)
+        return decrypt(message_key, ciphertext, _EMPTY_AD)
+
+    def _message_key_for(self, target: int) -> bytes:
+        """Return the message key for ``target``, advancing the chain and caching
+        keys for any skipped (not-yet-seen) iterations along the way.
+        """
+        cached = self._skipped.pop(target, None)
+        if cached is not None:
+            return cached
+        if target < self._iteration:
+            raise ValueError("Sender key message is older than the current chain")
+        if target - self._iteration > MAX_SKIP:
+            raise ValueError("Too many skipped sender key messages")
+        while self._iteration < target:
+            chain_key, message_key = kdf_chain_key(self._chain_key)
+            self._skipped[self._iteration] = message_key
+            self._chain_key = chain_key
+            self._iteration += 1
+        chain_key, message_key = kdf_chain_key(self._chain_key)
+        self._chain_key = chain_key
+        self._iteration += 1
+        return message_key

--- a/sdk/python/tests/test_signal_sender_key.py
+++ b/sdk/python/tests/test_signal_sender_key.py
@@ -1,0 +1,323 @@
+"""Tests for the Signal Sender Key port (:mod:`tinyplace.signal.sender_key`).
+
+Covers the group-messaging flow: a sender's distribution snapshot fanning out
+to multiple receivers, iteration advance, out-of-order / skipped delivery,
+Ed25519 signature-verification rejection (forged / tampered messages),
+serialize/restore round-trips through :class:`SenderKeyState` (both halves),
+membership-change rotation (a fresh key supersedes the old), and a fixed
+known-answer (KAT) interop vector pinning the exact ciphertext / signature
+bytes for a deterministic encrypt step.
+
+Full TS-runtime interop is tracked separately (#48); the KAT here is derived
+independently from the crypto primitives (see ``test_known_answer_vector``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tinyplace.signal.crypto import (
+    ed25519_keypair_from_seed,
+    encrypt,
+    from_base64,
+    kdf_chain_key,
+    to_base64,
+)
+from tinyplace.signal.memory_store import MemorySessionStore
+from tinyplace.signal.sender_key import (
+    MAX_SKIP,
+    GroupSenderKey,
+    GroupSenderKeyReceiver,
+    SenderKeyDistribution,
+    SenderKeyMessage,
+)
+from tinyplace.signal.store import SenderKeyState, X25519KeyPair
+
+DISTRIBUTION_ID = "group-1:alice"
+
+
+def _receiver_from(sender: GroupSenderKey) -> GroupSenderKeyReceiver:
+    return GroupSenderKeyReceiver.from_distribution(sender.distribution())
+
+
+# --------------------------------------------------------------------------
+# Send -> all receivers decrypt; iteration advances.
+# --------------------------------------------------------------------------
+
+
+def test_send_fans_out_to_all_receivers() -> None:
+    sender = GroupSenderKey.create()
+    # Each member initialises its own receiver from the same distribution.
+    receivers = [_receiver_from(sender) for _ in range(3)]
+
+    plaintext = b"hello group"
+    message = sender.encrypt(plaintext)
+
+    for receiver in receivers:
+        assert receiver.decrypt(message) == plaintext
+
+
+def test_iteration_advances_per_message() -> None:
+    sender = GroupSenderKey.create()
+    receiver = _receiver_from(sender)
+
+    assert sender.current_iteration == 0
+    messages = []
+    for index in range(4):
+        message = sender.encrypt(f"msg-{index}".encode())
+        assert message.iteration == index
+        messages.append(message)
+    assert sender.current_iteration == 4
+
+    for index, message in enumerate(messages):
+        assert receiver.decrypt(message) == f"msg-{index}".encode()
+
+
+# --------------------------------------------------------------------------
+# Out-of-order / skipped delivery.
+# --------------------------------------------------------------------------
+
+
+def test_out_of_order_delivery() -> None:
+    sender = GroupSenderKey.create()
+    receiver = _receiver_from(sender)
+
+    m0 = sender.encrypt(b"zero")
+    m1 = sender.encrypt(b"one")
+    m2 = sender.encrypt(b"two")
+
+    # Deliver 2, then 0, then 1 — the receiver caches skipped keys.
+    assert receiver.decrypt(m2) == b"two"
+    assert receiver.decrypt(m0) == b"zero"
+    assert receiver.decrypt(m1) == b"one"
+
+
+def test_replayed_or_too_old_message_rejected() -> None:
+    sender = GroupSenderKey.create()
+    receiver = _receiver_from(sender)
+
+    m0 = sender.encrypt(b"zero")
+    m1 = sender.encrypt(b"one")
+
+    assert receiver.decrypt(m0) == b"zero"
+    assert receiver.decrypt(m1) == b"one"
+    # m0 is now behind the chain head and no longer cached.
+    with pytest.raises(ValueError, match="older than the current chain"):
+        receiver.decrypt(m0)
+
+
+def test_too_many_skipped_rejected() -> None:
+    sender = GroupSenderKey.create()
+    receiver = _receiver_from(sender)
+
+    # Forge a message claiming an iteration far beyond MAX_SKIP. Re-sign with
+    # the sender's real key so we exercise the skip cap, not signature checks.
+    far = sender.encrypt(b"first")  # iteration 0
+    forged = SenderKeyMessage(
+        iteration=MAX_SKIP + 5,
+        ciphertext=far.ciphertext,
+        signature=far.signature,
+    )
+    with pytest.raises(ValueError, match="Too many skipped"):
+        receiver.decrypt(forged)
+
+
+# --------------------------------------------------------------------------
+# Signature-verification rejection.
+# --------------------------------------------------------------------------
+
+
+def test_tampered_ciphertext_rejected() -> None:
+    sender = GroupSenderKey.create()
+    receiver = _receiver_from(sender)
+
+    message = sender.encrypt(b"authentic")
+    raw = bytearray(from_base64(message.ciphertext))
+    raw[0] ^= 0x01
+    tampered = SenderKeyMessage(
+        iteration=message.iteration,
+        ciphertext=to_base64(bytes(raw)),
+        signature=message.signature,
+    )
+    with pytest.raises(ValueError, match="signature verification failed"):
+        receiver.decrypt(tampered)
+
+
+def test_forged_signature_from_wrong_key_rejected() -> None:
+    sender = GroupSenderKey.create()
+    receiver = _receiver_from(sender)
+
+    message = sender.encrypt(b"authentic")
+    # An attacker re-signs the same ciphertext with a different (wrong) key.
+    attacker = GroupSenderKey.create()
+    attacker_sig = attacker.encrypt(b"throwaway")  # any sig from wrong key
+    forged = SenderKeyMessage(
+        iteration=message.iteration,
+        ciphertext=message.ciphertext,
+        signature=attacker_sig.signature,
+    )
+    with pytest.raises(ValueError, match="signature verification failed"):
+        receiver.decrypt(forged)
+
+
+# --------------------------------------------------------------------------
+# Serialize / restore round-trip through SenderKeyState (both halves).
+# --------------------------------------------------------------------------
+
+
+def test_own_serialize_restore_round_trip() -> None:
+    sender = GroupSenderKey.create()
+    sender.encrypt(b"warm up")  # advance to iteration 1
+
+    state = sender.serialize(DISTRIBUTION_ID)
+    assert isinstance(state, SenderKeyState)
+    assert state.distribution_id == DISTRIBUTION_ID
+    assert state.signing_private_key is not None
+    assert state.iteration == 1
+
+    restored = GroupSenderKey.restore(state)
+    assert restored.current_iteration == sender.current_iteration
+
+    # The restored sender continues the exact same chain: its iteration-1
+    # output is byte-identical to what the original would have produced, and a
+    # receiver seeded from the (iteration-1) distribution decrypts it.
+    receiver = _receiver_from(restored)
+    message = restored.encrypt(b"after restore")
+    assert message.iteration == 1
+    assert receiver.decrypt(message) == b"after restore"
+
+
+def test_restore_own_without_private_key_rejected() -> None:
+    receiver_state = SenderKeyState(
+        distribution_id=DISTRIBUTION_ID,
+        chain_key=b"\x00" * 32,
+        iteration=0,
+        signing_public_key=b"\x00" * 32,
+        signing_private_key=None,
+    )
+    with pytest.raises(ValueError, match="no signing_private_key"):
+        GroupSenderKey.restore(receiver_state)
+
+
+def test_receiver_serialize_restore_round_trip_preserves_skipped() -> None:
+    sender = GroupSenderKey.create()
+    receiver = _receiver_from(sender)
+
+    m0 = sender.encrypt(b"zero")
+    m1 = sender.encrypt(b"one")
+    m2 = sender.encrypt(b"two")
+
+    # Decrypt out of order so the receiver caches a skipped key for iteration 1.
+    assert receiver.decrypt(m0) == b"zero"
+    assert receiver.decrypt(m2) == b"two"
+
+    state = receiver.serialize(DISTRIBUTION_ID)
+    assert state.signing_private_key is None
+    assert 1 in state.skipped_keys  # iteration 1 cached while waiting
+
+    restored = GroupSenderKeyReceiver.restore(state)
+    # The restored receiver can still decrypt the previously-skipped message.
+    assert restored.decrypt(m1) == b"one"
+
+
+async def test_round_trip_through_memory_store() -> None:
+    identity = X25519KeyPair(public_key=b"\x01" * 32, private_key=b"\x02" * 32)
+    store = MemorySessionStore(identity)
+
+    sender = GroupSenderKey.create()
+    # Snapshot the receiver distribution BEFORE encrypting (iteration 0).
+    receiver = _receiver_from(sender)
+    message = sender.encrypt(b"persisted")
+    await store.store_sender_key(sender.serialize(DISTRIBUTION_ID))
+
+    loaded = await store.get_sender_key(DISTRIBUTION_ID)
+    assert loaded is not None
+    restored = GroupSenderKey.restore(loaded)
+    assert restored.current_iteration == 1
+
+    # A receiver persisted and reloaded also works.
+    receiver_id = "group-1:alice:recv"
+    rstate = receiver.serialize(receiver_id)
+    rstate.distribution_id = receiver_id
+    await store.store_sender_key(rstate)
+    rloaded = await store.get_sender_key(receiver_id)
+    assert rloaded is not None
+    rrestored = GroupSenderKeyReceiver.restore(rloaded)
+    assert rrestored.decrypt(message) == b"persisted"
+
+
+# --------------------------------------------------------------------------
+# Membership-change rotation.
+# --------------------------------------------------------------------------
+
+
+def test_rotation_supersedes_old_key() -> None:
+    old = GroupSenderKey.create()
+    old_receiver = _receiver_from(old)
+    old_message = old.encrypt(b"before rotation")
+    assert old_receiver.decrypt(old_message) == b"before rotation"
+
+    # Membership changes -> a fresh sender key with a new chain + signing pair.
+    new = GroupSenderKey.create()
+    assert new.distribution().chain_key != old.distribution().chain_key
+    assert (
+        new.distribution().signature_public_key
+        != old.distribution().signature_public_key
+    )
+
+    new_receiver = _receiver_from(new)
+    new_message = new.encrypt(b"after rotation")
+    assert new_receiver.decrypt(new_message) == b"after rotation"
+
+    # The old receiver must NOT be able to verify messages from the new key
+    # (different signing key) — confirming the rotation is a clean break.
+    with pytest.raises(ValueError, match="signature verification failed"):
+        old_receiver.decrypt(new_message)
+
+
+# --------------------------------------------------------------------------
+# Known-answer (KAT) interop vector.
+# --------------------------------------------------------------------------
+
+
+def test_known_answer_vector() -> None:
+    """Pin exact bytes for a deterministic encrypt step.
+
+    Provenance: derived independently from the Python crypto primitives with a
+    fixed chain key (0x00..0x1f) and a fixed Ed25519 seed (0xAA * 32). These
+    are the same primitives the TypeScript reference uses, so the values double
+    as an interop anchor for the full TS-runtime check tracked in #48.
+    """
+    chain_key = bytes(range(32))
+    seed = bytes([0xAA]) * 32
+    public_key, _secret = ed25519_keypair_from_seed(seed)
+
+    expected_public_key = "5zTqbCtiV95yNV5HKqBaTEh+a0Y8Ap7TBt8vAbVja1g="
+    expected_ciphertext = "HniLoazpN9WdAhgLPPQ42eJ3igUSDfZe"
+    expected_signature = (
+        "gmQ/bDL9DZHibIw3auk5SqcXnTsoXSd6CuC/r18EjQQR"
+        "MwMVnSfLib4QUKlAi1QJq6G/rXdNo2usolazizAXBA=="
+    )
+    assert to_base64(public_key) == expected_public_key
+
+    # Drive the sending half through this exact state and pin the output.
+    sender = GroupSenderKey(chain_key, 0, seed, public_key)
+    message = sender.encrypt(b"hello group")
+    assert message.iteration == 0
+    assert message.ciphertext == expected_ciphertext
+    assert message.signature == expected_signature
+    assert sender.current_iteration == 1
+
+    # Cross-check the primitives produced the same bytes directly.
+    _ck, message_key = kdf_chain_key(chain_key)
+    assert to_base64(encrypt(message_key, b"hello group", b"")) == expected_ciphertext
+
+    # A receiver seeded with the same distribution decrypts it.
+    receiver = GroupSenderKeyReceiver.from_distribution(
+        SenderKeyDistribution(
+            chain_key=to_base64(chain_key),
+            iteration=0,
+            signature_public_key=to_base64(public_key),
+        )
+    )
+    assert receiver.decrypt(message) == b"hello group"


### PR DESCRIPTION
## What this ports

A byte-compatible Python port of `sdk/typescript/src/signal/sender-key.ts`, adding Signal **Sender Keys** (group messaging) to the Python SDK. Implements both halves of the construction:

- **`GroupSenderKey` (sending half)** — `create()` (random 32-byte chain key + Ed25519 signing pair), `serialize`/`restore`, `distribution()` snapshot (chain key + iteration + signing public key), and `encrypt(plaintext)` which ratchets the chain once (`kdf_chain_key`), AEADs with **empty** associated data, **Ed25519-signs the ciphertext**, and advances the iteration.
- **`GroupSenderKeyReceiver` (receiving half)** — `from_distribution`, `serialize`/`restore`, and `decrypt(message)` which **verifies the Ed25519 signature first**, then derives the message key, tolerating out-of-order delivery via a skipped-key cache (`MAX_SKIP = 2000`).

Both halves persist through the store's `SenderKeyState` (own = has `signing_private_key`; receiver = `signing_public_key` + `skipped_keys`). All crypto is reused verbatim from `tinyplace.signal.crypto` — no crypto is reimplemented.

## Files

- `sdk/python/src/tinyplace/signal/sender_key.py` (new)
- `sdk/python/tests/test_signal_sender_key.py` (new)
- `sdk/python/src/tinyplace/signal/__init__.py` (exports)

## Tests

Covers: send → all-receivers-decrypt; iteration advance; out-of-order/skipped delivery; replay/too-old and too-many-skipped (`MAX_SKIP`) rejection; **signature-verification rejection** (tampered ciphertext + forged signature from a wrong key); serialize/restore round-trips for both halves (including through `MemorySessionStore`, preserving cached skipped keys); membership-change **rotation** (a fresh key supersedes the old, old receiver rejects new-key messages); and a deterministic **known-answer interop vector** pinning the exact ciphertext/signature bytes (provenance noted in-test). Full TS-runtime interop is tracked separately in #48.

```
154 passed, 2 skipped in 1.00s
Required test coverage of 80% reached. Total coverage: 93.89%
```
(`sender_key.py` at 100% line/branch coverage.)

Closes #47
Part of #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)