### PR TITLE
feat(sdk/rust): Signal Double Ratchet (part 5 of #18)

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -25,6 +25,16 @@ async-trait = "0.1"
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 
+# Signal protocol (E2E encryption) primitives. Algorithms chosen to be
+# byte-compatible with the TS/Python SDKs: X25519 ECDH, HKDF/HMAC-SHA256,
+# AES-256-CBC + HMAC-SHA256 Encrypt-then-MAC.
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+curve25519-dalek = "4"
+hkdf = "0.12"
+hmac = "0.12"
+aes = "0.8"
+cbc = { version = "0.1", features = ["alloc"] }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 wiremock = "0.6"

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -27,6 +27,7 @@ pub mod auth;
 pub mod crypto;
 pub mod error;
 pub mod http;
+pub mod signal;
 pub mod signer;
 pub mod util;
 pub mod websocket;

--- a/sdk/rust/src/signal/crypto.rs
+++ b/sdk/rust/src/signal/crypto.rs
@@ -1,0 +1,199 @@
+//! Signal protocol crypto primitives. Mirrors `sdk/typescript/src/signal/crypto.ts`
+//! and the Python port, kept byte-compatible for cross-language interop:
+//!
+//! - **DH:** X25519 (Curve25519)
+//! - **Conversions:** Ed25519 seed/pubkey → X25519
+//! - **KDF:** HKDF-SHA256 (root key) + HMAC-SHA256 chain ratchet
+//! - **AEAD:** AES-256-CBC (PKCS#7) + HMAC-SHA256 truncated to 8 bytes,
+//!   Encrypt-then-MAC over `associated_data || ciphertext`.
+
+use aes::Aes256;
+use cbc::cipher::block_padding::Pkcs7;
+use cbc::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use curve25519_dalek::edwards::CompressedEdwardsY;
+use hkdf::Hkdf;
+use hmac::{Hmac, Mac};
+use rand::RngCore as _;
+use sha2::{Digest, Sha256, Sha512};
+use x25519_dalek::{PublicKey, StaticSecret};
+
+use crate::error::{Error, Result};
+
+type HmacSha256 = Hmac<Sha256>;
+
+const HKDF_INFO: &[u8] = b"WhisperRatchet";
+const MESSAGE_KEY_INFO: &[u8] = b"WhisperMessageKeys";
+const CHAIN_KEY_SEED_MESSAGE: &[u8] = &[0x01];
+const CHAIN_KEY_SEED_CHAIN: &[u8] = &[0x02];
+
+/// An X25519 (Curve25519) key pair, raw 32-byte keys.
+#[derive(Debug, Clone)]
+pub struct X25519KeyPair {
+    pub public_key: [u8; 32],
+    pub private_key: [u8; 32],
+}
+
+/// Generate a fresh random X25519 key pair.
+pub fn generate_x25519_keypair() -> X25519KeyPair {
+    let mut private_key = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut private_key);
+    let public_key = x25519_public_key(&private_key);
+    X25519KeyPair {
+        public_key,
+        private_key,
+    }
+}
+
+/// The X25519 public key for a raw private key (clamped basepoint multiply).
+pub fn x25519_public_key(private_key: &[u8; 32]) -> [u8; 32] {
+    let secret = StaticSecret::from(*private_key);
+    PublicKey::from(&secret).to_bytes()
+}
+
+/// Compute the X25519 shared secret for `private_key` and `public_key`.
+pub fn x25519_shared_secret(private_key: &[u8; 32], public_key: &[u8; 32]) -> [u8; 32] {
+    let secret = StaticSecret::from(*private_key);
+    let public = PublicKey::from(*public_key);
+    secret.diffie_hellman(&public).to_bytes()
+}
+
+/// Derive the X25519 private scalar from an Ed25519 seed: `sha512(seed)[..32]`
+/// with the standard Curve25519 clamping.
+pub fn ed25519_seed_to_x25519_private(seed: &[u8; 32]) -> [u8; 32] {
+    let hash = Sha512::digest(seed);
+    let mut scalar = [0u8; 32];
+    scalar.copy_from_slice(&hash[..32]);
+    scalar[0] &= 248;
+    scalar[31] &= 127;
+    scalar[31] |= 64;
+    scalar
+}
+
+/// Derive the X25519 key pair from an Ed25519 seed.
+pub fn ed25519_seed_to_x25519_keypair(seed: &[u8; 32]) -> X25519KeyPair {
+    let private_key = ed25519_seed_to_x25519_private(seed);
+    let public_key = x25519_public_key(&private_key);
+    X25519KeyPair {
+        public_key,
+        private_key,
+    }
+}
+
+/// Convert an Ed25519 public key to the corresponding X25519 (Montgomery)
+/// public key (`u = (1 + y) / (1 - y)`).
+pub fn ed25519_pub_to_x25519_pub(ed_pub: &[u8; 32]) -> Result<[u8; 32]> {
+    let point = CompressedEdwardsY(*ed_pub)
+        .decompress()
+        .ok_or_else(|| Error::InvalidArgument("invalid Ed25519 public key".into()))?;
+    Ok(point.to_montgomery().to_bytes())
+}
+
+/// Derive the next root key and chain key from the current root key and a fresh
+/// DH output. `HKDF-SHA256(ikm = dh_output, salt = root_key, info)`.
+pub fn kdf_root_key(root_key: &[u8], dh_output: &[u8]) -> ([u8; 32], [u8; 32]) {
+    let output = hkdf_sha256(dh_output, Some(root_key), HKDF_INFO, 64);
+    let mut next_root = [0u8; 32];
+    let mut chain = [0u8; 32];
+    next_root.copy_from_slice(&output[..32]);
+    chain.copy_from_slice(&output[32..64]);
+    (next_root, chain)
+}
+
+/// Advance a chain key, returning `(next_chain_key, message_key)`.
+pub fn kdf_chain_key(chain_key: &[u8]) -> ([u8; 32], [u8; 32]) {
+    let next_chain = compute_hmac(chain_key, CHAIN_KEY_SEED_CHAIN);
+    let message_key = compute_hmac(chain_key, CHAIN_KEY_SEED_MESSAGE);
+    (next_chain, message_key)
+}
+
+/// Derive `(enc_key[32], mac_key[32], iv[16])` from a message key.
+pub fn derive_message_keys(message_key: &[u8]) -> ([u8; 32], [u8; 32], [u8; 16]) {
+    let output = hkdf_sha256(message_key, Some(&[0u8; 32]), MESSAGE_KEY_INFO, 80);
+    let mut enc = [0u8; 32];
+    let mut mac = [0u8; 32];
+    let mut iv = [0u8; 16];
+    enc.copy_from_slice(&output[..32]);
+    mac.copy_from_slice(&output[32..64]);
+    iv.copy_from_slice(&output[64..80]);
+    (enc, mac, iv)
+}
+
+/// HMAC-SHA256 of `data` under `key`.
+pub fn compute_hmac(key: &[u8], data: &[u8]) -> [u8; 32] {
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().into()
+}
+
+/// Encrypt-then-MAC: AES-256-CBC(enc, iv) then append `HMAC-SHA256(mac, ad ||
+/// ciphertext)[..8]`. Keys/iv are derived from `message_key`.
+pub fn encrypt(message_key: &[u8], plaintext: &[u8], associated_data: &[u8]) -> Vec<u8> {
+    let (enc_key, mac_key, iv) = derive_message_keys(message_key);
+    let ciphertext = aes_cbc_encrypt(&enc_key, &iv, plaintext);
+    let mac = mac_tag(&mac_key, associated_data, &ciphertext);
+    let mut result = ciphertext;
+    result.extend_from_slice(&mac);
+    result
+}
+
+/// Verify the MAC and AES-256-CBC-decrypt. Errors on MAC mismatch.
+pub fn decrypt(
+    message_key: &[u8],
+    ciphertext_with_mac: &[u8],
+    associated_data: &[u8],
+) -> Result<Vec<u8>> {
+    if ciphertext_with_mac.len() < 8 {
+        return Err(Error::InvalidArgument("ciphertext too short".into()));
+    }
+    let (enc_key, mac_key, iv) = derive_message_keys(message_key);
+    let split = ciphertext_with_mac.len() - 8;
+    let ciphertext = &ciphertext_with_mac[..split];
+    let received_mac = &ciphertext_with_mac[split..];
+    let expected_mac = mac_tag(&mac_key, associated_data, ciphertext);
+    if !constant_time_eq(received_mac, &expected_mac) {
+        return Err(Error::InvalidArgument("MAC verification failed".into()));
+    }
+    aes_cbc_decrypt(&enc_key, &iv, ciphertext)
+}
+
+// --- internal helpers ------------------------------------------------------
+
+fn hkdf_sha256(ikm: &[u8], salt: Option<&[u8]>, info: &[u8], length: usize) -> Vec<u8> {
+    let hk = Hkdf::<Sha256>::new(salt, ikm);
+    let mut okm = vec![0u8; length];
+    hk.expand(info, &mut okm)
+        .expect("HKDF output length within bounds");
+    okm
+}
+
+fn mac_tag(mac_key: &[u8], associated_data: &[u8], ciphertext: &[u8]) -> [u8; 8] {
+    let mut input = Vec::with_capacity(associated_data.len() + ciphertext.len());
+    input.extend_from_slice(associated_data);
+    input.extend_from_slice(ciphertext);
+    let full = compute_hmac(mac_key, &input);
+    let mut tag = [0u8; 8];
+    tag.copy_from_slice(&full[..8]);
+    tag
+}
+
+fn aes_cbc_encrypt(key: &[u8; 32], iv: &[u8; 16], plaintext: &[u8]) -> Vec<u8> {
+    cbc::Encryptor::<Aes256>::new(&(*key).into(), &(*iv).into())
+        .encrypt_padded_vec_mut::<Pkcs7>(plaintext)
+}
+
+fn aes_cbc_decrypt(key: &[u8; 32], iv: &[u8; 16], ciphertext: &[u8]) -> Result<Vec<u8>> {
+    cbc::Decryptor::<Aes256>::new(&(*key).into(), &(*iv).into())
+        .decrypt_padded_vec_mut::<Pkcs7>(ciphertext)
+        .map_err(|_| Error::InvalidArgument("AES-CBC unpad failed".into()))
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}

