### PR TITLE
feat(sdk/rust): Signal Sender Keys / group messaging (part 7 of #18)

### DIFF
--- a/sdk/rust/src/signal/mod.rs
+++ b/sdk/rust/src/signal/mod.rs
@@ -9,6 +9,7 @@ pub mod crypto;
 pub mod keys;
 pub mod memory_store;
 pub mod ratchet;
+pub mod sender_key;
 pub mod session;
 pub mod store;
 pub mod x3dh;

--- a/sdk/rust/src/signal/sender_key.rs
+++ b/sdk/rust/src/signal/sender_key.rs
@@ -1,0 +1,236 @@
+//! Sender Keys for group messaging. Mirrors `sdk/typescript/src/signal/sender-key.ts`.
+//!
+//! Each sender has a symmetric chain key (ratcheted once per message) plus an
+//! Ed25519 signing key so receivers can attribute and verify messages. A sender
+//! shares a [`SenderKeyDistribution`] (chain key at an iteration + its signature
+//! public key) over an already-secure 1:1 channel; receivers init from it and
+//! read forward.
+
+use std::collections::HashMap;
+
+use ed25519_dalek::{Signature, Signer as _, SigningKey, Verifier as _, VerifyingKey};
+use rand::RngCore as _;
+use serde::{Deserialize, Serialize};
+
+use crate::crypto::{from_base64, to_base64};
+use crate::error::{Error, Result};
+use crate::signal::crypto::{decrypt, encrypt, kdf_chain_key};
+
+/// How far a receiver will fast-forward to reach an out-of-order message.
+const MAX_SKIP: u32 = 2000;
+
+/// Group sender-key messages carry no associated data; the Ed25519 signature
+/// authenticates the sender.
+const EMPTY_AD: &[u8] = &[];
+
+/// Public, distributable snapshot of a sender's group key, shared over a secure
+/// 1:1 channel so other members can decrypt from `iteration` forward.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SenderKeyDistribution {
+    pub chain_key: String,
+    pub iteration: u32,
+    pub signature_public_key: String,
+}
+
+/// A single encrypted group message produced by a [`GroupSenderKey`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SenderKeyMessage {
+    pub iteration: u32,
+    pub ciphertext: String,
+    pub signature: String,
+}
+
+/// Persistable snapshot of the sending half (includes the private signing key).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SenderKeyOwnState {
+    pub chain_key: String,
+    pub iteration: u32,
+    pub signature_private_key: String,
+    pub signature_public_key: String,
+}
+
+/// Persistable snapshot of the receiving half.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SenderKeyReceiverState {
+    pub chain_key: String,
+    pub iteration: u32,
+    pub signature_public_key: String,
+    pub skipped: HashMap<u32, String>,
+}
+
+/// The sending half of a Sender Key. One per (group, sender, membership epoch).
+pub struct GroupSenderKey {
+    chain_key: [u8; 32],
+    iteration: u32,
+    signing_key: SigningKey,
+}
+
+impl GroupSenderKey {
+    /// A brand-new sender key with a random chain key and signing pair.
+    pub fn create() -> Self {
+        let mut chain_key = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut chain_key);
+        let mut seed = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut seed);
+        Self {
+            chain_key,
+            iteration: 0,
+            signing_key: SigningKey::from_bytes(&seed),
+        }
+    }
+
+    /// Rebuild from [`serialize`](Self::serialize) output.
+    pub fn restore(state: &SenderKeyOwnState) -> Result<Self> {
+        Ok(Self {
+            chain_key: decode_key(&state.chain_key)?,
+            iteration: state.iteration,
+            signing_key: SigningKey::from_bytes(&decode_key(&state.signature_private_key)?),
+        })
+    }
+
+    /// The current message number (advances after each [`encrypt`](Self::encrypt)).
+    pub fn current_iteration(&self) -> u32 {
+        self.iteration
+    }
+
+    /// Persistable snapshot including the private signing key. Keep secret.
+    pub fn serialize(&self) -> SenderKeyOwnState {
+        SenderKeyOwnState {
+            chain_key: to_base64(&self.chain_key),
+            iteration: self.iteration,
+            signature_private_key: to_base64(&self.signing_key.to_bytes()),
+            signature_public_key: to_base64(&self.signing_key.verifying_key().to_bytes()),
+        }
+    }
+
+    /// Snapshot to hand other members so they can decrypt from here forward.
+    pub fn distribution(&self) -> SenderKeyDistribution {
+        SenderKeyDistribution {
+            chain_key: to_base64(&self.chain_key),
+            iteration: self.iteration,
+            signature_public_key: to_base64(&self.signing_key.verifying_key().to_bytes()),
+        }
+    }
+
+    /// Encrypt and sign one group message, ratcheting the chain forward.
+    pub fn encrypt(&mut self, plaintext: &[u8]) -> SenderKeyMessage {
+        let iteration = self.iteration;
+        let (next_chain, message_key) = kdf_chain_key(&self.chain_key);
+        let ciphertext = encrypt(&message_key, plaintext, EMPTY_AD);
+        let signature = self.signing_key.sign(&ciphertext);
+        self.chain_key = next_chain;
+        self.iteration += 1;
+        SenderKeyMessage {
+            iteration,
+            ciphertext: to_base64(&ciphertext),
+            signature: to_base64(&signature.to_bytes()),
+        }
+    }
+}
+
+/// The receiving half of a Sender Key: another member's chain key + signature
+/// public key, tolerant of out-of-order delivery via cached skipped keys.
+pub struct GroupSenderKeyReceiver {
+    chain_key: [u8; 32],
+    iteration: u32,
+    signature_public_key: [u8; 32],
+    skipped: HashMap<u32, [u8; 32]>,
+}
+
+impl GroupSenderKeyReceiver {
+    /// Initialise from a sender's distribution snapshot.
+    pub fn from_distribution(distribution: &SenderKeyDistribution) -> Result<Self> {
+        Ok(Self {
+            chain_key: decode_key(&distribution.chain_key)?,
+            iteration: distribution.iteration,
+            signature_public_key: decode_key(&distribution.signature_public_key)?,
+            skipped: HashMap::new(),
+        })
+    }
+
+    /// Rebuild from [`serialize`](Self::serialize) output.
+    pub fn restore(state: &SenderKeyReceiverState) -> Result<Self> {
+        let mut skipped = HashMap::with_capacity(state.skipped.len());
+        for (iteration, key) in &state.skipped {
+            skipped.insert(*iteration, decode_key(key)?);
+        }
+        Ok(Self {
+            chain_key: decode_key(&state.chain_key)?,
+            iteration: state.iteration,
+            signature_public_key: decode_key(&state.signature_public_key)?,
+            skipped,
+        })
+    }
+
+    /// Persistable snapshot of the receiver chain and any cached skipped keys.
+    pub fn serialize(&self) -> SenderKeyReceiverState {
+        SenderKeyReceiverState {
+            chain_key: to_base64(&self.chain_key),
+            iteration: self.iteration,
+            signature_public_key: to_base64(&self.signature_public_key),
+            skipped: self
+                .skipped
+                .iter()
+                .map(|(iteration, key)| (*iteration, to_base64(key)))
+                .collect(),
+        }
+    }
+
+    /// Verify the signature, then decrypt the message at its iteration.
+    pub fn decrypt(&mut self, message: &SenderKeyMessage) -> Result<Vec<u8>> {
+        let ciphertext = from_base64(&message.ciphertext)
+            .map_err(|_| Error::InvalidArgument("invalid ciphertext".into()))?;
+        let signature_bytes = from_base64(&message.signature)
+            .map_err(|_| Error::InvalidArgument("invalid signature".into()))?;
+        let signature = Signature::from_slice(&signature_bytes)
+            .map_err(|_| Error::InvalidArgument("invalid signature".into()))?;
+        let verifying = VerifyingKey::from_bytes(&self.signature_public_key)
+            .map_err(|_| Error::InvalidArgument("invalid sender key".into()))?;
+        verifying.verify(&ciphertext, &signature).map_err(|_| {
+            Error::InvalidArgument("Sender key signature verification failed".into())
+        })?;
+
+        let message_key = self.message_key_for(message.iteration)?;
+        decrypt(&message_key, &ciphertext, EMPTY_AD)
+    }
+
+    /// Message key for `target`, advancing the chain and caching keys for any
+    /// skipped iterations along the way.
+    fn message_key_for(&mut self, target: u32) -> Result<[u8; 32]> {
+        if let Some(cached) = self.skipped.remove(&target) {
+            return Ok(cached);
+        }
+        if target < self.iteration {
+            return Err(Error::InvalidArgument(
+                "Sender key message is older than the current chain".into(),
+            ));
+        }
+        if target - self.iteration > MAX_SKIP {
+            return Err(Error::InvalidArgument(
+                "Too many skipped sender key messages".into(),
+            ));
+        }
+        while self.iteration < target {
+            let (next_chain, message_key) = kdf_chain_key(&self.chain_key);
+            self.skipped.insert(self.iteration, message_key);
+            self.chain_key = next_chain;
+            self.iteration += 1;
+        }
+        let (next_chain, message_key) = kdf_chain_key(&self.chain_key);
+        self.chain_key = next_chain;
+        self.iteration += 1;
+        Ok(message_key)
+    }
+}
+
+fn decode_key(base64: &str) -> Result<[u8; 32]> {
+    let bytes =
+        from_base64(base64).map_err(|_| Error::InvalidArgument("invalid base64 key".into()))?;
+    bytes
+        .try_into()
+        .map_err(|_| Error::InvalidArgument("key is not 32 bytes".into()))
+}

