### PR TITLE
fix(openclaw): resolve base58 cryptoId recipients via the directory

### DIFF
--- a/sdk/plugin-openclaw/src/messaging.test.ts
+++ b/sdk/plugin-openclaw/src/messaging.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { TinyPlaceClient } from "@tinyhumansai/tinyplace";
+
+import { isPublicKey, resolveRecipientKey } from "./messaging.js";
+
+const RAW_KEY = "WM8smAepeXnyL8+36sM0I3a/dfE5RkxJ66w3eXIrOSM=";
+const CRYPTO_ID = "57mjBDibe6f6Vqv9uvhB6nckcz6cKwSCqt4Lio1DawJh";
+const ENC_KEY = "PSrOROSZtKSyUbKZzlyEal05zhM7VJOIRv+NBCW1sII=";
+
+test("isPublicKey accepts a base64 32-byte key (44 chars, trailing =)", () => {
+  assert.equal(isPublicKey(RAW_KEY), true);
+});
+
+test("isPublicKey rejects a base58 cryptoId (no trailing =)", () => {
+  // Regression: a base58 cryptoId is ~44 chars of [A-Za-z0-9] and used to be
+  // misread as a raw key, sending the bundle fetch to /keys/<cryptoId>/bundle.
+  assert.equal(isPublicKey(CRYPTO_ID), false);
+});
+
+test("isPublicKey rejects a @handle", () => {
+  assert.equal(isPublicKey("@openclawtest"), false);
+});
+
+test("resolveRecipientKey passes a raw base64 key through untouched", async () => {
+  const client = {
+    directory: {
+      getAgent: (): never => {
+        throw new Error("should not be called for a raw key");
+      },
+    },
+  } as unknown as TinyPlaceClient;
+  assert.equal(await resolveRecipientKey(client, RAW_KEY), RAW_KEY);
+});
+
+test("resolveRecipientKey resolves a base58 cryptoId via the directory card", async () => {
+  let asked = "";
+  const client = {
+    directory: {
+      getAgent: (id: string): Promise<unknown> => {
+        asked = id;
+        return Promise.resolve({
+          agentId: CRYPTO_ID,
+          publicKey: ENC_KEY,
+          metadata: { encryptionPublicKey: ENC_KEY },
+        });
+      },
+    },
+  } as unknown as TinyPlaceClient;
+  assert.equal(await resolveRecipientKey(client, CRYPTO_ID), ENC_KEY);
+  assert.equal(asked, CRYPTO_ID);
+});
+
+test("resolveRecipientKey resolves a @handle via directory.resolve", async () => {
+  const client = {
+    directory: {
+      resolve: (name: string): Promise<unknown> => {
+        assert.equal(name, "@openclawtest");
+        return Promise.resolve({
+          identity: { publicKey: "ignored" },
+          agent: {
+            agentId: CRYPTO_ID,
+            publicKey: ENC_KEY,
+            metadata: { encryptionPublicKey: ENC_KEY },
+          },
+        });
+      },
+    },
+  } as unknown as TinyPlaceClient;
+  assert.equal(await resolveRecipientKey(client, "@openclawtest"), ENC_KEY);
+});
+
+test("resolveRecipientKey falls back to the card's own publicKey when no encryption key is advertised", async () => {
+  const client = {
+    directory: {
+      getAgent: (): Promise<unknown> =>
+        Promise.resolve({ agentId: CRYPTO_ID, publicKey: ENC_KEY }),
+    },
+  } as unknown as TinyPlaceClient;
+  assert.equal(await resolveRecipientKey(client, CRYPTO_ID), ENC_KEY);
+});

--- a/sdk/plugin-openclaw/src/messaging.test.ts
+++ b/sdk/plugin-openclaw/src/messaging.test.ts
@@ -71,6 +71,32 @@ test("resolveRecipientKey resolves a @handle via directory.resolve", async () =>
   assert.equal(await resolveRecipientKey(client, "@openclawtest"), ENC_KEY);
 });
 
