### PR TITLE
fix(messaging): make Signal key-publish failures visible (#77)

### DIFF
--- a/website/src/common/signal-messaging.test.ts
+++ b/website/src/common/signal-messaging.test.ts
@@ -1,0 +1,60 @@
+import type { KeyBundle, TinyPlaceClient } from "@tinyhumansai/tinyplace";
+import { describe, expect, it, vi } from "vitest";
+
+import { verifyKeyBundlePublished } from "./signal-messaging";
+
+const ADDRESS = "Zm9vYmFy";
+
+function clientReturning(
+	getBundle: (agentId: string) => Promise<KeyBundle>
+): TinyPlaceClient {
+	return {
+		keys: { getBundle: vi.fn(getBundle) },
+	} as unknown as TinyPlaceClient;
+}
+
+function bundle(signedPreKeyPublicKey: string | undefined): KeyBundle {
+	return {
+		agentId: ADDRESS,
+		identityKey: ADDRESS,
+		signedPreKey: signedPreKeyPublicKey
+			? { keyId: "spk_1", publicKey: signedPreKeyPublicKey }
+			: ({ keyId: "spk_1" } as KeyBundle["signedPreKey"]),
+		updatedAt: "2026-01-01T00:00:00.000Z",
+	};
+}
+
+describe("verifyKeyBundlePublished", () => {
+	it("resolves and probes the relay when the bundle landed with a signed pre-key", async () => {
+		const getBundle = vi.fn(
+			(): Promise<KeyBundle> => Promise.resolve(bundle("c2lnbmVk"))
+		);
+		const client = clientReturning(getBundle);
+
+		await expect(
+			verifyKeyBundlePublished(client, ADDRESS)
+		).resolves.toBeUndefined();
+		expect(getBundle).toHaveBeenCalledWith(ADDRESS);
+	});
+
+	it("rejects when the relay has no bundle (404 surfaces as a throw)", async () => {
+		const client = clientReturning(
+			(): Promise<KeyBundle> =>
+				Promise.reject(new Error("Request failed with status 404"))
+		);
+
+		await expect(verifyKeyBundlePublished(client, ADDRESS)).rejects.toThrow(
+			"404"
+		);
+	});
+
+	it("rejects when a bundle exists but carries no usable signed pre-key", async () => {
+		const client = clientReturning(
+			(): Promise<KeyBundle> => Promise.resolve(bundle(undefined))
+		);
+
+		await expect(verifyKeyBundlePublished(client, ADDRESS)).rejects.toThrow(
+			"did not land on the relay"
+		);
+	});
+});

--- a/website/src/common/signal-messaging.ts
+++ b/website/src/common/signal-messaging.ts
@@ -1,7 +1,4 @@
-import {
-	SignalSession,
-	type TinyPlaceClient,
-} from "@tinyhumansai/tinyplace";
+import { SignalSession, type TinyPlaceClient } from "@tinyhumansai/tinyplace";
 
 import { createClient } from "@src/common/api-client";
 import type { SignalIdentity } from "@src/common/signal-identity";
@@ -47,6 +44,28 @@ export async function publishKeyBundle(
 	encClient: TinyPlaceClient
 ): Promise<void> {
 	await encClient.enableEncryption();
+}
+
+/**
+ * Confirms the identity's Signal key bundle is actually fetchable from the relay,
+ * so a successful publish can't silently leave the agent unreachable for DMs. The
+ * relay returns 404 (the SDK throws) when no bundle landed; a bundle missing its
+ * signed pre-key is treated the same way.
+ *
+ * @param encClient - The encryption-authenticated client.
+ * @param address - The identity's messaging address (base64 encryption pubkey).
+ * @throws If the bundle cannot be fetched or has no usable signed pre-key.
+ */
+export async function verifyKeyBundlePublished(
+	encClient: TinyPlaceClient,
+	address: string
+): Promise<void> {
+	const bundle = await encClient.keys.getBundle(address);
+	if (!bundle.signedPreKey?.publicKey) {
+		throw new Error(
+			`Key bundle for ${address} did not land on the relay (no signed pre-key)`
+		);
+	}
 }
 
 /**

--- a/website/src/hooks/use-signal-identity.test.ts
+++ b/website/src/hooks/use-signal-identity.test.ts
@@ -1,0 +1,135 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SignalIdentity } from "@src/common/signal-identity";
+import { useAuthStore } from "@src/store/auth";
+import { useConversationsStore } from "@src/store/conversations";
+import { useMessagingStore } from "@src/store/messaging";
+import { useSignalStore } from "@src/store/signal";
+
+import { useSignalIdentity } from "./use-signal-identity";
+
+const mocks = vi.hoisted(() => ({
+	signMessage: vi.fn(),
+	loadOrCreateSignalIdentity: vi.fn(),
+	publishKeyBundle: vi.fn(),
+	verifyKeyBundlePublished: vi.fn(),
+	publishEncryptionKey: vi.fn(),
+}));
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+	useWallet: (): unknown => ({
+		connected: true,
+		signMessage: mocks.signMessage,
+	}),
+}));
+
+vi.mock("@src/common/api-context", () => ({
+	useApiClient: (): unknown => ({}),
+}));
+
+vi.mock("@src/common/signal-identity", () => ({
+	loadOrCreateSignalIdentity: mocks.loadOrCreateSignalIdentity,
+	// The auto-restore effect calls hasSignalIdentity(); default it to false so
+	// these tests exercise the explicit enable() path deterministically.
+	hasSignalIdentity: (): boolean => false,
+}));
+
+vi.mock("@src/common/signal-messaging", () => ({
+	createEncryptionClient: (): unknown => ({ keys: { getBundle: vi.fn() } }),
+	createSession: (): unknown => ({}),
+	publishKeyBundle: mocks.publishKeyBundle,
+	verifyKeyBundlePublished: mocks.verifyKeyBundlePublished,
+}));
+
+vi.mock("@src/common/encryption-discovery", () => ({
+	publishEncryptionKey: mocks.publishEncryptionKey,
+}));
+
+const ADDRESS = "addr-1";
+const identity = {
+	signer: { publicKeyBase64: ADDRESS },
+	store: {},
+} as unknown as SignalIdentity;
+
+describe("useSignalIdentity enable()", () => {
+	beforeEach(() => {
+		useSignalStore.getState().reset();
+		useMessagingStore.getState().reset();
+		useConversationsStore.getState().reset();
+		useAuthStore.setState({ agentId: "wallet-agent" });
+
+		mocks.loadOrCreateSignalIdentity.mockResolvedValue(identity);
+		mocks.publishKeyBundle.mockResolvedValue(undefined);
+		mocks.verifyKeyBundlePublished.mockResolvedValue(undefined);
+		mocks.publishEncryptionKey.mockResolvedValue(undefined);
+		vi.spyOn(console, "error").mockImplementation((): void => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("reports ready and probes the relay once the bundle is verified", async () => {
+		const { result } = renderHook(() => useSignalIdentity());
+
+		let returned: SignalIdentity | undefined;
+		await act(async (): Promise<void> => {
+			returned = await result.current.enable();
+		});
+
+		expect(returned).toBe(identity);
+		// Success means the bundle was actually verified on the relay post-enable.
+		expect(mocks.verifyKeyBundlePublished).toHaveBeenCalledWith(
+			expect.anything(),
+			ADDRESS
+		);
+		expect(result.current.isReady).toBe(true);
+		expect(result.current.error).toBeUndefined();
+		expect(useMessagingStore.getState().bundleVerified).toBe(true);
+	});
+
+	it("propagates a publish failure into error state instead of silent success", async () => {
+		mocks.publishKeyBundle.mockRejectedValue(
+			new Error("MyTonWallet cannot sign prekeys")
+		);
+
+		const { result } = renderHook(() => useSignalIdentity());
+
+		let returned: SignalIdentity | undefined;
+		await act(async (): Promise<void> => {
+			returned = await result.current.enable();
+		});
+
+		// Must NOT report a usable identity when the bundle never published.
+		expect(returned).toBeUndefined();
+		expect(result.current.isReady).toBe(false);
+		expect(result.current.status).toBe("error");
+		expect(result.current.error).toContain("Messaging not reachable");
+		expect(result.current.error).toContain("MyTonWallet cannot sign prekeys");
+		expect(useMessagingStore.getState().bundleVerified).toBe(false);
+	});
+
+	it("fails when publish succeeds but the verification probe finds no bundle", async () => {
+		mocks.verifyKeyBundlePublished.mockRejectedValue(
+			new Error("Key bundle for addr-1 did not land on the relay")
+		);
+
+		const { result } = renderHook(() => useSignalIdentity());
+
+		let returned: SignalIdentity | undefined;
+		await act(async (): Promise<void> => {
+			returned = await result.current.enable();
+		});
+
+		expect(returned).toBeUndefined();
+		expect(result.current.isReady).toBe(false);
+		expect(result.current.status).toBe("error");
+		expect(result.current.error).toContain("did not land on the relay");
+		expect(useMessagingStore.getState().bundleVerified).toBe(false);
+		// Publish/advertise progress is cleared so a retry re-publishes instead of
+		// skipping straight to a verification that would keep failing.
+		expect(useMessagingStore.getState().bundlePublished).toBe(false);
+		expect(useMessagingStore.getState().keyAdvertised).toBe(false);
+	});
+});

--- a/website/src/hooks/use-signal-identity.ts
+++ b/website/src/hooks/use-signal-identity.ts
@@ -9,7 +9,10 @@ import {
 	hasSignalIdentity,
 	type SignalIdentity,
 } from "@src/common/signal-identity";
-import { publishKeyBundle } from "@src/common/signal-messaging";
+import {
+	publishKeyBundle,
+	verifyKeyBundlePublished,
+} from "@src/common/signal-messaging";
 import { useAuthStore } from "@src/store/auth";
 import { useConversationsStore } from "@src/store/conversations";
 import { useGroupConversationsStore } from "@src/store/group-conversations";
@@ -44,7 +47,9 @@ export function useSignalIdentity(): UseSignalIdentityResult {
 	const identity = useSignalStore((state) => state.identity);
 	const error = useSignalStore((state) => state.error);
 	const enableIdentity = useSignalStore((state) => state.enable);
+	const setPublishError = useSignalStore((state) => state.setPublishError);
 	const reset = useSignalStore((state) => state.reset);
+	const bundleVerified = useMessagingStore((state) => state.bundleVerified);
 	const setupMessaging = useMessagingStore((state) => state.setup);
 	const resetMessaging = useMessagingStore((state) => state.reset);
 	const ensureConversationsOwner = useConversationsStore(
@@ -90,26 +95,44 @@ export function useSignalIdentity(): UseSignalIdentityResult {
 			setupMessaging(readyIdentity);
 		}
 
-		// Publish the key bundle and advertise the encryption key. Both are tracked
-		// independently and retried on every enable() until they succeed, so a
-		// transient failure can't leave the user unreachable for DMs.
 		const encryptionClient = useMessagingStore.getState().encryptionClient;
-		if (encryptionClient) {
-			if (!useMessagingStore.getState().bundlePublished) {
-				try {
+		if (!encryptionClient) {
+			return undefined;
+		}
+
+		// Publish the key bundle, advertise the encryption key, then PROBE the relay
+		// to confirm the bundle is actually fetchable. Each step is tracked so a retry
+		// resumes where it failed. A failure here is propagated into the error state
+		// (not swallowed) and we return undefined, so "ready" can never mean
+		// "published but unreachable for DMs". The visible error + the enable button
+		// give the user a retry affordance.
+		if (!useMessagingStore.getState().bundleVerified) {
+			try {
+				if (!useMessagingStore.getState().bundlePublished) {
 					await publishKeyBundle(encryptionClient);
 					useMessagingStore.getState().markBundlePublished();
-				} catch (publishError) {
-					console.warn("Failed to publish key bundle:", publishError);
 				}
-			}
-			if (!useMessagingStore.getState().keyAdvertised) {
-				try {
+				if (!useMessagingStore.getState().keyAdvertised) {
 					await publishEncryptionKey(walletClient, agentId, address);
 					useMessagingStore.getState().markKeyAdvertised();
-				} catch (advertiseError) {
-					console.warn("Failed to advertise encryption key:", advertiseError);
 				}
+				await verifyKeyBundlePublished(encryptionClient, address);
+				useMessagingStore.getState().markBundleVerified();
+			} catch (publishError) {
+				const message =
+					publishError instanceof Error
+						? publishError.message
+						: "Unknown error";
+				// Surface to telemetry and the user instead of silently succeeding.
+				console.error("Failed to publish messaging key bundle:", publishError);
+				// Clear publish/advertise progress so a retry re-publishes: if the
+				// verification probe failed, the bundle may not be on the relay, and
+				// skipping straight to verify again would re-fail forever.
+				useMessagingStore.getState().clearPublishProgress();
+				setPublishError(
+					`Messaging not reachable — key publish failed: ${message}`
+				);
+				return undefined;
 			}
 		}
 
@@ -121,6 +144,7 @@ export function useSignalIdentity(): UseSignalIdentityResult {
 		setupMessaging,
 		ensureConversationsOwner,
 		ensureGroupConversationsOwner,
+		setPublishError,
 		walletClient,
 	]);
 
@@ -156,7 +180,9 @@ export function useSignalIdentity(): UseSignalIdentityResult {
 		status,
 		identity,
 		error,
-		isReady: status === "ready",
+		// "ready" requires a confirmed, fetchable bundle — a derived identity whose
+		// bundle never landed on the relay is unreachable, not ready.
+		isReady: status === "ready" && bundleVerified,
 		canEnable,
 		enable,
 	};

--- a/website/src/store/messaging.ts
+++ b/website/src/store/messaging.ts
@@ -18,10 +18,20 @@ type MessagingState = {
 	bundlePublished: boolean;
 	/** Whether the encryption key has been advertised on the directory card. */
 	keyAdvertised: boolean;
+	/** Whether a post-publish probe confirmed the bundle is fetchable from the relay. */
+	bundleVerified: boolean;
 	/** Builds the encryption client and session from a ready identity. */
 	setup: (identity: SignalIdentity) => void;
 	markBundlePublished: () => void;
 	markKeyAdvertised: () => void;
+	markBundleVerified: () => void;
+	/**
+	 * Clears the publish/advertise progress flags so the next enable() retries
+	 * those steps. Used when a later stage (e.g. the verification probe) fails:
+	 * the bundle may not actually be on the relay, so a retry must re-publish
+	 * rather than skip ahead and re-fail verification forever.
+	 */
+	clearPublishProgress: () => void;
 	/** Tears down the messaging clients (e.g. on wallet disconnect). */
 	reset: () => void;
 };
