### PR TITLE
feat(sdk/rust): Signal crypto primitives (part 1 of #18)

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -25,6 +25,16 @@ async-trait = "0.1"
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 
+# Signal protocol (E2E encryption) primitives. Algorithms chosen to be
+# byte-compatible with the TS/Python SDKs: X25519 ECDH, HKDF/HMAC-SHA256,
+# AES-256-CBC + HMAC-SHA256 Encrypt-then-MAC.
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+curve25519-dalek = "4"
+hkdf = "0.12"
+hmac = "0.12"
+aes = "0.8"
+cbc = { version = "0.1", features = ["alloc"] }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 wiremock = "0.6"

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -27,6 +27,7 @@ pub mod auth;
 pub mod crypto;
 pub mod error;
 pub mod http;
+pub mod signal;
 pub mod signer;
 pub mod util;
 pub mod websocket;

--- a/sdk/rust/src/signal/crypto.rs
+++ b/sdk/rust/src/signal/crypto.rs
@@ -1,0 +1,199 @@
+//! Signal protocol crypto primitives. Mirrors `sdk/typescript/src/signal/crypto.ts`
+//! and the Python port, kept byte-compatible for cross-language interop:
+//!
+//! - **DH:** X25519 (Curve25519)
+//! - **Conversions:** Ed25519 seed/pubkey → X25519
+//! - **KDF:** HKDF-SHA256 (root key) + HMAC-SHA256 chain ratchet
+//! - **AEAD:** AES-256-CBC (PKCS#7) + HMAC-SHA256 truncated to 8 bytes,
+//!   Encrypt-then-MAC over `associated_data || ciphertext`.
+
+use aes::Aes256;
+use cbc::cipher::block_padding::Pkcs7;
+use cbc::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use curve25519_dalek::edwards::CompressedEdwardsY;
+use hkdf::Hkdf;
+use hmac::{Hmac, Mac};
+use rand::RngCore as _;
+use sha2::{Digest, Sha256, Sha512};
+use x25519_dalek::{PublicKey, StaticSecret};
+
+use crate::error::{Error, Result};
+
+type HmacSha256 = Hmac<Sha256>;
+
+const HKDF_INFO: &[u8] = b"WhisperRatchet";
+const MESSAGE_KEY_INFO: &[u8] = b"WhisperMessageKeys";
+const CHAIN_KEY_SEED_MESSAGE: &[u8] = &[0x01];
+const CHAIN_KEY_SEED_CHAIN: &[u8] = &[0x02];
+
+/// An X25519 (Curve25519) key pair, raw 32-byte keys.
+#[derive(Debug, Clone)]
+pub struct X25519KeyPair {
+    pub public_key: [u8; 32],
+    pub private_key: [u8; 32],
+}
+
+/// Generate a fresh random X25519 key pair.
+pub fn generate_x25519_keypair() -> X25519KeyPair {
+    let mut private_key = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut private_key);
+    let public_key = x25519_public_key(&private_key);
+    X25519KeyPair {
+        public_key,
+        private_key,
+    }
+}
+
+/// The X25519 public key for a raw private key (clamped basepoint multiply).
+pub fn x25519_public_key(private_key: &[u8; 32]) -> [u8; 32] {
+    let secret = StaticSecret::from(*private_key);
+    PublicKey::from(&secret).to_bytes()
+}
+
+/// Compute the X25519 shared secret for `private_key` and `public_key`.
+pub fn x25519_shared_secret(private_key: &[u8; 32], public_key: &[u8; 32]) -> [u8; 32] {
+    let secret = StaticSecret::from(*private_key);
+    let public = PublicKey::from(*public_key);
+    secret.diffie_hellman(&public).to_bytes()
+}
+
+/// Derive the X25519 private scalar from an Ed25519 seed: `sha512(seed)[..32]`
+/// with the standard Curve25519 clamping.
+pub fn ed25519_seed_to_x25519_private(seed: &[u8; 32]) -> [u8; 32] {
+    let hash = Sha512::digest(seed);
+    let mut scalar = [0u8; 32];
+    scalar.copy_from_slice(&hash[..32]);
+    scalar[0] &= 248;
+    scalar[31] &= 127;
+    scalar[31] |= 64;
+    scalar
+}
+
+/// Derive the X25519 key pair from an Ed25519 seed.
+pub fn ed25519_seed_to_x25519_keypair(seed: &[u8; 32]) -> X25519KeyPair {
+    let private_key = ed25519_seed_to_x25519_private(seed);
+    let public_key = x25519_public_key(&private_key);
+    X25519KeyPair {
+        public_key,
+        private_key,
+    }
+}
+
+/// Convert an Ed25519 public key to the corresponding X25519 (Montgomery)
+/// public key (`u = (1 + y) / (1 - y)`).
+pub fn ed25519_pub_to_x25519_pub(ed_pub: &[u8; 32]) -> Result<[u8; 32]> {
+    let point = CompressedEdwardsY(*ed_pub)
+        .decompress()
+        .ok_or_else(|| Error::InvalidArgument("invalid Ed25519 public key".into()))?;
+    Ok(point.to_montgomery().to_bytes())
+}
+
+/// Derive the next root key and chain key from the current root key and a fresh
+/// DH output. `HKDF-SHA256(ikm = dh_output, salt = root_key, info)`.
+pub fn kdf_root_key(root_key: &[u8], dh_output: &[u8]) -> ([u8; 32], [u8; 32]) {
+    let output = hkdf_sha256(dh_output, Some(root_key), HKDF_INFO, 64);
+    let mut next_root = [0u8; 32];
+    let mut chain = [0u8; 32];
+    next_root.copy_from_slice(&output[..32]);
+    chain.copy_from_slice(&output[32..64]);
+    (next_root, chain)
+}
+
+/// Advance a chain key, returning `(next_chain_key, message_key)`.
+pub fn kdf_chain_key(chain_key: &[u8]) -> ([u8; 32], [u8; 32]) {
+    let next_chain = compute_hmac(chain_key, CHAIN_KEY_SEED_CHAIN);
+    let message_key = compute_hmac(chain_key, CHAIN_KEY_SEED_MESSAGE);
+    (next_chain, message_key)
+}
+
+/// Derive `(enc_key[32], mac_key[32], iv[16])` from a message key.
+pub fn derive_message_keys(message_key: &[u8]) -> ([u8; 32], [u8; 32], [u8; 16]) {
+    let output = hkdf_sha256(message_key, Some(&[0u8; 32]), MESSAGE_KEY_INFO, 80);
+    let mut enc = [0u8; 32];
+    let mut mac = [0u8; 32];
+    let mut iv = [0u8; 16];
+    enc.copy_from_slice(&output[..32]);
+    mac.copy_from_slice(&output[32..64]);
+    iv.copy_from_slice(&output[64..80]);
+    (enc, mac, iv)
+}
+
+/// HMAC-SHA256 of `data` under `key`.
+pub fn compute_hmac(key: &[u8], data: &[u8]) -> [u8; 32] {
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().into()
+}
+
+/// Encrypt-then-MAC: AES-256-CBC(enc, iv) then append `HMAC-SHA256(mac, ad ||
+/// ciphertext)[..8]`. Keys/iv are derived from `message_key`.
+pub fn encrypt(message_key: &[u8], plaintext: &[u8], associated_data: &[u8]) -> Vec<u8> {
+    let (enc_key, mac_key, iv) = derive_message_keys(message_key);
+    let ciphertext = aes_cbc_encrypt(&enc_key, &iv, plaintext);
+    let mac = mac_tag(&mac_key, associated_data, &ciphertext);
+    let mut result = ciphertext;
+    result.extend_from_slice(&mac);
+    result
+}
+
+/// Verify the MAC and AES-256-CBC-decrypt. Errors on MAC mismatch.
+pub fn decrypt(
+    message_key: &[u8],
+    ciphertext_with_mac: &[u8],
+    associated_data: &[u8],
+) -> Result<Vec<u8>> {
+    if ciphertext_with_mac.len() < 8 {
+        return Err(Error::InvalidArgument("ciphertext too short".into()));
+    }
+    let (enc_key, mac_key, iv) = derive_message_keys(message_key);
+    let split = ciphertext_with_mac.len() - 8;
+    let ciphertext = &ciphertext_with_mac[..split];
+    let received_mac = &ciphertext_with_mac[split..];
+    let expected_mac = mac_tag(&mac_key, associated_data, ciphertext);
+    if !constant_time_eq(received_mac, &expected_mac) {
+        return Err(Error::InvalidArgument("MAC verification failed".into()));
+    }
+    aes_cbc_decrypt(&enc_key, &iv, ciphertext)
+}
+
+// --- internal helpers ------------------------------------------------------
+
+fn hkdf_sha256(ikm: &[u8], salt: Option<&[u8]>, info: &[u8], length: usize) -> Vec<u8> {
+    let hk = Hkdf::<Sha256>::new(salt, ikm);
+    let mut okm = vec![0u8; length];
+    hk.expand(info, &mut okm)
+        .expect("HKDF output length within bounds");
+    okm
+}
+
+fn mac_tag(mac_key: &[u8], associated_data: &[u8], ciphertext: &[u8]) -> [u8; 8] {
+    let mut input = Vec::with_capacity(associated_data.len() + ciphertext.len());
+    input.extend_from_slice(associated_data);
+    input.extend_from_slice(ciphertext);
+    let full = compute_hmac(mac_key, &input);
+    let mut tag = [0u8; 8];
+    tag.copy_from_slice(&full[..8]);
+    tag
+}
+
+fn aes_cbc_encrypt(key: &[u8; 32], iv: &[u8; 16], plaintext: &[u8]) -> Vec<u8> {
+    cbc::Encryptor::<Aes256>::new(&(*key).into(), &(*iv).into())
+        .encrypt_padded_vec_mut::<Pkcs7>(plaintext)
+}
+
+fn aes_cbc_decrypt(key: &[u8; 32], iv: &[u8; 16], ciphertext: &[u8]) -> Result<Vec<u8>> {
+    cbc::Decryptor::<Aes256>::new(&(*key).into(), &(*iv).into())
+        .decrypt_padded_vec_mut::<Pkcs7>(ciphertext)
+        .map_err(|_| Error::InvalidArgument("AES-CBC unpad failed".into()))
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}