+test("resolveRecipientKey normalizes a bare handle (no @) and resolves it", async () => {
+  // Regression: a bare registered handle like "iris" must NOT be treated as a
+  // cryptoId/agentId — it is normalized to "@iris" and resolved.
+  let resolvedName = "";
+  const client = {
+    directory: {
+      resolve: (name: string): Promise<unknown> => {
+        resolvedName = name;
+        return Promise.resolve({
+          identity: { publicKey: "ignored" },
+          agent: {
+            agentId: CRYPTO_ID,
+            publicKey: ENC_KEY,
+            metadata: { encryptionPublicKey: ENC_KEY },
+          },
+        });
+      },
+      getAgent: (): never => {
+        throw new Error("a bare handle must not hit getAgent");
+      },
+    },
+  } as unknown as TinyPlaceClient;
+  assert.equal(await resolveRecipientKey(client, "iris"), ENC_KEY);
+  assert.equal(resolvedName, "@iris");
+});
+
 test("resolveRecipientKey falls back to the card's own publicKey when no encryption key is advertised", async () => {
   const client = {
     directory: {

--- a/sdk/plugin-openclaw/src/messaging.ts
+++ b/sdk/plugin-openclaw/src/messaging.ts
@@ -61,6 +61,17 @@ export function isPublicKey(value: string): boolean {
   return /^[A-Za-z0-9+/]{43}=$/.test(value);
 }
 
+/**
+ * Looks like a base58 cryptoId / agentId: 32-44 base58 chars (the Solana address
+ * alphabet, no 0/O/I/l). A registered @handle ("iris") is short and may also use
+ * those characters, so this length-bounded check is what tells a bare cryptoId
+ * apart from a bare handle — the former is looked up directly, the latter is
+ * normalized + resolved.
+ */
+function isCryptoId(value: string): boolean {
+  return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value);
+}
+
 /** Picks the messaging address from a card: advertised encryption key, else the card's own key. */
 function cardEncryptionAddress(
   advertised: unknown,
@@ -84,12 +95,15 @@ function cardEncryptionAddress(
 
 /**
  * Resolves a recipient to the base64 encryption public key to address messages +
- * bundles to. Accepts three forms: a raw base64 key (used as-is), an `@handle`
- * (directory.resolve), or a base58 cryptoId/agentId (directory.getAgent). For the
- * latter two it mirrors the web app's `resolveEncryptionAddress`: prefer the
- * card's advertised encryption key, then the card's own public key (single-key
- * agents, like this CLI), then the identity key. This is what lets the CLI
- * message web-app users that run a distinct encryption identity.
+ * bundles to. Accepts three forms:
+ *   - a raw base64 key — used as-is;
+ *   - a base58 cryptoId/agentId — looked up directly via `directory.getAgent`;
+ *   - a handle, with or without a leading `@` (e.g. `iris` or `@iris`) — a bare
+ *     name is normalized to `@iris` and resolved via `directory.resolve`.
+ * For the directory paths it mirrors the web app's `resolveEncryptionAddress`:
+ * prefer the card's advertised encryption key, then the card's own public key
+ * (single-key agents, like this CLI), then the identity key. This is what lets
+ * the CLI message web-app users that run a distinct encryption identity.
  */
 export async function resolveRecipientKey(
   client: TinyPlaceClient,
@@ -97,23 +111,25 @@ export async function resolveRecipientKey(
 ): Promise<string> {
   if (isPublicKey(recipient)) return recipient;
 
-  if (recipient.startsWith("@")) {
-    const resolved = await client.directory.resolve(recipient);
+  // A bare base58 cryptoId/agentId is fetched directly; anything else is a
+  // handle (a bare name like "iris" is normalized to "@iris") and resolved.
+  if (!recipient.startsWith("@") && isCryptoId(recipient)) {
+    const card = await client.directory.getAgent(recipient);
     return cardEncryptionAddress(
-      resolved.agent?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA],
-      resolved.agent?.publicKey,
-      resolved.identity?.publicKey,
+      card.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA],
+      card.publicKey,
+      undefined,
       recipient,
     );
   }
 
-  // A bare base58 cryptoId / agentId: look up its directory card directly.
-  const card = await client.directory.getAgent(recipient);
+  const handle = recipient.startsWith("@") ? recipient : `@${recipient}`;
+  const resolved = await client.directory.resolve(handle);
   return cardEncryptionAddress(
-    card.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA],
-    card.publicKey,
-    undefined,
-    recipient,
+    resolved.agent?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA],
+    resolved.agent?.publicKey,
+    resolved.identity?.publicKey,
+    handle,
   );
 }
 

--- a/sdk/plugin-openclaw/src/messaging.ts
+++ b/sdk/plugin-openclaw/src/messaging.ts
@@ -43,39 +43,78 @@ const ENCRYPTION_PUBLIC_KEY_METADATA = "encryptionPublicKey";
 function randomId(prefix: string): string {
   const bytes = new Uint8Array(8);
   globalThis.crypto.getRandomValues(bytes);
-  const suffix = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  const suffix = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(
+    "",
+  );
   return `${prefix}-${Date.now().toString(36)}-${suffix}`;
 }
 
-/** Looks like a raw base64 Ed25519 public key (44 chars, base64) vs a @handle. */
-function isPublicKey(value: string): boolean {
-  return !value.startsWith("@") && /^[A-Za-z0-9+/]{42,46}={0,2}$/.test(value);
+/**
+ * Looks like a raw base64 Ed25519 public key. A base64-encoded 32-byte key is
+ * always 44 chars ending in a single `=` pad. We require that trailing pad so a
+ * base58 cryptoId/agentId — which is also ~44 chars of [A-Za-z0-9] but never
+ * contains `+`, `/`, or `=` — is NOT misread as a raw key (that misread sent the
+ * bundle fetch to `/keys/<cryptoId>/bundle`, which 404s instead of resolving the
+ * recipient's card to its advertised encryption key).
+ */
+export function isPublicKey(value: string): boolean {
+  return /^[A-Za-z0-9+/]{43}=$/.test(value);
+}
+
+/** Picks the messaging address from a card: advertised encryption key, else the card's own key. */
+function cardEncryptionAddress(
+  advertised: unknown,
+  publicKey: string | undefined,
+  identityKey: string | undefined,
+  recipient: string,
+): string {
+  const address =
+    (typeof advertised === "string" && advertised.length > 0
+      ? advertised
+      : undefined) ??
+    publicKey ??
+    identityKey;
+  if (!address) {
+    throw new Error(
+      `could not resolve ${recipient} to an encryption public key`,
+    );
+  }
+  return address;
 }
 
 /**
- * Resolves a recipient (a @handle or a raw base64 public key) to the base64
- * encryption public key to address messages + bundles to. Mirrors the web app's
- * `resolveEncryptionAddress`: prefer the card's advertised encryption key, then
- * the card's own public key (single-key agents, like this CLI), then the
- * identity key. This is what lets the CLI message web-app users that run a
- * distinct encryption identity.
+ * Resolves a recipient to the base64 encryption public key to address messages +
+ * bundles to. Accepts three forms: a raw base64 key (used as-is), an `@handle`
+ * (directory.resolve), or a base58 cryptoId/agentId (directory.getAgent). For the
+ * latter two it mirrors the web app's `resolveEncryptionAddress`: prefer the
+ * card's advertised encryption key, then the card's own public key (single-key
+ * agents, like this CLI), then the identity key. This is what lets the CLI
+ * message web-app users that run a distinct encryption identity.
  */
-async function resolveRecipientKey(
+export async function resolveRecipientKey(
   client: TinyPlaceClient,
   recipient: string,
 ): Promise<string> {
   if (isPublicKey(recipient)) return recipient;
-  const handle = recipient.startsWith("@") ? recipient : `@${recipient}`;
-  const resolved = await client.directory.resolve(handle);
-  const advertised = resolved.agent?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA];
-  const address =
-    (typeof advertised === "string" && advertised.length > 0 ? advertised : undefined) ??
-    resolved.agent?.publicKey ??
-    resolved.identity?.publicKey;
-  if (!address) {
-    throw new Error(`could not resolve ${recipient} to an encryption public key`);
+
+  if (recipient.startsWith("@")) {
+    const resolved = await client.directory.resolve(recipient);
+    return cardEncryptionAddress(
+      resolved.agent?.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA],
+      resolved.agent?.publicKey,
+      resolved.identity?.publicKey,
+      recipient,
+    );
   }
-  return address;
+
+  // A bare base58 cryptoId / agentId: look up its directory card directly.
+  const card = await client.directory.getAgent(recipient);
+  return cardEncryptionAddress(
+    card.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA],
+    card.publicKey,
+    undefined,
+    recipient,
+  );
 }
 
 export interface PublishKeysResult {
@@ -281,9 +320,7 @@ export async function readMessages(
       from: envelope.from,
       timestamp: envelope.timestamp,
       type: envelope.type,
-      ...(handoff
-        ? { control: `group-key:${handoff.groupId}` }
-        : { text }),
+      ...(handoff ? { control: `group-key:${handoff.groupId}` } : { text }),
     });
     // Acknowledge separately: the message is already decrypted + persisted, so an
     // ack failure must not be reported as a decrypt failure.


### PR DESCRIPTION
## Summary

`message send <recipient>` failed for a base58 cryptoId/agentId recipient — `isPublicKey` matched any 42–46 char `[A-Za-z0-9+/]` string, so a cryptoId (also ~44 chars, no `+`/`/`/`=`) was misclassified as a raw base64 encryption key. The send then fetched `/keys/<cryptoId>/bundle` directly and 404'd, instead of resolving the recipient's directory card to its advertised encryption key.

## Fix

- `isPublicKey` now requires the trailing base64 `=` pad (a 32-byte Ed25519 key is always 44 chars ending in `=`); a base58 cryptoId never has it.
- A bare cryptoId/agentId is resolved via `directory.getAgent` → the card's `encryptionPublicKey` (falling back to the card's `publicKey`).
- `message send` now accepts all three recipient forms: raw base64 key, `@handle`, and cryptoId.

## Tests

Added `messaging.test.ts` (node:test): `isPublicKey` classification (base64 key / cryptoId / @handle) and `resolveRecipientKey` across all three paths incl. the encryption-key fallback. Full plugin suite: 57 passing.

## Verification

Reproduced + fixed live against staging: sending to a cryptoId previously 404'd on the bundle fetch; after the fix it resolves the card and delivers an E2E message (PREKEY_BUNDLE → CIPHERTEXT).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public utilities to validate raw base64 encryption keys and to resolve recipients from `@handles`, agent/crypto IDs, and key formats.
* **Refactor**
  * Improved recipient/key resolution flow with clear handling for `@handle` vs bare IDs and enhanced fallback selection of the best available encryption public key.
* **Tests**
  * Added Node test coverage for key validation and recipient resolution, including edge cases and metadata fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->