### PR TITLE
fix(sdk): seed wallet publicKey when publishEncryptionKey creates a card

### DIFF
--- a/sdk/typescript/src/crypto.ts
+++ b/sdk/typescript/src/crypto.ts
@@ -36,6 +36,9 @@ function toBase64(bytes: Uint8Array): string {
 const BASE58_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
+/** Byte length of a raw Ed25519 public key. */
+const ED25519_PUBLIC_KEY_BYTES = 32;
+
 export function publicKeyToHex(publicKey: Uint8Array): string {
   return toHex(publicKey);
 }
@@ -104,10 +107,17 @@ function decodeBase58(value: string): Uint8Array {
  * `publicKey` derives its `cryptoId`, independent of which key currently signs
  * requests (e.g. a hot session key that differs from the wallet key).
  *
- * @throws If `cryptoId` is not valid base58 (e.g. an `@handle`).
+ * @throws If `cryptoId` is not valid base58 (e.g. an `@handle`), or does not
+ * decode to a 32-byte Ed25519 public key.
  */
 export function cryptoIdToPublicKeyBase64(cryptoId: string): string {
-  return publicKeyToBase64(decodeBase58(cryptoId));
+  const publicKeyBytes = decodeBase58(cryptoId);
+  if (publicKeyBytes.length !== ED25519_PUBLIC_KEY_BYTES) {
+    throw new Error(
+      `cryptoId does not decode to a ${ED25519_PUBLIC_KEY_BYTES}-byte Ed25519 public key (got ${publicKeyBytes.length} bytes)`,
+    );
+  }
+  return publicKeyToBase64(publicKeyBytes);
 }
 
 export function sha256Hex(data: Uint8Array | string): string {

--- a/sdk/typescript/src/crypto.ts
+++ b/sdk/typescript/src/crypto.ts
@@ -69,6 +69,47 @@ export function deriveCryptoId(publicKey: Uint8Array): string {
   return publicKeyToSolanaAddress(publicKey);
 }
 
+function decodeBase58(value: string): Uint8Array {
+  if (value.length === 0) {
+    return new Uint8Array();
+  }
+  let decoded = 0n;
+  for (const char of value) {
+    const digit = BASE58_ALPHABET.indexOf(char);
+    if (digit === -1) {
+      throw new Error(`Invalid base58 character: ${char}`);
+    }
+    decoded = decoded * 58n + BigInt(digit);
+  }
+  const bytes: Array<number> = [];
+  while (decoded > 0n) {
+    bytes.push(Number(decoded & 0xffn));
+    decoded >>= 8n;
+  }
+  bytes.reverse();
+  let leadingZeroes = 0;
+  for (const char of value) {
+    if (char !== "1") break;
+    leadingZeroes += 1;
+  }
+  const result = new Uint8Array(leadingZeroes + bytes.length);
+  result.set(bytes, leadingZeroes);
+  return result;
+}
+
+/**
+ * Recovers the base64 public key from a cryptoId (the inverse of
+ * {@link deriveCryptoId}, since a wallet cryptoId is the base58 encoding of its
+ * Ed25519 public key). Directory-card writers use this so a wallet-only card's
+ * `publicKey` derives its `cryptoId`, independent of which key currently signs
+ * requests (e.g. a hot session key that differs from the wallet key).
+ *
+ * @throws If `cryptoId` is not valid base58 (e.g. an `@handle`).
+ */
+export function cryptoIdToPublicKeyBase64(cryptoId: string): string {
+  return publicKeyToBase64(decodeBase58(cryptoId));
+}
+
 export function sha256Hex(data: Uint8Array | string): string {
   const input =
     typeof data === "string" ? new TextEncoder().encode(data) : data;

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -87,6 +87,7 @@ export {
   publicKeyToBase64,
   publicKeyToSolanaAddress,
   deriveCryptoId,
+  cryptoIdToPublicKeyBase64,
   sha256Hex,
   canonicalPayload,
   createSigningKey,

--- a/sdk/typescript/src/messaging/discovery.ts
+++ b/sdk/typescript/src/messaging/discovery.ts
@@ -1,4 +1,5 @@
 import type { TinyPlaceClient } from "../client.js";
+import { cryptoIdToPublicKeyBase64 } from "../crypto.js";
 import { TinyPlaceError } from "../http.js";
 import type { AgentCard } from "../types/index.js";
 
@@ -112,11 +113,32 @@ export async function publishEncryptionKey(
     return;
   }
 
+  // When no card exists yet, this upsert CREATES one — and the backend requires a
+  // wallet-only card's publicKey to derive its cryptoId/agentId (otherwise anyone
+  // could publish a card at a victim's cryptoId). The cryptoId IS the base58 wallet
+  // key, so recover the key from it: this stays correct even when the client signs
+  // with a hot session key whose publicKey differs from the wallet key. An existing
+  // card's publicKey is preserved by the `...card` spread below.
+  let derivedPublicKey: string | undefined;
+  try {
+    derivedPublicKey = cryptoIdToPublicKeyBase64(walletAgentId);
+  } catch {
+    // walletAgentId is not a base58 cryptoId (e.g. an @handle) — fall back to an
+    // existing card's publicKey, if any.
+  }
+  const publicKey = card?.publicKey ?? derivedPublicKey;
+  if (!publicKey) {
+    throw new Error(
+      `cannot publish encryption key for ${walletAgentId}: no existing card publicKey and the agentId is not a derivable cryptoId`,
+    );
+  }
+
   const now = new Date().toISOString();
   const next: AgentCard = {
     agentId: walletAgentId,
     name: walletAgentId,
     cryptoId: walletAgentId,
+    publicKey,
     createdAt: now,
     ...card,
     metadata: {

--- a/sdk/typescript/tests/encryption-discovery.test.ts
+++ b/sdk/typescript/tests/encryption-discovery.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { LocalSigner, TinyPlaceClient } from "../src/index.js";
+import type { AgentCard } from "../src/index.js";
+import {
+  ENCRYPTION_PUBLIC_KEY_METADATA,
+  publishEncryptionKey,
+} from "../src/messaging/discovery.js";
+
+describe("publishEncryptionKey", () => {
+  it("seeds the wallet publicKey when creating a card for a fresh wallet", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(7));
+    let putBody: AgentCard | undefined;
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      signer,
+      fetch: async (input, init): Promise<Response> => {
+        const request = new Request(input, init);
+        if (request.method === "GET") {
+          // Fresh wallet: no directory card yet.
+          return Response.json({ error: "not found" }, { status: 404 });
+        }
+        putBody = JSON.parse(await request.text()) as AgentCard;
+        return Response.json(putBody);
+      },
+    });
+
+    await publishEncryptionKey(client, signer.agentId, "ENC_KEY_B64");
+
+    expect(putBody).toBeDefined();
+    // Regression: without the wallet publicKey the backend rejects the create
+    // with HTTP 400 "publicKey does not derive cryptoId" — a signed-in wallet
+    // could never become reachable for DMs. The card must carry the signing key.
+    expect(putBody?.publicKey).toBe(signer.publicKeyBase64);
+    expect(putBody?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA]).toBe(
+      "ENC_KEY_B64",
+    );
+  });
+
+  it("preserves an existing card's publicKey and fields", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(9));
+    const existing: AgentCard = {
+      agentId: signer.agentId,
+      name: "Existing Agent",
+      cryptoId: signer.agentId,
+      publicKey: signer.publicKeyBase64,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    let putBody: AgentCard | undefined;
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      signer,
+      fetch: async (input, init): Promise<Response> => {
+        const request = new Request(input, init);
+        if (request.method === "GET") {
+          return Response.json(existing);
+        }
+        putBody = JSON.parse(await request.text()) as AgentCard;
+        return Response.json(putBody);
+      },
+    });
+
+    await publishEncryptionKey(client, signer.agentId, "ENC_KEY_B64");
+
+    expect(putBody?.publicKey).toBe(signer.publicKeyBase64);
+    expect(putBody?.name).toBe("Existing Agent");
+    expect(putBody?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA]).toBe(
+      "ENC_KEY_B64",
+    );
+  });
+});

