### PR TITLE
fix(messaging): resolve @handle DM recipients via directory.resolve

### DIFF
--- a/website/src/common/peer-resolution.test.ts
+++ b/website/src/common/peer-resolution.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+import type {
+	AgentCard,
+	ResolveResponse,
+	TinyPlaceClient,
+} from "@tinyhumansai/tinyplace";
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveDirectoryPeer } from "./peer-resolution";
+
+const CRYPTO_ID = "57mjBDibe6f6Vqv9uvhB6nckcz6cKwSCqt4Lio1DawJh";
+const ENC_KEY = "WM8smAepeXnyL8+36sM0I3a/dfE5RkxJ66w3eXIrOSM=";
+const WALLET_KEY = "Mvzw9tEbDl4wl36Z5Yhg83IQTMwyzB8AWgBkf2EMjKw=";
+
+function clientWith(directory: Partial<TinyPlaceClient["directory"]>): {
+	client: TinyPlaceClient;
+	getAgent: ReturnType<typeof vi.fn>;
+	resolve: ReturnType<typeof vi.fn>;
+} {
+	const getAgent = vi.fn(directory.getAgent);
+	const resolve = vi.fn(directory.resolve);
+	const client = {
+		directory: { getAgent, resolve },
+	} as unknown as TinyPlaceClient;
+	return { client, getAgent, resolve };
+}
+
+describe("resolveDirectoryPeer", () => {
+	it("resolves a base58 cryptoId via getAgent and prefers the advertised encryption key", async () => {
+		const card: AgentCard = {
+			agentId: CRYPTO_ID,
+			publicKey: WALLET_KEY,
+			metadata: { encryptionPublicKey: ENC_KEY },
+		} as unknown as AgentCard;
+		const { client, getAgent, resolve } = clientWith({
+			getAgent: () => Promise.resolve(card),
+		});
+
+		const peer = await resolveDirectoryPeer(client, CRYPTO_ID);
+
+		expect(getAgent).toHaveBeenCalledWith(CRYPTO_ID);
+		expect(resolve).not.toHaveBeenCalled();
+		expect(peer).toEqual({ address: ENC_KEY, agentId: CRYPTO_ID });
+	});
+
+	it("resolves a @handle via directory.resolve, then fetches the card by cryptoId", async () => {
+		// The resolve endpoint returns the identity but not the full agent card,
+		// so the card must be fetched by cryptoId to pick up the encryption key.
+		const { client, getAgent, resolve } = clientWith({
+			resolve: () =>
+				Promise.resolve({
+					identity: { cryptoId: CRYPTO_ID, username: "@openclawtest" },
+				} as unknown as ResolveResponse),
+			getAgent: () =>
+				Promise.resolve({
+					agentId: CRYPTO_ID,
+					publicKey: WALLET_KEY,
+					username: "@openclawtest",
+					metadata: { encryptionPublicKey: ENC_KEY },
+				} as unknown as AgentCard),
+		});
+
+		const peer = await resolveDirectoryPeer(client, "@openclawtest");
+
+		expect(resolve).toHaveBeenCalledWith("@openclawtest");
+		expect(getAgent).toHaveBeenCalledWith(CRYPTO_ID);
+		expect(peer).toEqual({
+			address: ENC_KEY,
+			agentId: CRYPTO_ID,
+			username: "@openclawtest",
+		});
+	});
+
+	it("uses the agent card embedded in the resolve response when present", async () => {
+		const { client, getAgent, resolve } = clientWith({
+			resolve: () =>
+				Promise.resolve({
+					identity: { cryptoId: CRYPTO_ID, username: "@openclawtest" },
+					agent: {
+						agentId: CRYPTO_ID,
+						publicKey: WALLET_KEY,
+						username: "@openclawtest",
+						metadata: { encryptionPublicKey: ENC_KEY },
+					},
+				} as unknown as ResolveResponse),
+		});
+
+		const peer = await resolveDirectoryPeer(client, "@openclawtest");
+
+		expect(resolve).toHaveBeenCalledWith("@openclawtest");
+		expect(getAgent).not.toHaveBeenCalled();
+		expect(peer.address).toBe(ENC_KEY);
+	});
+
+	it("falls back to the card's own publicKey when no encryption key is advertised", async () => {
+		const { client } = clientWith({
+			getAgent: () =>
+				Promise.resolve({
+					agentId: CRYPTO_ID,
+					publicKey: WALLET_KEY,
+				} as unknown as AgentCard),
+		});
+
+		const peer = await resolveDirectoryPeer(client, CRYPTO_ID);
+
+		expect(peer.address).toBe(WALLET_KEY);
+	});
+
+	it("throws when a handle cannot be resolved to a cryptoId", async () => {
+		const { client } = clientWith({
+			resolve: () =>
+				Promise.resolve({ identity: null } as unknown as ResolveResponse),
+		});
+
+		await expect(resolveDirectoryPeer(client, "@ghost")).rejects.toThrow(
+			/Could not resolve @ghost/
+		);
+	});
+});