--- a/sdk/rust/src/signal/mod.rs
+++ b/sdk/rust/src/signal/mod.rs
@@ -1,0 +1,7 @@
+//! Signal protocol end-to-end encryption, ported from
+//! `sdk/typescript/src/signal/` and kept byte-compatible for cross-language
+//! interop with the TS and Python SDKs.
+//!
+//! Built up in parts (see issue #18): this is part 1, the crypto primitives.
+
+pub mod crypto;

--- a/sdk/rust/tests/signal_crypto.rs
+++ b/sdk/rust/tests/signal_crypto.rs
@@ -1,0 +1,114 @@
+//! Known-answer + interop tests for the Signal crypto primitives. Vectors are
+//! the RFC 7748 (X25519) and RFC 8032 (Ed25519) test vectors, matching the
+//! Python port's crypto tests so the Rust port stays byte-compatible.
+
+use ed25519_dalek::SigningKey;
+use tinyplace::signal::crypto::{
+    decrypt, derive_message_keys, ed25519_pub_to_x25519_pub, ed25519_seed_to_x25519_keypair,
+    ed25519_seed_to_x25519_private, encrypt, generate_x25519_keypair, kdf_chain_key, kdf_root_key,
+    x25519_public_key, x25519_shared_secret,
+};
+
+fn hex32(s: &str) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).unwrap();
+    }
+    out
+}
+
+// RFC 8032 Ed25519 test vector 1.
+const ED_SEED: &str = "9d61b19deffebc3a73c632cc930009b6c11a6a3a87ca9a7c2bb59e9d8d3f6d2c";
+const ED_PUB: &str = "ec5f8b680397c8aab0f17e6b801dc855603f11b17a948a297a7db6823c7787c4";
+
+#[test]
+fn x25519_shared_secret_rfc7748() {
+    // RFC 7748 §5.2.
+    let priv_key = hex32("a546e36bf0527c9d3b16154b82465edd62144c0ac1fc5a18506a2244ba449ac4");
+    let pub_key = hex32("e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c");
+    let expected = hex32("c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552");
+    assert_eq!(x25519_shared_secret(&priv_key, &pub_key), expected);
+}
+
+#[test]
+fn x25519_keypair_dh_agrees_both_ways() {
+    let alice = generate_x25519_keypair();
+    let bob = generate_x25519_keypair();
+    assert_ne!(alice.public_key, bob.public_key);
+    let ab = x25519_shared_secret(&alice.private_key, &bob.public_key);
+    let ba = x25519_shared_secret(&bob.private_key, &alice.public_key);
+    assert_eq!(ab, ba);
+}
+
+#[test]
+fn ed25519_to_x25519_conversions_are_consistent() {
+    let seed = hex32(ED_SEED);
+    // Sanity-check the vector against ed25519-dalek's own pubkey derivation.
+    let ed_pub = SigningKey::from_bytes(&seed).verifying_key().to_bytes();
+    assert_eq!(ed_pub, hex32(ED_PUB));
+
+    // The X25519 public key derived from the seed's private scalar must equal
+    // the X25519 public key converted from the Ed25519 public key.
+    let from_private = x25519_public_key(&ed25519_seed_to_x25519_private(&seed));
+    let from_ed_pub = ed25519_pub_to_x25519_pub(&ed_pub).unwrap();
+    assert_eq!(from_private, from_ed_pub);
+
+    // The keypair helper agrees with the standalone private derivation.
+    assert_eq!(
+        ed25519_seed_to_x25519_keypair(&seed).public_key,
+        from_private
+    );
+}
+
+#[test]
+fn kdf_root_and_chain_are_deterministic() {
+    let root = [7u8; 32];
+    let dh = [9u8; 32];
+    let (r1, c1) = kdf_root_key(&root, &dh);
+    let (r2, c2) = kdf_root_key(&root, &dh);
+    assert_eq!((r1, c1), (r2, c2));
+    assert_ne!(r1, c1);
+
+    let (next_chain, message_key) = kdf_chain_key(&c1);
+    assert_ne!(next_chain, message_key);
+    // Advancing again yields a different chain key (ratchet moves forward).
+    assert_ne!(kdf_chain_key(&next_chain).0, next_chain);
+}
+
+#[test]
+fn derive_message_keys_lengths_and_determinism() {
+    let mk = [3u8; 32];
+    let (enc1, mac1, iv1) = derive_message_keys(&mk);
+    let (enc2, mac2, iv2) = derive_message_keys(&mk);
+    assert_eq!((enc1, mac1, iv1), (enc2, mac2, iv2));
+    assert_ne!(enc1, mac1);
+}
+
+#[test]
+fn aead_round_trip() {
+    let mk = [42u8; 32];
+    let plaintext = b"the quick brown fox jumps over a tiny place";
+    let ad = b"associated-data";
+    let sealed = encrypt(&mk, plaintext, ad);
+    // Output is deterministic (iv derives from the message key).
+    assert_eq!(sealed, encrypt(&mk, plaintext, ad));
+    let opened = decrypt(&mk, &sealed, ad).unwrap();
+    assert_eq!(opened, plaintext);
+}
+
+#[test]
+fn aead_rejects_tampered_mac() {
+    let mk = [42u8; 32];
+    let ad = b"ad";
+    let mut sealed = encrypt(&mk, b"secret", ad);
+    let last = sealed.len() - 1;
+    sealed[last] ^= 0x01;
+    assert!(decrypt(&mk, &sealed, ad).is_err());
+}
+
+#[test]
+fn aead_rejects_wrong_associated_data() {
+    let mk = [42u8; 32];
+    let sealed = encrypt(&mk, b"secret", b"ad-a");
+    assert!(decrypt(&mk, &sealed, b"ad-b").is_err());
+}


