### PR TITLE
fix(sdk/python): address agents by cryptoId so encrypted-messaging relay writes authenticate

### DIFF
--- a/sdk/python/src/tinyplace/api/messages.py
+++ b/sdk/python/src/tinyplace/api/messages.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Callable, Optional
 
+from ..crypto import decode_base58
 from ..http import HttpClient, encode
 from ..signal.crypto import ed25519_pub_to_x25519_pub, from_base64
 from ..types import Json, JsonDict
@@ -128,7 +129,7 @@ class MessagesApi:
         """
         has_session = await session.has_session(to_address)
         bundle = None if has_session else _bundle_of(await self._fetch_bundle(to_address))
-        recipient_ed25519 = from_base64(to_address)
+        recipient_ed25519 = decode_agent_address(to_address)
         recipient_x25519 = ed25519_pub_to_x25519_pub(recipient_ed25519)
 
         encrypted = await session.encrypt(
@@ -192,7 +193,7 @@ class MessagesApi:
         for envelope in messages:
             sender = str(envelope.get("from") or "")
             try:
-                sender_x25519 = ed25519_pub_to_x25519_pub(from_base64(sender))
+                sender_x25519 = ed25519_pub_to_x25519_pub(decode_agent_address(sender))
                 plaintext = await session.decrypt(sender, sender_x25519, envelope)
             except Exception as error:  # noqa: BLE001 - one bad message must not abort the batch
                 if on_error is not None:
@@ -240,6 +241,25 @@ _CURSOR_SEP = "|"
 _LOGGER = logging.getLogger(__name__)
 
 _message_counter = 0
+
+
+def decode_agent_address(address: str) -> bytes:
+    """Decode an agent messaging address to its 32-byte Ed25519 public key.
+
+    An agent address is that key encoded as either a **base58 cryptoId** (the
+    canonical, URL-safe form the backend routes/authenticates on) or **base64**.
+    The base64 form contains ``/`` and ``=``, which break signed relay writes
+    whose path/query carry the address, so the cryptoId form is preferred; base64
+    is accepted as a fallback for interop. Base58 is tried first and only
+    accepted when it yields exactly 32 bytes.
+    """
+    try:
+        raw = decode_base58(address)
+        if len(raw) == 32:
+            return raw
+    except Exception:  # noqa: BLE001 - not base58; fall back to base64 below
+        pass
+    return from_base64(address)
 
 
 def _next_message_id() -> str:

--- a/sdk/python/src/tinyplace/api/messages.py
+++ b/sdk/python/src/tinyplace/api/messages.py
@@ -259,7 +259,12 @@ def decode_agent_address(address: str) -> bytes:
             return raw
     except Exception:  # noqa: BLE001 - not base58; fall back to base64 below
         pass
-    return from_base64(address)
+    raw = from_base64(address)
+    if len(raw) != 32:
+        raise ValueError(
+            f"Agent address must decode to a 32-byte Ed25519 public key, got {len(raw)}"
+        )
+    return raw
 
 
 def _next_message_id() -> str:

--- a/sdk/python/tests/test_agent_address.py
+++ b/sdk/python/tests/test_agent_address.py
@@ -1,0 +1,45 @@
+"""decode_agent_address accepts both cryptoId (base58) and base64 forms.
+
+An agent's messaging address is its 32-byte Ed25519 public key. The base64
+encoding contains ``/`` and ``=``, which break signed relay writes that carry
+the address in the path/query, so the base58 cryptoId is the canonical form;
+base64 is accepted for interop. Both must decode to the same key bytes.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tinyplace.api.messages import decode_agent_address
+from tinyplace.crypto import derive_crypto_id, public_key_to_base64
+
+
+def test_decodes_cryptoid_and_base64_to_same_key() -> None:
+    pub = os.urandom(32)
+    crypto_id = derive_crypto_id(pub)        # base58
+    base64_addr = public_key_to_base64(pub)  # base64 (std alphabet, may have / or =)
+
+    assert decode_agent_address(crypto_id) == pub
+    assert decode_agent_address(base64_addr) == pub
+
+
+def test_decodes_base64_address_containing_slash() -> None:
+    # Find a key whose base64 contains '/' or '=' (the chars that broke relay
+    # auth); decoding must still recover the exact key.
+    for _ in range(64):
+        pub = os.urandom(32)
+        b64 = public_key_to_base64(pub)
+        if "/" in b64 or "=" in b64:
+            assert decode_agent_address(b64) == pub
+            return
+    pytest.skip("no base64 with / or = generated in 64 tries (vanishingly unlikely)")
+
+
+def test_prefers_base58_when_ambiguous() -> None:
+    # A real cryptoId is valid base58 decoding to 32 bytes; it must be taken as
+    # base58, not mis-read as base64.
+    pub = os.urandom(32)
+    crypto_id = derive_crypto_id(pub)
+    assert decode_agent_address(crypto_id) == pub

--- a/sdk/python/tests/test_agent_address.py
+++ b/sdk/python/tests/test_agent_address.py
@@ -43,3 +43,11 @@ def test_prefers_base58_when_ambiguous() -> None:
     pub = os.urandom(32)
     crypto_id = derive_crypto_id(pub)
     assert decode_agent_address(crypto_id) == pub
+
+
+def test_rejects_address_of_wrong_length() -> None:
+    # A base64 value that decodes to != 32 bytes must raise a clear error, not
+    # return malformed key bytes that crash deeper in the Signal stack.
+    short = public_key_to_base64(os.urandom(16))
+    with pytest.raises(ValueError, match="32-byte"):
+        decode_agent_address(short)


### PR DESCRIPTION
## Problem

The Python SDK's **encrypted messaging never worked against a live backend** (its e2e tests are skipped, so this path was never exercised). Reproduced against staging: publishing prekeys returns `403 relay signature required`.

Two coupled failures, both rooted in agent-address encoding:
1. A **base64** Ed25519 public key contains `/` and `=` → `%2F`/`%3D` in the URL. The relay signs over the server-side RequestURI, so signed writes addressed by the base64 key (`PUT /keys/{id}/signed-prekey`, `/prekeys`, `GET /messages?agentId=`) fail signature verification. The backend accepts the URL-safe **base58 cryptoId** (`PublicKeyMatchesCryptoID`).
2. `send_encrypted`/`poll_inbox_decrypted` derived the peer identity via `from_base64(address)`; a cryptoId address then decoded to garbage and the X3DH bundle signature was rejected.

> Note: the **website TS SDK has the same latent bug** (`signal-messaging.ts` uses `signer.publicKeyBase64` as the address). Worth a follow-up; this PR fixes the Python side.

## Fix

`decode_agent_address()` — base58 cryptoId (preferred, 32-byte check) with base64 fallback for interop — used at both crypto-identity-derivation sites. The Hermes plugin now addresses by cryptoId (separate PR #75).

## Verification

End-to-end against **staging**: two agents publish prekeys, exchange an X3DH `PREKEY_BUNDLE` message, and the recipient decrypts it. Existing suite: 172 passed; 3 new unit tests for the decoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved agent address decoding used by encrypted messaging to correctly interpret both base58 and base64 address formats, with stricter validation to prevent incorrect key lengths during encryption/decryption.

* **Tests**
  * Added new coverage for address decoding, including canonical conversions, handling of base64 characters, preference rules for ambiguous inputs, and clear failure behavior when the decoded value is not the expected size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->