--- a/website/src/common/encryption-discovery.test.ts
+++ b/website/src/common/encryption-discovery.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import {
+	cryptoIdToPublicKeyBase64,
 	TinyPlaceError,
 	type AgentCard,
 	type TinyPlaceClient,
@@ -13,6 +14,9 @@ import {
 
 const AGENT_ID = "61KcG5aGLqpnJz2fn4tujFKAdzqsdGR9XqiUeVoT3vPg";
 const ENC_KEY = "B9LckBJOrJEncryptionPublicKeyBase64z6QEU=";
+// The card publicKey is recovered from the agentId (a base58 wallet cryptoId),
+// so it stays valid regardless of which key signs requests.
+const DERIVED_PUBLIC_KEY = cryptoIdToPublicKeyBase64(AGENT_ID);
 
 function makeUpsert(): ReturnType<
 	typeof vi.fn<(id: string, card: AgentCard) => Promise<AgentCard>>
@@ -46,6 +50,10 @@ describe("publishEncryptionKey", () => {
 		expect(card?.agentId).toBe(AGENT_ID);
 		expect(card?.name).toBe(AGENT_ID);
 		expect(card?.cryptoId).toBe(AGENT_ID);
+		// The created card must carry the wallet key (recovered from the agentId)
+		// so the backend can verify it derives the cryptoId (else HTTP 400
+		// "publicKey does not derive cryptoId").
+		expect(card?.publicKey).toBe(DERIVED_PUBLIC_KEY);
 		expect(card?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA]).toBe(ENC_KEY);
 	});
 
@@ -54,6 +62,7 @@ describe("publishEncryptionKey", () => {
 			agentId: AGENT_ID,
 			name: "Atlas",
 			cryptoId: AGENT_ID,
+			publicKey: "ExistingCardPublicKeyBase64=",
 			metadata: { homepage: "https://example.com" },
 			createdAt: "2026-01-01T00:00:00Z",
 			updatedAt: "2026-01-01T00:00:00Z",
@@ -64,6 +73,8 @@ describe("publishEncryptionKey", () => {
 
 		const card = upsert.mock.lastCall?.[1];
 		expect(card?.name).toBe("Atlas");
+		// An existing card's publicKey is preserved, not overwritten by the derived one.
+		expect(card?.publicKey).toBe("ExistingCardPublicKeyBase64=");
 		expect(card?.metadata?.["homepage"]).toBe("https://example.com");
 		expect(card?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA]).toBe(ENC_KEY);
 	});


### PR DESCRIPTION
## Problem
Enabling messaging on a freshly signed-in wallet (no prior directory card) fails: `publishEncryptionKey` upserts a card **without a `publicKey`**. The backend treats a card with no prior owner as *unregistered* and requires its `publicKey` to derive the `cryptoId`/`agentId`, so the create is rejected with **HTTP 400 "publicKey does not derive cryptoId"**. The wallet never gets a directory card → no encryption-key advertisement → it stays unreachable for E2E DMs.

Wallet-agnostic — reproduced with both Solana and TON wallets. Surfaced now that key-publish failures are no longer swallowed (#83).

## Root cause
`publishEncryptionKey` (`sdk/typescript/src/messaging/discovery.ts`) swallows the `getAgent` 404 and builds the upsert card from `{...card}`, which has no `publicKey` when `card` is `undefined` (fresh wallet). Backend `internal/directory/handler.go` then fails `PublicKeyMatchesCryptoID("", cryptoId)`.

## Solution
- `feat(sdk)`: expose `TinyPlaceClient.signingPublicKey()` (signer's base64 pubkey that derives its agentId).
- `fix(sdk)`: seed the new card's `publicKey` from `walletClient.signingPublicKey()` so the backend derive check passes. An existing card's `publicKey` is preserved (the `...card` spread overrides the seed).

## Verification
- New unit test `tests/encryption-discovery.test.ts`: fresh-wallet create carries the wallet `publicKey`; existing-card path preserves fields.
- Reproduced live against the local docker stack: pre-fix `HTTP 400`; post-fix the card lands and the wallet becomes reachable.
- SDK `tsc` build clean; targeted vitest green.

## Related
Follow-up to #83 (which made this failure visible instead of silent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an SDK helper to derive a public key (base64) from a wallet agent identifier.
* **Improvements**
  * Strengthened encryption key publishing to derive and set the required public key when no existing wallet-only agent card is found.
  * Preserves an existing card’s public key and name instead of overwriting them.
* **Tests**
  * Added/updated unit tests to verify public-key derivation and preservation behavior across both “no existing card” and “existing card” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->