--- a/sdk/rust/src/signal/crypto.rs
+++ b/sdk/rust/src/signal/crypto.rs
@@ -158,7 +158,7 @@ pub fn decrypt(
 
 // --- internal helpers ------------------------------------------------------
 
-fn hkdf_sha256(ikm: &[u8], salt: Option<&[u8]>, info: &[u8], length: usize) -> Vec<u8> {
+pub(crate) fn hkdf_sha256(ikm: &[u8], salt: Option<&[u8]>, info: &[u8], length: usize) -> Vec<u8> {
     let hk = Hkdf::<Sha256>::new(salt, ikm);
     let mut okm = vec![0u8; length];
     hk.expand(info, &mut okm)

--- a/sdk/rust/src/signal/keys.rs
+++ b/sdk/rust/src/signal/keys.rs
@@ -1,0 +1,71 @@
+//! Pre-key generation & serialization. Mirrors `sdk/typescript/src/signal/keys.ts`.
+//!
+//! A pre-key is an X25519 key pair plus the identity key's signature over the
+//! base64 string of its public key — the backend verifies
+//! `ed25519.Verify(identityPubKey, base64(preKey.publicKey), signature)`.
+
+use crate::crypto::to_base64;
+use crate::error::Result;
+use crate::signal::crypto::{generate_x25519_keypair, X25519KeyPair};
+use crate::signer::Signer;
+use crate::types::SignedKey;
+
+/// A pre-key: an X25519 key pair and the identity-key signature over its base64
+/// public key. Signed and one-time pre-keys share this shape.
+#[derive(Debug, Clone)]
+pub struct PreKeyPair {
+    pub key_id: String,
+    pub key_pair: X25519KeyPair,
+    pub signature: Vec<u8>,
+}
+
+/// Signed pre-keys have the same shape as one-time pre-keys.
+pub type SignedPreKeyPair = PreKeyPair;
+
+/// Generate a signed pre-key with the given id.
+pub async fn generate_signed_pre_key(
+    signer: &dyn Signer,
+    key_id: &str,
+) -> Result<SignedPreKeyPair> {
+    let key_pair = generate_x25519_keypair();
+    let signature = sign_public_key(signer, &key_pair.public_key).await?;
+    Ok(PreKeyPair {
+        key_id: key_id.to_string(),
+        key_pair,
+        signature,
+    })
+}
+
+/// Generate `count` one-time pre-keys with ids `pk_{start_id + i}`.
+pub async fn generate_pre_keys(
+    signer: &dyn Signer,
+    start_id: u64,
+    count: usize,
+) -> Result<Vec<PreKeyPair>> {
+    let mut pre_keys = Vec::with_capacity(count);
+    for index in 0..count {
+        let key_id = format!("pk_{}", start_id + index as u64);
+        let key_pair = generate_x25519_keypair();
+        let signature = sign_public_key(signer, &key_pair.public_key).await?;
+        pre_keys.push(PreKeyPair {
+            key_id,
+            key_pair,
+            signature,
+        });
+    }
+    Ok(pre_keys)
+}
+
+/// Serialize a pre-key (signed or one-time) into the wire form uploaded to
+/// `/keys` (`{ keyId, publicKey, signature }`, all base64).
+pub fn serialize_pre_key(pre_key: &PreKeyPair) -> SignedKey {
+    SignedKey {
+        key_id: pre_key.key_id.clone(),
+        public_key: to_base64(&pre_key.key_pair.public_key),
+        signature: Some(to_base64(&pre_key.signature)),
+    }
+}
+
+async fn sign_public_key(signer: &dyn Signer, public_key: &[u8]) -> Result<Vec<u8>> {
+    signer.sign(to_base64(public_key).as_bytes()).await
+}

--- a/sdk/rust/src/signal/memory_store.rs
+++ b/sdk/rust/src/signal/memory_store.rs
@@ -1,0 +1,106 @@
+//! In-memory [`SessionStore`]. Mirrors `sdk/typescript/src/signal/memory-store.ts`.
+//! Suitable for tests and ephemeral sessions; persist with a custom store for
+//! durability across restarts.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use crate::error::{Error, Result};
+use crate::signal::crypto::X25519KeyPair;
+use crate::signal::keys::{PreKeyPair, SignedPreKeyPair};
+use crate::signal::store::{SessionState, SessionStore};
+
+/// A [`SessionStore`] holding everything in memory.
+pub struct MemorySessionStore {
+    identity_key_pair: X25519KeyPair,
+    signed_pre_keys: Mutex<HashMap<String, SignedPreKeyPair>>,
+    pre_keys: Mutex<HashMap<String, PreKeyPair>>,
+    sessions: Mutex<HashMap<String, SessionState>>,
+    active_signed_pre_key_id: Mutex<Option<String>>,
+}
+
+impl MemorySessionStore {
+    /// Create a store bound to the given identity X25519 key pair.
+    pub fn new(identity_key_pair: X25519KeyPair) -> Self {
+        Self {
+            identity_key_pair,
+            signed_pre_keys: Mutex::new(HashMap::new()),
+            pre_keys: Mutex::new(HashMap::new()),
+            sessions: Mutex::new(HashMap::new()),
+            active_signed_pre_key_id: Mutex::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl SessionStore for MemorySessionStore {
+    async fn identity_x25519_key_pair(&self) -> Result<X25519KeyPair> {
+        Ok(self.identity_key_pair.clone())
+    }
+
+    async fn signed_pre_key(&self, key_id: &str) -> Result<Option<SignedPreKeyPair>> {
+        Ok(self.signed_pre_keys.lock().unwrap().get(key_id).cloned())
+    }
+
+    async fn active_signed_pre_key(&self) -> Result<SignedPreKeyPair> {
+        let active = self.active_signed_pre_key_id.lock().unwrap().clone();
+        let key_id =
+            active.ok_or_else(|| Error::InvalidArgument("No active signed pre-key".into()))?;
+        self.signed_pre_keys
+            .lock()
+            .unwrap()
+            .get(&key_id)
+            .cloned()
+            .ok_or_else(|| Error::InvalidArgument("Active signed pre-key not found".into()))
+    }
+
+    async fn store_signed_pre_key(&self, pre_key: SignedPreKeyPair) -> Result<()> {
+        let key_id = pre_key.key_id.clone();
+        self.signed_pre_keys
+            .lock()
+            .unwrap()
+            .insert(key_id.clone(), pre_key);
+        *self.active_signed_pre_key_id.lock().unwrap() = Some(key_id);
+        Ok(())
+    }
+
+    async fn pre_key(&self, key_id: &str) -> Result<Option<PreKeyPair>> {
+        Ok(self.pre_keys.lock().unwrap().get(key_id).cloned())
+    }
+
+    async fn remove_pre_key(&self, key_id: &str) -> Result<()> {
+        self.pre_keys.lock().unwrap().remove(key_id);
+        Ok(())
+    }
+
+    async fn store_pre_key(&self, pre_key: PreKeyPair) -> Result<()> {
+        self.pre_keys
+            .lock()
+            .unwrap()
+            .insert(pre_key.key_id.clone(), pre_key);
+        Ok(())
+    }
+
+    async fn all_pre_keys(&self) -> Result<Vec<PreKeyPair>> {
+        Ok(self.pre_keys.lock().unwrap().values().cloned().collect())
+    }
+
+    async fn session(&self, address: &str) -> Result<Option<SessionState>> {
+        Ok(self.sessions.lock().unwrap().get(address).cloned())
+    }
+
+    async fn store_session(&self, address: &str, session: SessionState) -> Result<()> {
+        self.sessions
+            .lock()
+            .unwrap()
+            .insert(address.to_string(), session);
+        Ok(())
+    }
+
+    async fn remove_session(&self, address: &str) -> Result<()> {
+        self.sessions.lock().unwrap().remove(address);
+        Ok(())
+    }
+}

--- a/sdk/rust/src/signal/mod.rs
+++ b/sdk/rust/src/signal/mod.rs
@@ -5,3 +5,4 @@
 //! Built up in parts (see issue #18): this is part 1, the crypto primitives.
 
 pub mod crypto;
+pub mod keys;

--- a/sdk/rust/src/signal/mod.rs
+++ b/sdk/rust/src/signal/mod.rs
@@ -8,3 +8,4 @@ pub mod crypto;
 pub mod keys;
 pub mod memory_store;
 pub mod store;
+pub mod x3dh;

--- a/sdk/rust/src/signal/mod.rs
+++ b/sdk/rust/src/signal/mod.rs
@@ -6,3 +6,5 @@
 
 pub mod crypto;
 pub mod keys;
+pub mod memory_store;
+pub mod store;

--- a/sdk/rust/src/signal/mod.rs
+++ b/sdk/rust/src/signal/mod.rs
@@ -1,0 +1,7 @@
+//! Signal protocol end-to-end encryption, ported from
+//! `sdk/typescript/src/signal/` and kept byte-compatible for cross-language
+//! interop with the TS and Python SDKs.
+//!
+//! Built up in parts (see issue #18): this is part 1, the crypto primitives.
+
+pub mod crypto;

--- a/sdk/rust/src/signal/mod.rs
+++ b/sdk/rust/src/signal/mod.rs
@@ -7,5 +7,6 @@
 pub mod crypto;
 pub mod keys;
 pub mod memory_store;
+pub mod ratchet;
 pub mod store;
 pub mod x3dh;

--- a/sdk/rust/src/signal/ratchet.rs
+++ b/sdk/rust/src/signal/ratchet.rs
@@ -1,0 +1,151 @@
+//! Double Ratchet. Mirrors `sdk/typescript/src/signal/ratchet.ts`.
+//!
+//! Symmetric-key ratchet per chain + a DH ratchet on each direction change,
+//! with skipped-message-key handling for out-of-order delivery. Encrypt/decrypt
+//! are synchronous here (Rust AES is sync, unlike the TS WebCrypto port).
+
+use crate::error::{Error, Result};
+use crate::signal::crypto::{
+    decrypt, encrypt, generate_x25519_keypair, kdf_chain_key, kdf_root_key, x25519_shared_secret,
+};
+use crate::signal::store::{skipped_key_id, SessionState};
+
+const MAX_SKIP: u32 = 1000;
+
+/// Per-message ratchet header (sent in the clear, bound into the MAC).
+#[derive(Debug, Clone)]
+pub struct RatchetHeader {
+    pub public_key: [u8; 32],
+    pub previous_chain_length: u32,
+    pub message_number: u32,
+}
+
+/// A ratchet header plus its ciphertext.
+#[derive(Debug, Clone)]
+pub struct RatchetMessage {
+    pub header: RatchetHeader,
+    pub ciphertext: Vec<u8>,
+}
+
+/// Encrypt the next message in the sending chain, advancing the ratchet.
+pub fn ratchet_encrypt(
+    state: &mut SessionState,
+    plaintext: &[u8],
+    associated_data: &[u8],
+) -> Result<RatchetMessage> {
+    if state.send_chain_key.is_none() {
+        dh_ratchet_step(state)?;
+    }
+    let chain = state
+        .send_chain_key
+        .expect("send chain key set after ratchet");
+    let (next_chain, message_key) = kdf_chain_key(&chain);
+    state.send_chain_key = Some(next_chain);
+
+    let header = RatchetHeader {
+        public_key: state.dh_send_key_pair.public_key,
+        previous_chain_length: state.previous_chain_length,
+        message_number: state.send_message_number,
+    };
+    state.send_message_number += 1;
+
+    let ad = [associated_data, &encode_header(&header)].concat();
+    let ciphertext = encrypt(&message_key, plaintext, &ad);
+    Ok(RatchetMessage { header, ciphertext })
+}
+
+/// Decrypt a message, performing a DH ratchet step and/or replaying skipped
+/// message keys as needed.
+pub fn ratchet_decrypt(
+    state: &mut SessionState,
+    message: &RatchetMessage,
+    associated_data: &[u8],
+) -> Result<Vec<u8>> {
+    let skipped_id = skipped_key_id(&message.header.public_key, message.header.message_number);
+    if let Some(skipped_key) = state.skipped_keys.get(&skipped_id).copied() {
+        state.skipped_keys.remove(&skipped_id);
+        let ad = [associated_data, &encode_header(&message.header)].concat();
+        return decrypt(&skipped_key, &message.ciphertext, &ad);
+    }
+
+    if state.dh_recv_public_key != Some(message.header.public_key) {
+        if state.recv_chain_key.is_some() {
+            skip_message_keys(state, message.header.previous_chain_length)?;
+        }
+        dh_ratchet_step_with_recv(state, message.header.public_key);
+    }
+
+    skip_message_keys(state, message.header.message_number)?;
+
+    let chain = state
+        .recv_chain_key
+        .expect("recv chain key set after ratchet");
+    let (next_chain, message_key) = kdf_chain_key(&chain);
+    state.recv_chain_key = Some(next_chain);
+    state.recv_message_number += 1;
+
+    let ad = [associated_data, &encode_header(&message.header)].concat();
+    decrypt(&message_key, &message.ciphertext, &ad)
+}
+
+fn dh_ratchet_step(state: &mut SessionState) -> Result<()> {
+    let recv = state.dh_recv_public_key.ok_or_else(|| {
+        Error::InvalidArgument("Cannot perform DH ratchet without recipient public key".into())
+    })?;
+    let dh_output = x25519_shared_secret(&state.dh_send_key_pair.private_key, &recv);
+    let (root_key, chain_key) = kdf_root_key(&state.root_key, &dh_output);
+    state.root_key = root_key;
+    state.send_chain_key = Some(chain_key);
+    Ok(())
+}
+
+fn dh_ratchet_step_with_recv(state: &mut SessionState, new_recv_public_key: [u8; 32]) {
+    state.previous_chain_length = state.send_message_number;
+    state.send_message_number = 0;
+    state.recv_message_number = 0;
+    state.dh_recv_public_key = Some(new_recv_public_key);
+
+    let dh_recv = x25519_shared_secret(&state.dh_send_key_pair.private_key, &new_recv_public_key);
+    let (root_key, recv_chain) = kdf_root_key(&state.root_key, &dh_recv);
+    state.root_key = root_key;
+    state.recv_chain_key = Some(recv_chain);
+
+    state.dh_send_key_pair = generate_x25519_keypair();
+    let dh_send = x25519_shared_secret(&state.dh_send_key_pair.private_key, &new_recv_public_key);
+    let (root_key, send_chain) = kdf_root_key(&state.root_key, &dh_send);
+    state.root_key = root_key;
+    state.send_chain_key = Some(send_chain);
+}
+
+fn skip_message_keys(state: &mut SessionState, until: u32) -> Result<()> {
+    if state.recv_chain_key.is_none() {
+        return Ok(());
+    }
+    if until.saturating_sub(state.recv_message_number) > MAX_SKIP {
+        return Err(Error::InvalidArgument("Too many skipped messages".into()));
+    }
+    let recv_public_key = state
+        .dh_recv_public_key
+        .expect("recv public key set when recv chain key is set");
+    while state.recv_message_number < until {
+        let chain = state
+            .recv_chain_key
+            .expect("recv chain key present in loop");
+        let (next_chain, message_key) = kdf_chain_key(&chain);
+        state.recv_chain_key = Some(next_chain);
+        let skipped_id = skipped_key_id(&recv_public_key, state.recv_message_number);
+        state.skipped_keys.insert(skipped_id, message_key);
+        state.recv_message_number += 1;
+    }
+    Ok(())
+}
+
+/// Header wire form: `public_key(32) || previous_chain_length(u32 BE) ||
+/// message_number(u32 BE)`.
+fn encode_header(header: &RatchetHeader) -> [u8; 40] {
+    let mut out = [0u8; 40];
+    out[..32].copy_from_slice(&header.public_key);
+    out[32..36].copy_from_slice(&header.previous_chain_length.to_be_bytes());
+    out[36..40].copy_from_slice(&header.message_number.to_be_bytes());
+    out
+}

--- a/sdk/rust/src/signal/store.rs
+++ b/sdk/rust/src/signal/store.rs
@@ -1,0 +1,47 @@
+//! Session-store trait + Double Ratchet session state. Mirrors
+//! `sdk/typescript/src/signal/store.ts`.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use crate::crypto::to_hex;
+use crate::error::Result;
+use crate::signal::crypto::X25519KeyPair;
+use crate::signal::keys::{PreKeyPair, SignedPreKeyPair};
+
+/// Per-peer Double Ratchet state, persisted by a [`SessionStore`].
+#[derive(Debug, Clone)]
+pub struct SessionState {
+    pub dh_send_key_pair: X25519KeyPair,
+    pub dh_recv_public_key: Option<[u8; 32]>,
+    pub root_key: [u8; 32],
+    pub send_chain_key: Option<[u8; 32]>,
+    pub recv_chain_key: Option<[u8; 32]>,
+    pub send_message_number: u32,
+    pub recv_message_number: u32,
+    pub previous_chain_length: u32,
+    /// Skipped message keys, keyed by [`skipped_key_id`].
+    pub skipped_keys: HashMap<String, [u8; 32]>,
+}
+
+/// Persistence for identity/pre-keys and per-peer ratchet sessions.
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    async fn identity_x25519_key_pair(&self) -> Result<X25519KeyPair>;
+    async fn signed_pre_key(&self, key_id: &str) -> Result<Option<SignedPreKeyPair>>;
+    async fn active_signed_pre_key(&self) -> Result<SignedPreKeyPair>;
+    async fn store_signed_pre_key(&self, pre_key: SignedPreKeyPair) -> Result<()>;
+    async fn pre_key(&self, key_id: &str) -> Result<Option<PreKeyPair>>;
+    async fn remove_pre_key(&self, key_id: &str) -> Result<()>;
+    async fn store_pre_key(&self, pre_key: PreKeyPair) -> Result<()>;
+    async fn all_pre_keys(&self) -> Result<Vec<PreKeyPair>>;
+    async fn session(&self, address: &str) -> Result<Option<SessionState>>;
+    async fn store_session(&self, address: &str, session: SessionState) -> Result<()>;
+    async fn remove_session(&self, address: &str) -> Result<()>;
+}
+
+/// Stable id for a skipped message key: `hex(ratchet_public_key):message_number`.
+pub fn skipped_key_id(ratchet_public_key: &[u8], message_number: u32) -> String {
+    format!("{}:{}", to_hex(ratchet_public_key), message_number)
+}

--- a/sdk/rust/src/signal/x3dh.rs
+++ b/sdk/rust/src/signal/x3dh.rs
@@ -1,0 +1,164 @@
+//! X3DH key agreement. Mirrors `sdk/typescript/src/signal/x3dh.ts`.
+
+use std::collections::HashMap;
+
+use ed25519_dalek::{Signature, Verifier as _, VerifyingKey};
+
+use crate::crypto::from_base64;
+use crate::error::{Error, Result};
+use crate::signal::crypto::{
+    generate_x25519_keypair, hkdf_sha256, x25519_shared_secret, X25519KeyPair,
+};
+use crate::signal::store::SessionState;
+
+const X3DH_INFO: &[u8] = b"WhisperText";
+const PADDING: [u8; 32] = [0xff; 32];
+
+/// A peer's fetched key bundle (all X25519 public keys).
+#[derive(Debug, Clone)]
+pub struct X3DHBundle {
+    pub identity_key: [u8; 32],
+    pub signed_pre_key_id: String,
+    pub signed_pre_key: [u8; 32],
+    pub one_time_pre_key_id: Option<String>,
+    pub one_time_pre_key: Option<[u8; 32]>,
+}
+
+/// The result of initiating X3DH: the new session plus the public values the
+/// responder needs (carried in the first message's prekey header).
+#[derive(Debug, Clone)]
+pub struct X3DHInitResult {
+    pub session: SessionState,
+    pub ephemeral_public_key: [u8; 32],
+    pub signed_pre_key_id: String,
+    pub one_time_pre_key_id: Option<String>,
+}
+
+/// Verify a fetched pre-key was signed by the peer's long-term Ed25519 identity
+/// key, exactly as the backend does: `ed25519.Verify(identityPubKey,
+/// base64(preKey.publicKey), signature)`. Errors on a missing or invalid
+/// signature so a malicious relay can't substitute attacker pre-keys.
+///
+/// `identity_ed25519_public_key` is the peer's long-term Ed25519 key (from a
+/// trusted address), NOT the X25519 key from the served bundle.
+pub fn verify_pre_key_signature(
+    identity_ed25519_public_key: &[u8; 32],
+    pre_key_public_key_base64: &str,
+    signature_base64: Option<&str>,
+    label: &str,
+) -> Result<()> {
+    let signature_base64 = signature_base64.ok_or_else(|| {
+        Error::InvalidArgument(format!(
+            "Key bundle rejected: {label} is missing its Ed25519 signature"
+        ))
+    })?;
+    let reject = || {
+        Error::InvalidArgument(format!(
+            "Key bundle rejected: invalid Ed25519 signature on {label}"
+        ))
+    };
+    let signature_bytes = from_base64(signature_base64).map_err(|_| reject())?;
+    let signature = Signature::from_slice(&signature_bytes).map_err(|_| reject())?;
+    let verifying = VerifyingKey::from_bytes(identity_ed25519_public_key).map_err(|_| reject())?;
+    verifying
+        .verify(pre_key_public_key_base64.as_bytes(), &signature)
+        .map_err(|_| reject())
+}
+
+/// Initiate X3DH against a peer's bundle, deriving the initial root key.
+pub fn x3dh_initiate(
+    our_identity_key_pair: &X25519KeyPair,
+    their_bundle: &X3DHBundle,
+) -> X3DHInitResult {
+    let ephemeral = generate_x25519_keypair();
+
+    // DH1: our identity <-> their signed pre-key
+    let dh1 = x25519_shared_secret(
+        &our_identity_key_pair.private_key,
+        &their_bundle.signed_pre_key,
+    );
+    // DH2: our ephemeral <-> their identity
+    let dh2 = x25519_shared_secret(&ephemeral.private_key, &their_bundle.identity_key);
+    // DH3: our ephemeral <-> their signed pre-key
+    let dh3 = x25519_shared_secret(&ephemeral.private_key, &their_bundle.signed_pre_key);
+
+    let mut parts: Vec<&[u8]> = vec![&PADDING, &dh1, &dh2, &dh3];
+    let dh4;
+    if let Some(one_time) = &their_bundle.one_time_pre_key {
+        dh4 = x25519_shared_secret(&ephemeral.private_key, one_time);
+        parts.push(&dh4);
+    }
+    let root_key = derive_root_key(&parts);
+
+    let session = SessionState {
+        dh_send_key_pair: generate_x25519_keypair(),
+        dh_recv_public_key: Some(their_bundle.signed_pre_key),
+        root_key,
+        send_chain_key: None,
+        recv_chain_key: None,
+        send_message_number: 0,
+        recv_message_number: 0,
+        previous_chain_length: 0,
+        skipped_keys: HashMap::new(),
+    };
+
+    X3DHInitResult {
+        session,
+        ephemeral_public_key: ephemeral.public_key,
+        signed_pre_key_id: their_bundle.signed_pre_key_id.clone(),
+        one_time_pre_key_id: their_bundle.one_time_pre_key_id.clone(),
+    }
+}
+
+/// Respond to an X3DH initiation, deriving the same root key.
+pub fn x3dh_respond(
+    our_identity_key_pair: &X25519KeyPair,
+    our_signed_pre_key_pair: &X25519KeyPair,
+    their_identity_key: &[u8; 32],
+    their_ephemeral_key: &[u8; 32],
+    our_one_time_pre_key_pair: Option<&X25519KeyPair>,
+) -> SessionState {
+    // DH1: their identity <-> our signed pre-key
+    let dh1 = x25519_shared_secret(&our_signed_pre_key_pair.private_key, their_identity_key);
+    // DH2: their ephemeral <-> our identity
+    let dh2 = x25519_shared_secret(&our_identity_key_pair.private_key, their_ephemeral_key);
+    // DH3: their ephemeral <-> our signed pre-key
+    let dh3 = x25519_shared_secret(&our_signed_pre_key_pair.private_key, their_ephemeral_key);
+
+    let mut parts: Vec<&[u8]> = vec![&PADDING, &dh1, &dh2, &dh3];
+    let dh4;
+    if let Some(one_time) = our_one_time_pre_key_pair {
+        dh4 = x25519_shared_secret(&one_time.private_key, their_ephemeral_key);
+        parts.push(&dh4);
+    }
+    let root_key = derive_root_key(&parts);
+
+    SessionState {
+        dh_send_key_pair: our_signed_pre_key_pair.clone(),
+        dh_recv_public_key: None,
+        root_key,
+        send_chain_key: None,
+        recv_chain_key: None,
+        send_message_number: 0,
+        recv_message_number: 0,
+        previous_chain_length: 0,
+        skipped_keys: HashMap::new(),
+    }
+}
+
+/// Associated data bound into every message MAC: `sender_identity ||
+/// recipient_identity` (X25519 identity keys).
+pub fn build_associated_data(sender_identity_key: &[u8], recipient_identity_key: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(sender_identity_key.len() + recipient_identity_key.len());
+    out.extend_from_slice(sender_identity_key);
+    out.extend_from_slice(recipient_identity_key);
+    out
+}
+
+fn derive_root_key(parts: &[&[u8]]) -> [u8; 32] {
+    let dh_concat: Vec<u8> = parts.concat();
+    let okm = hkdf_sha256(&dh_concat, Some(&[0u8; 32]), X3DH_INFO, 32);
+    let mut root = [0u8; 32];
+    root.copy_from_slice(&okm);
+    root
+}

--- a/sdk/rust/tests/signal_crypto.rs
+++ b/sdk/rust/tests/signal_crypto.rs
@@ -1,0 +1,114 @@
+//! Known-answer + interop tests for the Signal crypto primitives. Vectors are
+//! the RFC 7748 (X25519) and RFC 8032 (Ed25519) test vectors, matching the
+//! Python port's crypto tests so the Rust port stays byte-compatible.
+
+use ed25519_dalek::SigningKey;
+use tinyplace::signal::crypto::{
+    decrypt, derive_message_keys, ed25519_pub_to_x25519_pub, ed25519_seed_to_x25519_keypair,
+    ed25519_seed_to_x25519_private, encrypt, generate_x25519_keypair, kdf_chain_key, kdf_root_key,
+    x25519_public_key, x25519_shared_secret,
+};
+
+fn hex32(s: &str) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).unwrap();
+    }
+    out
+}
+
+// RFC 8032 Ed25519 test vector 1.
+const ED_SEED: &str = "9d61b19deffebc3a73c632cc930009b6c11a6a3a87ca9a7c2bb59e9d8d3f6d2c";
+const ED_PUB: &str = "ec5f8b680397c8aab0f17e6b801dc855603f11b17a948a297a7db6823c7787c4";
+
+#[test]
+fn x25519_shared_secret_rfc7748() {
+    // RFC 7748 §5.2.
+    let priv_key = hex32("a546e36bf0527c9d3b16154b82465edd62144c0ac1fc5a18506a2244ba449ac4");
+    let pub_key = hex32("e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c");
+    let expected = hex32("c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552");
+    assert_eq!(x25519_shared_secret(&priv_key, &pub_key), expected);
+}
+
+#[test]
+fn x25519_keypair_dh_agrees_both_ways() {
+    let alice = generate_x25519_keypair();
+    let bob = generate_x25519_keypair();
+    assert_ne!(alice.public_key, bob.public_key);
+    let ab = x25519_shared_secret(&alice.private_key, &bob.public_key);
+    let ba = x25519_shared_secret(&bob.private_key, &alice.public_key);
+    assert_eq!(ab, ba);
+}
+
+#[test]
+fn ed25519_to_x25519_conversions_are_consistent() {
+    let seed = hex32(ED_SEED);
+    // Sanity-check the vector against ed25519-dalek's own pubkey derivation.
+    let ed_pub = SigningKey::from_bytes(&seed).verifying_key().to_bytes();
+    assert_eq!(ed_pub, hex32(ED_PUB));
+
+    // The X25519 public key derived from the seed's private scalar must equal
+    // the X25519 public key converted from the Ed25519 public key.
+    let from_private = x25519_public_key(&ed25519_seed_to_x25519_private(&seed));
+    let from_ed_pub = ed25519_pub_to_x25519_pub(&ed_pub).unwrap();
+    assert_eq!(from_private, from_ed_pub);
+
+    // The keypair helper agrees with the standalone private derivation.
+    assert_eq!(
+        ed25519_seed_to_x25519_keypair(&seed).public_key,
+        from_private
+    );
+}
+
+#[test]
+fn kdf_root_and_chain_are_deterministic() {
+    let root = [7u8; 32];
+    let dh = [9u8; 32];
+    let (r1, c1) = kdf_root_key(&root, &dh);
+    let (r2, c2) = kdf_root_key(&root, &dh);
+    assert_eq!((r1, c1), (r2, c2));
+    assert_ne!(r1, c1);
+
+    let (next_chain, message_key) = kdf_chain_key(&c1);
+    assert_ne!(next_chain, message_key);
+    // Advancing again yields a different chain key (ratchet moves forward).
+    assert_ne!(kdf_chain_key(&next_chain).0, next_chain);
+}
+
+#[test]
+fn derive_message_keys_lengths_and_determinism() {
+    let mk = [3u8; 32];
+    let (enc1, mac1, iv1) = derive_message_keys(&mk);
+    let (enc2, mac2, iv2) = derive_message_keys(&mk);
+    assert_eq!((enc1, mac1, iv1), (enc2, mac2, iv2));
+    assert_ne!(enc1, mac1);
+}
+
+#[test]
+fn aead_round_trip() {
+    let mk = [42u8; 32];
+    let plaintext = b"the quick brown fox jumps over a tiny place";
+    let ad = b"associated-data";
+    let sealed = encrypt(&mk, plaintext, ad);
+    // Output is deterministic (iv derives from the message key).
+    assert_eq!(sealed, encrypt(&mk, plaintext, ad));
+    let opened = decrypt(&mk, &sealed, ad).unwrap();
+    assert_eq!(opened, plaintext);
+}
+
+#[test]
+fn aead_rejects_tampered_mac() {
+    let mk = [42u8; 32];
+    let ad = b"ad";
+    let mut sealed = encrypt(&mk, b"secret", ad);
+    let last = sealed.len() - 1;
+    sealed[last] ^= 0x01;
+    assert!(decrypt(&mk, &sealed, ad).is_err());
+}
+
+#[test]
+fn aead_rejects_wrong_associated_data() {
+    let mk = [42u8; 32];
+    let sealed = encrypt(&mk, b"secret", b"ad-a");
+    assert!(decrypt(&mk, &sealed, b"ad-b").is_err());
+}

--- a/sdk/rust/tests/signal_keys.rs
+++ b/sdk/rust/tests/signal_keys.rs
@@ -1,0 +1,59 @@
+//! Tests for Signal pre-key generation & serialization. The signature contract
+//! (Ed25519 over the base64 public key) is interop-critical — the backend
+//! verifies it the same way — so we verify it here with ed25519-dalek directly.
+
+use base64::Engine as _;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use tinyplace::signal::keys::{generate_pre_keys, generate_signed_pre_key, serialize_pre_key};
+use tinyplace::LocalSigner;
+
+fn b64(value: &str) -> Vec<u8> {
+    base64::engine::general_purpose::STANDARD
+        .decode(value)
+        .unwrap()
+}
+
+fn verify_signature(signer: &LocalSigner, public_key: &[u8], signature: &[u8]) -> bool {
+    let verifying = VerifyingKey::from_bytes(signer.public_key()).unwrap();
+    let public_key_b64 = base64::engine::general_purpose::STANDARD.encode(public_key);
+    let sig = Signature::from_slice(signature).unwrap();
+    verifying.verify(public_key_b64.as_bytes(), &sig).is_ok()
+}
+
+#[tokio::test]
+async fn signed_pre_key_signature_verifies_over_base64_pubkey() {
+    let signer = LocalSigner::from_seed(&[1u8; 32]).unwrap();
+    let pre_key = generate_signed_pre_key(&signer, "spk_1").await.unwrap();
+    assert_eq!(pre_key.key_id, "spk_1");
+    assert_eq!(pre_key.key_pair.public_key.len(), 32);
+    assert!(verify_signature(
+        &signer,
+        &pre_key.key_pair.public_key,
+        &pre_key.signature
+    ));
+}
+
+#[tokio::test]
+async fn generate_pre_keys_ids_and_count() {
+    let signer = LocalSigner::from_seed(&[2u8; 32]).unwrap();
+    let pre_keys = generate_pre_keys(&signer, 100, 3).await.unwrap();
+    let ids: Vec<&str> = pre_keys.iter().map(|k| k.key_id.as_str()).collect();
+    assert_eq!(ids, ["pk_100", "pk_101", "pk_102"]);
+    for pre_key in &pre_keys {
+        assert!(verify_signature(
+            &signer,
+            &pre_key.key_pair.public_key,
+            &pre_key.signature
+        ));
+    }
+}
+
+#[tokio::test]
+async fn serialize_pre_key_round_trips_base64() {
+    let signer = LocalSigner::from_seed(&[3u8; 32]).unwrap();
+    let pre_key = generate_signed_pre_key(&signer, "spk_2").await.unwrap();
+    let serialized = serialize_pre_key(&pre_key);
+    assert_eq!(serialized.key_id, "spk_2");
+    assert_eq!(b64(&serialized.public_key), pre_key.key_pair.public_key);
+    assert_eq!(b64(&serialized.signature.unwrap()), pre_key.signature);
+}

--- a/sdk/rust/tests/signal_ratchet.rs
+++ b/sdk/rust/tests/signal_ratchet.rs
@@ -1,0 +1,93 @@
+//! Double Ratchet end-to-end tests: bootstrap two sessions via X3DH, then
+//! exchange messages (back-and-forth + out-of-order) and assert they decrypt.
+
+use tinyplace::signal::crypto::{ed25519_seed_to_x25519_keypair, generate_x25519_keypair};
+use tinyplace::signal::ratchet::{ratchet_decrypt, ratchet_encrypt};
+use tinyplace::signal::store::SessionState;
+use tinyplace::signal::x3dh::{build_associated_data, x3dh_initiate, x3dh_respond, X3DHBundle};
+
+/// Bootstrap an (initiator, responder) session pair via X3DH.
+fn bootstrap() -> (SessionState, SessionState, Vec<u8>, Vec<u8>) {
+    let alice = ed25519_seed_to_x25519_keypair(&[1u8; 32]);
+    let bob = ed25519_seed_to_x25519_keypair(&[2u8; 32]);
+    let bob_spk = generate_x25519_keypair();
+    let bob_otk = generate_x25519_keypair();
+
+    let bundle = X3DHBundle {
+        identity_key: bob.public_key,
+        signed_pre_key_id: "spk_1".into(),
+        signed_pre_key: bob_spk.public_key,
+        one_time_pre_key_id: Some("pk_1".into()),
+        one_time_pre_key: Some(bob_otk.public_key),
+    };
+
+    let init = x3dh_initiate(&alice, &bundle);
+    let bob_session = x3dh_respond(
+        &bob,
+        &bob_spk,
+        &alice.public_key,
+        &init.ephemeral_public_key,
+        Some(&bob_otk),
+    );
+
+    // AD is direction-scoped: sender_identity || recipient_identity.
+    let a_to_b = build_associated_data(&alice.public_key, &bob.public_key);
+    let b_to_a = build_associated_data(&bob.public_key, &alice.public_key);
+    (init.session, bob_session, a_to_b, b_to_a)
+}
+
+#[test]
+fn back_and_forth_conversation() {
+    let (mut alice, mut bob, a_to_b, b_to_a) = bootstrap();
+
+    // Alice -> Bob
+    let m1 = ratchet_encrypt(&mut alice, b"hello bob", &a_to_b).unwrap();
+    assert_eq!(
+        ratchet_decrypt(&mut bob, &m1, &a_to_b).unwrap(),
+        b"hello bob"
+    );
+
+    // Bob -> Alice (triggers a DH ratchet on both sides)
+    let m2 = ratchet_encrypt(&mut bob, b"hi alice", &b_to_a).unwrap();
+    assert_eq!(
+        ratchet_decrypt(&mut alice, &m2, &b_to_a).unwrap(),
+        b"hi alice"
+    );
+
+    // Alice -> Bob again
+    let m3 = ratchet_encrypt(&mut alice, b"how are you", &a_to_b).unwrap();
+    assert_eq!(
+        ratchet_decrypt(&mut bob, &m3, &a_to_b).unwrap(),
+        b"how are you"
+    );
+
+    // Several in a row from Bob.
+    for i in 0..5u8 {
+        let msg = vec![i; 10];
+        let ct = ratchet_encrypt(&mut bob, &msg, &b_to_a).unwrap();
+        assert_eq!(ratchet_decrypt(&mut alice, &ct, &b_to_a).unwrap(), msg);
+    }
+}
+
+#[test]
+fn out_of_order_delivery_uses_skipped_keys() {
+    let (mut alice, mut bob, a_to_b, _b_to_a) = bootstrap();
+
+    // Alice sends three; Bob receives them 3rd, 1st, 2nd.
+    let m1 = ratchet_encrypt(&mut alice, b"one", &a_to_b).unwrap();
+    let m2 = ratchet_encrypt(&mut alice, b"two", &a_to_b).unwrap();
+    let m3 = ratchet_encrypt(&mut alice, b"three", &a_to_b).unwrap();
+
+    assert_eq!(ratchet_decrypt(&mut bob, &m3, &a_to_b).unwrap(), b"three");
+    assert_eq!(ratchet_decrypt(&mut bob, &m1, &a_to_b).unwrap(), b"one");
+    assert_eq!(ratchet_decrypt(&mut bob, &m2, &a_to_b).unwrap(), b"two");
+}
+
+#[test]
+fn tampered_ciphertext_fails() {
+    let (mut alice, mut bob, a_to_b, _b_to_a) = bootstrap();
+    let mut m1 = ratchet_encrypt(&mut alice, b"secret", &a_to_b).unwrap();
+    let last = m1.ciphertext.len() - 1;
+    m1.ciphertext[last] ^= 0x01;
+    assert!(ratchet_decrypt(&mut bob, &m1, &a_to_b).is_err());
+}

--- a/sdk/rust/tests/signal_store.rs
+++ b/sdk/rust/tests/signal_store.rs
@@ -1,0 +1,86 @@
+//! Tests for the in-memory Signal session store.
+
+use std::collections::HashMap;
+
+use tinyplace::signal::crypto::{ed25519_seed_to_x25519_keypair, X25519KeyPair};
+use tinyplace::signal::keys::PreKeyPair;
+use tinyplace::signal::memory_store::MemorySessionStore;
+use tinyplace::signal::store::{skipped_key_id, SessionState, SessionStore};
+
+fn store() -> MemorySessionStore {
+    MemorySessionStore::new(ed25519_seed_to_x25519_keypair(&[1u8; 32]))
+}
+
+fn pre_key(id: &str) -> PreKeyPair {
+    PreKeyPair {
+        key_id: id.to_string(),
+        key_pair: X25519KeyPair {
+            public_key: [2u8; 32],
+            private_key: [3u8; 32],
+        },
+        signature: vec![4u8; 64],
+    }
+}
+
+fn session_state() -> SessionState {
+    SessionState {
+        dh_send_key_pair: X25519KeyPair {
+            public_key: [5u8; 32],
+            private_key: [6u8; 32],
+        },
+        dh_recv_public_key: None,
+        root_key: [7u8; 32],
+        send_chain_key: None,
+        recv_chain_key: None,
+        send_message_number: 0,
+        recv_message_number: 0,
+        previous_chain_length: 0,
+        skipped_keys: HashMap::new(),
+    }
+}
+
+#[tokio::test]
+async fn identity_key_pair_is_the_constructor_key() {
+    let expected = ed25519_seed_to_x25519_keypair(&[1u8; 32]);
+    let got = store().identity_x25519_key_pair().await.unwrap();
+    assert_eq!(got.public_key, expected.public_key);
+}
+
+#[tokio::test]
+async fn pre_key_store_get_remove_and_list() {
+    let store = store();
+    assert!(store.pre_key("pk_1").await.unwrap().is_none());
+    store.store_pre_key(pre_key("pk_1")).await.unwrap();
+    store.store_pre_key(pre_key("pk_2")).await.unwrap();
+    assert!(store.pre_key("pk_1").await.unwrap().is_some());
+    assert_eq!(store.all_pre_keys().await.unwrap().len(), 2);
+    store.remove_pre_key("pk_1").await.unwrap();
+    assert!(store.pre_key("pk_1").await.unwrap().is_none());
+    assert_eq!(store.all_pre_keys().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn signed_pre_key_tracks_active() {
+    let store = store();
+    assert!(store.active_signed_pre_key().await.is_err());
+    store.store_signed_pre_key(pre_key("spk_1")).await.unwrap();
+    store.store_signed_pre_key(pre_key("spk_2")).await.unwrap();
+    // Latest stored becomes active.
+    assert_eq!(store.active_signed_pre_key().await.unwrap().key_id, "spk_2");
+    assert!(store.signed_pre_key("spk_1").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn session_store_get_remove() {
+    let store = store();
+    assert!(store.session("peer").await.unwrap().is_none());
+    store.store_session("peer", session_state()).await.unwrap();
+    assert!(store.session("peer").await.unwrap().is_some());
+    store.remove_session("peer").await.unwrap();
+    assert!(store.session("peer").await.unwrap().is_none());
+}
+
+#[test]
+fn skipped_key_id_format() {
+    assert_eq!(skipped_key_id(&[0x00, 0xff, 0x0a], 7), "00ff0a:7");
+}

--- a/sdk/rust/tests/signal_x3dh.rs
+++ b/sdk/rust/tests/signal_x3dh.rs
@@ -1,0 +1,108 @@
+//! X3DH tests. The core property: initiator and responder derive the SAME root
+//! key — the agreement that bootstraps the Double Ratchet.
+
+use base64::Engine as _;
+use tinyplace::signal::crypto::{ed25519_seed_to_x25519_keypair, generate_x25519_keypair};
+use tinyplace::signal::keys::generate_signed_pre_key;
+use tinyplace::signal::x3dh::{verify_pre_key_signature, x3dh_initiate, x3dh_respond, X3DHBundle};
+use tinyplace::LocalSigner;
+
+#[test]
+fn initiator_and_responder_agree_with_one_time_prekey() {
+    let alice = ed25519_seed_to_x25519_keypair(&[1u8; 32]);
+    let bob = ed25519_seed_to_x25519_keypair(&[2u8; 32]);
+    let bob_spk = generate_x25519_keypair();
+    let bob_otk = generate_x25519_keypair();
+
+    let bundle = X3DHBundle {
+        identity_key: bob.public_key,
+        signed_pre_key_id: "spk_1".into(),
+        signed_pre_key: bob_spk.public_key,
+        one_time_pre_key_id: Some("pk_1".into()),
+        one_time_pre_key: Some(bob_otk.public_key),
+    };
+
+    let init = x3dh_initiate(&alice, &bundle);
+    let responder = x3dh_respond(
+        &bob,
+        &bob_spk,
+        &alice.public_key,
+        &init.ephemeral_public_key,
+        Some(&bob_otk),
+    );
+
+    assert_eq!(init.session.root_key, responder.root_key);
+    assert_eq!(init.signed_pre_key_id, "spk_1");
+    assert_eq!(init.one_time_pre_key_id.as_deref(), Some("pk_1"));
+}
+
+#[test]
+fn initiator_and_responder_agree_without_one_time_prekey() {
+    let alice = ed25519_seed_to_x25519_keypair(&[3u8; 32]);
+    let bob = ed25519_seed_to_x25519_keypair(&[4u8; 32]);
+    let bob_spk = generate_x25519_keypair();
+
+    let bundle = X3DHBundle {
+        identity_key: bob.public_key,
+        signed_pre_key_id: "spk_1".into(),
+        signed_pre_key: bob_spk.public_key,
+        one_time_pre_key_id: None,
+        one_time_pre_key: None,
+    };
+
+    let init = x3dh_initiate(&alice, &bundle);
+    let responder = x3dh_respond(
+        &bob,
+        &bob_spk,
+        &alice.public_key,
+        &init.ephemeral_public_key,
+        None,
+    );
+
+    assert_eq!(init.session.root_key, responder.root_key);
+}
+
+#[test]
+fn one_time_prekey_changes_the_root_key() {
+    // A bundle WITH a one-time prekey must derive a different root than WITHOUT.
+    let alice = ed25519_seed_to_x25519_keypair(&[5u8; 32]);
+    let bob = ed25519_seed_to_x25519_keypair(&[6u8; 32]);
+    let bob_spk = generate_x25519_keypair();
+    let bob_otk = generate_x25519_keypair();
+
+    let base = X3DHBundle {
+        identity_key: bob.public_key,
+        signed_pre_key_id: "spk_1".into(),
+        signed_pre_key: bob_spk.public_key,
+        one_time_pre_key_id: None,
+        one_time_pre_key: None,
+    };
+    let with_otk = X3DHBundle {
+        one_time_pre_key_id: Some("pk_1".into()),
+        one_time_pre_key: Some(bob_otk.public_key),
+        ..base.clone()
+    };
+
+    assert_ne!(
+        x3dh_initiate(&alice, &base).session.root_key,
+        x3dh_initiate(&alice, &with_otk).session.root_key
+    );
+}
+
+#[tokio::test]
+async fn verify_pre_key_signature_accepts_valid_and_rejects_tampered() {
+    let signer = LocalSigner::from_seed(&[9u8; 32]).unwrap();
+    let pre_key = generate_signed_pre_key(&signer, "spk_1").await.unwrap();
+    let pub_b64 = base64::engine::general_purpose::STANDARD.encode(pre_key.key_pair.public_key);
+    let sig_b64 = base64::engine::general_purpose::STANDARD.encode(&pre_key.signature);
+
+    assert!(verify_pre_key_signature(signer.public_key(), &pub_b64, Some(&sig_b64), "spk").is_ok());
+    assert!(verify_pre_key_signature(signer.public_key(), &pub_b64, None, "spk").is_err());
+
+    let mut tampered = pre_key.signature.clone();
+    tampered[0] ^= 0x01;
+    let bad_b64 = base64::engine::general_purpose::STANDARD.encode(&tampered);
+    assert!(
+        verify_pre_key_signature(signer.public_key(), &pub_b64, Some(&bad_b64), "spk").is_err()
+    );
+}


### PR DESCRIPTION
Part 5 of the Rust Signal port (#18) — the message-key state machine. Mirrors `sdk/typescript/src/signal/ratchet.ts`.

- `ratchet_encrypt` / `ratchet_decrypt` (synchronous — Rust AES, unlike TS WebCrypto)
- DH ratchet step on each direction change + symmetric-key ratchet per chain
- skipped-message-key handling (`MAX_SKIP=1000`) for out-of-order delivery
- `RatchetHeader` wire form: `public_key(32) || previous_chain_length(u32 BE) || message_number(u32 BE)`

Reuses crypto/store primitives from parts 1/3 — no duplicate logic.

## Tests (the real correctness check)
Bootstrap two sessions via X3DH, then:
- **Back-and-forth conversation** (Alice↔Bob, triggering DH ratchet steps both directions, plus a run of consecutive messages) ✅
- **Out-of-order delivery** — messages received 3rd/1st/2nd decrypt via skipped keys ✅
- **Tampered ciphertext** rejected ✅

## Validation (`sdk/rust/`)
- `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test` ✅

⚠️ Stacked on #73 → #72 → #70 → #69. Part of #18. Next: part 6 (1:1 session layer + message wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)