@@ -32,6 +42,7 @@ export const useMessagingStore = create<MessagingState>()((set) => ({
 	session: undefined,
 	bundlePublished: false,
 	keyAdvertised: false,
+	bundleVerified: false,
 	setup: (identity): void => {
 		set({
 			address: identity.signer.publicKeyBase64,
@@ -39,6 +50,7 @@ export const useMessagingStore = create<MessagingState>()((set) => ({
 			session: createSession(identity),
 			bundlePublished: false,
 			keyAdvertised: false,
+			bundleVerified: false,
 		});
 	},
 	markBundlePublished: (): void => {
@@ -47,6 +59,12 @@ export const useMessagingStore = create<MessagingState>()((set) => ({
 	markKeyAdvertised: (): void => {
 		set({ keyAdvertised: true });
 	},
+	markBundleVerified: (): void => {
+		set({ bundleVerified: true });
+	},
+	clearPublishProgress: (): void => {
+		set({ bundlePublished: false, keyAdvertised: false });
+	},
 	reset: (): void => {
 		set({
 			address: undefined,
@@ -54,6 +72,7 @@ export const useMessagingStore = create<MessagingState>()((set) => ({
 			session: undefined,
 			bundlePublished: false,
 			keyAdvertised: false,
+			bundleVerified: false,
 		});
 	},
 }));

--- a/website/src/store/signal.ts
+++ b/website/src/store/signal.ts
@@ -24,6 +24,12 @@ type SignalState = {
 		walletAgentId: string,
 		signMessage: SignMessageFunction
 	) => Promise<void>;
+	/**
+	 * Flags a post-derivation failure (e.g. the key bundle never reached the
+	 * relay) as an error without discarding the derived identity, so the next
+	 * enable() can retry the publish. Surfaces the message through `error`.
+	 */
+	setPublishError: (message: string) => void;
 	/** Clears the in-memory identity (e.g. on wallet disconnect). */
 	reset: () => void;
 };
@@ -54,6 +60,11 @@ export const useSignalStore = create<SignalState>()((set, get) => ({
 				error: error instanceof Error ? error.message : "Unknown error",
 			});
 		}
+	},
+	setPublishError: (message): void => {
+		// Keep `identity`/`agentId` so the next enable() reloads from IndexedDB
+		// (no fresh signature) and retries the publish; only flip status to error.
+		set({ status: "error", error: message });
 	},
 	reset: (): void => {
 		set({


### PR DESCRIPTION
Fixes #77.

## Problem
`enable()` in `website/src/hooks/use-signal-identity.ts` caught `publishKeyBundle` **and** `publishEncryptionKey` errors with only `console.warn` and still returned the identity as success. A user could sign/log in with any wallet — including an auto-detected MyTonWallet via Wallet Standard (the app uses Solana wallet-adapter with `wallets=[]`, no TonConnect) — the UI reported messaging **enabled**, but the backend never received their Signal prekey bundle: `GET /keys/<base64-signer-pubkey>/bundle` returned **404**, so they were unreachable for E2E DMs with **no error shown**.

## Fix
1. **Propagate failures into the hook's error state** instead of `console.warn`. On any publish/advertise/verify failure, `enable()` calls the new `setPublishError` (signal store) and returns `undefined` — it no longer reports `ready` or hands back a usable identity. The derived identity is kept so the next `enable()` retries the publish (the visible error + the existing *Enable encryption* button are the retry affordance).
2. **Post-enable verification probe** — `verifyKeyBundlePublished` does `GET /keys/<key>/bundle` and throws if the bundle (or its signed pre-key) is absent. `isReady` now requires a confirmed, fetchable bundle (`bundleVerified` in the messaging store), so "ready" can never mean "published but unreachable".
3. **Surface the underlying error** to the user (`error` state) and telemetry (`console.error`).

## Tests
- `signal-messaging.test.ts` — `verifyKeyBundlePublished` resolves when the bundle landed, rejects on 404 and on a bundle missing its signed pre-key.
- `use-signal-identity.test.ts` — regression: a forced publish failure sets error state and keeps `isReady` false (not silent success); a failing probe after a "successful" publish also fails; the happy path reports ready only after the relay confirms the bundle exists post-enable.

## Checks
| check | result |
| --- | --- |
| `tsc --noEmit` | pass |
| eslint (changed files) | pass |
| prettier --check | pass |
| vitest (new tests) | 6/6 pass |

Note: 4 pre-existing unit failures in `auth-payment.test.ts` / `session-wallet.test.ts` (SDK `LocalSigner.sign`) reproduce on a clean tree without these changes and are unrelated to this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signal messaging enablement now verifies the encryption key bundle is published, retrievable, and contains a usable signed pre-key on the relay before the app is marked ready.
  * Messaging readiness now depends on successful bundle verification, not just publish completion.

* **Bug Fixes**
  * Publish/verification failures now surface meaningful errors and block readiness when direct messaging may not work.
  * Failed verification resets related progress so retries will re-publish and re-check instead of skipping.

* **Tests**
  * Added unit coverage for successful verification, relay lookup failures, and bundles missing a usable signed pre-key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->