### PR TITLE
fix(sdk/python): registration signature must match backend canonical payload (401)

### DIFF
--- a/sdk/python/src/tinyplace/api/registry.py
+++ b/sdk/python/src/tinyplace/api/registry.py
@@ -167,13 +167,15 @@ def _normalize_handle(username: str) -> str:
 
 
 def _registration_signature_payload(request: JsonDict) -> str:
+    # Must byte-match the backend's registrationPayload
+    # (backend-tinyplace/internal/identity/auth.go): exactly these four fields,
+    # no actorType/primary. Both sides serialize canonically (sorted keys, null
+    # for absent values), so any extra signed field breaks verification (401).
     return canonical_payload(
         "identity.register",
         {
-            "actorType": request.get("actorType"),
             "cryptoId": request.get("cryptoId"),
             "paymentMethods": request.get("paymentMethods"),
-            "primary": request.get("primary"),
             "publicKey": request.get("publicKey"),
             "username": request.get("username"),
         },

--- a/sdk/python/tests/test_registration_payload.py
+++ b/sdk/python/tests/test_registration_payload.py
@@ -1,0 +1,30 @@
+"""The registration signature payload must byte-match the backend.
+
+The backend (backend-tinyplace/internal/identity/auth.go registrationPayload)
+signs canonical {cryptoId, paymentMethods, publicKey, username}. The SDK
+previously also signed actorType/primary, producing different bytes and a
+401 "invalid signature" on POST /registry/names.
+"""
+
+from __future__ import annotations
+
+from tinyplace.api.registry import _registration_signature_payload
+from tinyplace.crypto import canonical_payload
+
+
+def test_payload_matches_backend_field_set() -> None:
+    request = {
+        "username": "@alice",
+        "cryptoId": "CID",
+        "publicKey": "PK",
+        "actorType": "agent",     # must NOT be signed
+        "primary": True,          # must NOT be signed
+        "paymentMethods": None,
+    }
+    expected = canonical_payload(
+        "identity.register",
+        {"cryptoId": "CID", "paymentMethods": None, "publicKey": "PK", "username": "@alice"},
+    )
+    got = _registration_signature_payload(request)
+    assert got == expected
+    assert "actorType" not in got and "primary" not in got

--- a/sdk/python/tests/test_registry.py
+++ b/sdk/python/tests/test_registry.py
@@ -40,16 +40,16 @@ async def test_register_normalizes_and_signs() -> None:
 
     body = json_body(session)
     assert body["username"] == "@agent"
+    # Must match the backend's registrationPayload exactly: only these four
+    # fields (no actorType/primary), or the backend rejects it with 401.
     assert verify_fresh_signature(
         signer,
         body["signature"],
         canonical_payload(
             "identity.register",
             {
-                "actorType": None,
                 "cryptoId": signer.agent_id,
                 "paymentMethods": None,
-                "primary": None,
                 "publicKey": signer.public_key_base64,
                 "username": "@agent",
             },


### PR DESCRIPTION
## Problem

`POST /registry/names` returns **401 "invalid signature"**. The SDK signs the canonical payload `{actorType, cryptoId, paymentMethods, primary, publicKey, username}`, but the backend (`backend-tinyplace/internal/identity/auth.go` `registrationPayload`) signs only `{cryptoId, paymentMethods, publicKey, username}`. Both serialize with sorted keys + null-for-absent, so the extra `actorType`/`primary` fields change the signed bytes → verification fails.

(Same class as #76 — the Python SDK's signed paths were never exercised against a live backend.)

## Fix

Sign only the four fields the backend signs. **Verified against staging**: registration now passes auth and returns `402` x402 payment-required (the real next step — claiming a handle costs 5 USDC) instead of 401.

Updates the existing registry test (which asserted the buggy 6-field payload) and adds a payload-shape regression test. Suite: 177 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)