--- a/sdk/rust/tests/signal_sender_key.rs
+++ b/sdk/rust/tests/signal_sender_key.rs
@@ -1,0 +1,79 @@
+//! Sender Key (group messaging) tests: a sender's distribution bootstraps a
+//! receiver, who then verifies + decrypts messages, including out of order.
+
+use tinyplace::signal::sender_key::{GroupSenderKey, GroupSenderKeyReceiver, SenderKeyMessage};
+
+#[test]
+fn receiver_decrypts_in_order() {
+    let mut sender = GroupSenderKey::create();
+    let mut receiver = GroupSenderKeyReceiver::from_distribution(&sender.distribution()).unwrap();
+
+    for text in [b"one".as_slice(), b"two", b"three"] {
+        let msg = sender.encrypt(text);
+        assert_eq!(receiver.decrypt(&msg).unwrap(), text);
+    }
+}
+
+#[test]
+fn receiver_handles_out_of_order() {
+    let mut sender = GroupSenderKey::create();
+    let mut receiver = GroupSenderKeyReceiver::from_distribution(&sender.distribution()).unwrap();
+
+    let m0 = sender.encrypt(b"zero");
+    let m1 = sender.encrypt(b"one");
+    let m2 = sender.encrypt(b"two");
+
+    // Deliver 2, then 0, then 1.
+    assert_eq!(receiver.decrypt(&m2).unwrap(), b"two");
+    assert_eq!(receiver.decrypt(&m0).unwrap(), b"zero");
+    assert_eq!(receiver.decrypt(&m1).unwrap(), b"one");
+}
+
+#[test]
+fn distribution_lets_a_late_joiner_read_forward_only() {
+    let mut sender = GroupSenderKey::create();
+    let _early = sender.encrypt(b"before joining");
+    // Distribution snapshot taken AFTER the first message.
+    let mut receiver = GroupSenderKeyReceiver::from_distribution(&sender.distribution()).unwrap();
+
+    let later = sender.encrypt(b"after joining");
+    assert_eq!(receiver.decrypt(&later).unwrap(), b"after joining");
+
+    // The pre-join message is older than the receiver's chain — unreadable.
+    assert!(receiver.decrypt(&_early).is_err());
+}
+
+#[test]
+fn rejects_forged_signature() {
+    let sender = GroupSenderKey::create();
+    let receiver_dist = sender.distribution();
+    let mut receiver = GroupSenderKeyReceiver::from_distribution(&receiver_dist).unwrap();
+
+    // A different sender's signature over the same iteration must not verify.
+    let mut attacker = GroupSenderKey::restore(&{
+        let mut state = sender.serialize();
+        // Keep the chain, swap the signing key by creating a fresh own state.
+        let fresh = GroupSenderKey::create().serialize();
+        state.signature_private_key = fresh.signature_private_key;
+        state.signature_public_key = fresh.signature_public_key;
+        state
+    })
+    .unwrap();
+    let forged: SenderKeyMessage = attacker.encrypt(b"forged");
+    assert!(receiver.decrypt(&forged).is_err());
+}
+
+#[test]
+fn serialize_round_trips() {
+    let mut sender = GroupSenderKey::create();
+    let _ = sender.encrypt(b"advance");
+    let restored = GroupSenderKey::restore(&sender.serialize()).unwrap();
+    assert_eq!(restored.current_iteration(), sender.current_iteration());
+
+    let mut receiver = GroupSenderKeyReceiver::from_distribution(&sender.distribution()).unwrap();
+    let msg = sender.encrypt(b"hi");
+    let mut restored_receiver = GroupSenderKeyReceiver::restore(&receiver.serialize()).unwrap();
+    assert_eq!(restored_receiver.decrypt(&msg).unwrap(), b"hi");
+    // original receiver still works too
+    assert_eq!(receiver.decrypt(&msg).unwrap(), b"hi");
+}