--- a/website/src/common/peer-resolution.test.ts
+++ b/website/src/common/peer-resolution.test.ts
@@ -106,6 +106,25 @@ describe("resolveDirectoryPeer", () => {
 		expect(peer.address).toBe(WALLET_KEY);
 	});
 
+	it("falls back to the identity's username when the card has none", async () => {
+		const { client } = clientWith({
+			resolve: () =>
+				Promise.resolve({
+					identity: { cryptoId: CRYPTO_ID, username: "@openclawtest" },
+				} as unknown as ResolveResponse),
+			getAgent: () =>
+				Promise.resolve({
+					agentId: CRYPTO_ID,
+					publicKey: WALLET_KEY,
+					metadata: { encryptionPublicKey: ENC_KEY },
+				} as unknown as AgentCard),
+		});
+
+		const peer = await resolveDirectoryPeer(client, "@openclawtest");
+
+		expect(peer.username).toBe("@openclawtest");
+	});
+
 	it("throws when a handle cannot be resolved to a cryptoId", async () => {
 		const { client } = clientWith({
 			resolve: () =>

--- a/website/src/common/peer-resolution.ts
+++ b/website/src/common/peer-resolution.ts
@@ -1,0 +1,51 @@
+import type { TinyPlaceClient } from "@tinyhumansai/tinyplace";
+
+import { resolveEncryptionAddress } from "@src/common/encryption-discovery";
+
+/** A directory peer resolved to the address messages are encrypted/sent to. */
+export interface ResolvedDirectoryPeer {
+	/** The base64 encryption public key to address messages + key bundles to. */
+	address: string;
+	/** The peer's cryptoId / agent id. */
+	agentId: string;
+	/** The peer's @handle, when it has one. */
+	username?: string;
+}
+
+/**
+ * Resolves a directory recipient — an `@handle` or a base58 cryptoId/agentId — to
+ * its messaging address.
+ *
+ * A `@handle` is NOT a cryptoId, so it can't be fetched via `getAgent`
+ * (`GET /directory/agents/<id>` resolves a cryptoId and 404s on a handle). The
+ * handle is resolved to its cryptoId first; the resolve endpoint returns the
+ * identity (handle → cryptoId + key) but not always the full agent card, so the
+ * card is then fetched by cryptoId to pick up the advertised encryption key
+ * (agents whose messaging key differs from their wallet key rely on the card's
+ * metadata).
+ */
+export async function resolveDirectoryPeer(
+	client: TinyPlaceClient,
+	input: string
+): Promise<ResolvedDirectoryPeer> {
+	if (input.startsWith("@")) {
+		const resolved = await client.directory.resolve(input);
+		const cryptoId = resolved.identity?.cryptoId ?? resolved.agent?.agentId;
+		if (!cryptoId) {
+			throw new Error(`Could not resolve ${input} to an agent`);
+		}
+		const card = resolved.agent ?? (await client.directory.getAgent(cryptoId));
+		return {
+			address: resolveEncryptionAddress(card),
+			agentId: card.agentId,
+			username: card.username ?? resolved.identity?.username,
+		};
+	}
+
+	const card = await client.directory.getAgent(input);
+	return {
+		address: resolveEncryptionAddress(card),
+		agentId: card.agentId,
+		username: card.username,
+	};
+}

--- a/website/src/components/explore/DirectMessages.tsx
+++ b/website/src/components/explore/DirectMessages.tsx
@@ -23,6 +23,7 @@ export const DirectMessages = ({
 		peers,
 		threads,
 		addPeer,
+		addPeerError,
 		send,
 		isSending,
 		markThreadRead,
@@ -151,8 +152,14 @@ export const DirectMessages = ({
 						className="flex flex-col gap-1"
 						onSubmit={(event): void => {
 							event.preventDefault();
-							void addPeer(peerInput);
-							setPeerInput("");
+							// Clear the input only when the peer was actually added, so a
+							// failed resolve (e.g. an unknown handle) keeps the user's text
+							// and surfaces addPeerError instead of silently no-op'ing.
+							void addPeer(peerInput).then((added): void => {
+								if (added) {
+									setPeerInput("");
+								}
+							});
 						}}
 					>
 						<input
@@ -167,6 +174,9 @@ export const DirectMessages = ({
 								setPeerInput(event.target.value);
 							}}
 						/>
+						{addPeerError ? (
+							<p className="px-1 text-xs text-danger">{addPeerError}</p>
+						) : null}
 					</form>
 					{peers.length === 0 ? (
 						<p className={`px-1 text-xs ${mutedText}`}>No conversations yet</p>

--- a/website/src/hooks/use-direct-messages.ts
+++ b/website/src/hooks/use-direct-messages.ts
@@ -4,10 +4,8 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { useApiClient } from "@src/common/api-context";
-import {
-	lookupAgentByEncryptionKey,
-	resolveEncryptionAddress,
-} from "@src/common/encryption-discovery";
+import { lookupAgentByEncryptionKey } from "@src/common/encryption-discovery";
+import { resolveDirectoryPeer } from "@src/common/peer-resolution";
 import {
 	groupKeyManager,
 	parseGroupKeyDistribution,
@@ -179,18 +177,17 @@ export function useDirectMessages(): UseDirectMessagesResult {
 				return;
 			}
 			if (trimmed.startsWith("@") || SOLANA_ADDRESS_PATTERN.test(trimmed)) {
-				const card = await walletClient.directory.getAgent(trimmed);
-				const address = resolveEncryptionAddress(card);
+				const peer = await resolveDirectoryPeer(walletClient, trimmed);
 				// Record the encryption-key → identity mapping so this peer (and any
 				// future inbound messages from them) resolve to a real label.
 				recordIdentity({
-					encryptionKey: address,
-					agentId: card.agentId,
-					username: card.username,
+					encryptionKey: peer.address,
+					agentId: peer.agentId,
+					username: peer.username,
 				});
 				addPeerToStore({
-					address,
-					label: card.username ?? card.agentId,
+					address: peer.address,
+					label: peer.username ?? peer.agentId,
 				});
 				return;
 			}

--- a/website/src/hooks/use-direct-messages.ts
+++ b/website/src/hooks/use-direct-messages.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useApiClient } from "@src/common/api-context";
 import { lookupAgentByEncryptionKey } from "@src/common/encryption-discovery";
@@ -43,8 +43,14 @@ type UseDirectMessagesResult = {
 	enable: () => Promise<void>;
 	peers: Array<ConversationPeer>;
 	threads: Record<string, Array<DirectMessageEntry>>;
-	/** Resolves an @handle / agent id / raw encryption key to a peer and adds it. */
-	addPeer: (input: string) => Promise<void>;
+	/**
+	 * Resolves an @handle / agent id / raw encryption key to a peer and adds it.
+	 * Resolves to `true` on success, `false` on failure (with {@link addPeerError}
+	 * set) — never rejects, so fire-and-forget call sites can't leak a rejection.
+	 */
+	addPeer: (input: string) => Promise<boolean>;
+	/** Set when the last {@link addPeer} failed (e.g. an unresolvable handle). */
+	addPeerError: string | undefined;
 	send: (address: string, text: string) => Promise<void>;
 	isSending: boolean;
 	/** Marks every message in a peer's thread as read. */
@@ -78,6 +84,12 @@ export function useDirectMessages(): UseDirectMessagesResult {
 
 	const addressBook = useAddressBookStore((state) => state.entries);
 	const recordIdentity = useAddressBookStore((state) => state.record);
+
+	// Surfaced to the UI when adding a peer fails (e.g. an unresolvable handle),
+	// so the failure isn't swallowed by the fire-and-forget call site.
+	const [addPeerError, setAddPeerError] = useState<string | undefined>(
+		undefined
+	);
 
 	// Resolve each peer's label from the registry (handle / wallet id), falling
 	// back to whatever label the peer was stored with (a truncated key). This is
@@ -170,14 +182,12 @@ export function useDirectMessages(): UseDirectMessagesResult {
 		await enableIdentity();
 	}, [enableIdentity]);
 
-	const addPeer = useCallback(
-		async (input: string): Promise<void> => {
-			const trimmed = input.trim();
-			if (!trimmed) {
-				return;
-			}
-			if (trimmed.startsWith("@") || SOLANA_ADDRESS_PATTERN.test(trimmed)) {
-				const peer = await resolveDirectoryPeer(walletClient, trimmed);
+	// Resolves a @handle / cryptoId via the directory (recording its identity) and
+	// adds it; a raw key is stored directly. Throws when resolution fails.
+	const resolveAndRecordPeer = useCallback(
+		async (recipient: string): Promise<void> => {
+			if (recipient.startsWith("@") || SOLANA_ADDRESS_PATTERN.test(recipient)) {
+				const peer = await resolveDirectoryPeer(walletClient, recipient);
 				// Record the encryption-key → identity mapping so this peer (and any
 				// future inbound messages from them) resolve to a real label.
 				recordIdentity({
@@ -191,9 +201,32 @@ export function useDirectMessages(): UseDirectMessagesResult {
 				});
 				return;
 			}
-			addPeerToStore({ address: trimmed, label: `${trimmed.slice(0, 10)}…` });
+			addPeerToStore({
+				address: recipient,
+				label: `${recipient.slice(0, 10)}…`,
+			});
 		},
 		[walletClient, addPeerToStore, recordIdentity]
+	);
+
+	const addPeer = useCallback(
+		async (input: string): Promise<boolean> => {
+			const trimmed = input.trim();
+			if (!trimmed) {
+				return false;
+			}
+			setAddPeerError(undefined);
+			try {
+				await resolveAndRecordPeer(trimmed);
+				return true;
+			} catch (caught) {
+				setAddPeerError(
+					caught instanceof Error ? caught.message : `Could not add ${trimmed}`
+				);
+				return false;
+			}
+		},
+		[resolveAndRecordPeer]
 	);
 
 	const send = useCallback(
@@ -224,6 +257,7 @@ export function useDirectMessages(): UseDirectMessagesResult {
 		peers: resolvedPeers,
 		threads,
 		addPeer,
+		addPeerError,
 		send,
 		isSending: sendMutation.isPending,
 		markThreadRead,


### PR DESCRIPTION
## Summary

Adding a peer by **@handle** in direct messages silently failed (the Send button became a no-op). `addPeer` called `directory.getAgent(@handle)`, but `GET /directory/agents/<id>` only resolves a **cryptoId** and 404s on a handle. The throw left no peer added, so the conversation couldn't be selected and `handleSend`'s `if (!selected) return` made the button do nothing. Adding by raw cryptoId worked; adding by handle did not.

## Fix

Extract `resolveDirectoryPeer(client, input)`:
- `@handle` → `directory.resolve` to get the cryptoId, then fetch the card by cryptoId (the resolve endpoint returns the identity but not always the full agent card) to pick up the advertised `encryptionPublicKey` — important for agents whose messaging key differs from their wallet key.
- bare cryptoId/agentId → `directory.getAgent` as before.
- Uses the card embedded in the resolve response when present; falls back to the card's own `publicKey` when no encryption key is advertised.

`addPeer` now calls the helper for both `@handle` and cryptoId inputs.

## Tests

Added `peer-resolution.test.ts` (5 cases): cryptoId path, @handle→resolve→getAgent path, embedded-card path, publicKey fallback, and the unresolvable-handle error. Typecheck + lint clean.

## Verification

Reproduced live against staging on a local build: adding `@openclawtest` previously did nothing (getAgent 404); after the fix the handle resolves, the peer is added, and the message sends + decrypts E2E on the recipient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved direct-message peer resolution to better support directory handles and Solana addresses via a single resolver.
* **Bug Fixes**
  * Direct-message “add conversation” flow now clears the input only when the peer was successfully added, and surfaces resolution failures to the UI.
* **Tests**
  * Added a peer-resolution test suite covering handle resolution, agent card fetching, fallback behavior, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->