### PR DESCRIPTION
First slice of the **Rust** Signal E2E port (#18) — independent of the Python epic (#39). Mirrors the 8-part structure the Python port used, starting with the crypto primitives.

Adds `sdk/rust/src/signal/crypto.rs`, byte-compatible with `sdk/typescript/src/signal/crypto.ts`:
- **X25519** ECDH + keygen; **Ed25519→X25519** seed and pubkey conversions
- **HKDF-SHA256** root-key KDF, **HMAC-SHA256** chain ratchet, message-key derivation
- **AES-256-CBC (PKCS#7) + HMAC-SHA256[..8]** Encrypt-then-MAC

Constants (`WhisperRatchet`/`WhisperMessageKeys`, chain seeds `0x01`/`0x02`) and the EtM layout match the TS spec exactly.

## Interop confidence
- **RFC 7748** X25519 known-answer vector ✅
- **RFC 8032** Ed25519 vector + the Ed25519↔X25519 consistency identity (pubkey-from-private == converted-pubkey) ✅
- AEAD round-trip, MAC-tamper rejection, wrong-AD rejection ✅

(Same vectors the Python port's crypto tests use.)

## Validation (`sdk/rust/`)
- `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test` ✅ (8 new + full suite 429)

Deps added: `x25519-dalek`, `curve25519-dalek`, `hkdf`, `hmac`, `aes`, `cbc`.

Part of #18. Next: part 2 (key management & prekey bundles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Signal protocol end-to-end encryption support to the Rust SDK with full encryption and decryption capabilities.
  * Implemented key generation and key agreement operations for secure cryptographic communication.
  * Ensures interoperability with TypeScript and Python SDK implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->