### PR DESCRIPTION
Part 7 of the Rust Signal port (#18). Mirrors `sdk/typescript/src/signal/sender-key.ts`. Independent of part 6 (only depends on the part-1 crypto, already on `main`).

- **`GroupSenderKey`** (sending half) — symmetric chain key ratcheted once per message + an Ed25519 signing pair that signs every message. `create` / `restore` / `serialize` / `distribution` / `encrypt`.
- **`GroupSenderKeyReceiver`** (receiving half) — inits from a `SenderKeyDistribution`, **verifies the signature**, decrypts, and tolerates out-of-order delivery via cached skipped keys (`MAX_SKIP=2000`).
- Wire/persistence types: `SenderKeyDistribution`, `SenderKeyMessage`, `SenderKeyOwnState`, `SenderKeyReceiverState`.

Reuses `kdf_chain_key`/`encrypt`/`decrypt` — no duplicate logic.

## Tests
- In-order decrypt ✅
- Out-of-order delivery (2,0,1) via skipped keys ✅
- Late joiner reads forward-only (pre-join message unreadable) ✅
- Forged signature (different signing key) rejected ✅
- `serialize`/`restore` round-trips for both halves ✅

## Validation (`sdk/rust/`)
- `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test` ✅

Part of #18. Next: part 8 — cross-language interop verification + finalize (wire `signal` re-exports, README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Signal-style sender keys for group messaging in the Rust SDK, enabling secure message encryption, decryption, and automatic chain ratcheting for distributed group communications.

* **Tests**
  * Added comprehensive unit tests covering in-order and out-of-order message delivery scenarios, Ed25519 signature verification, forward-only access enforcement for late joiners, forgery detection, and state serialization round-trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->