### PR TITLE
fix(market): guard unsupported encrypted-message delivery in CLI sell

### DIFF
--- a/sdk/plugin-openclaw/src/market.test.ts
+++ b/sdk/plugin-openclaw/src/market.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { LocalSigner, TinyPlaceClient } from "@tinyhumansai/tinyplace";
+
+import { assertSupportedDeliveryMethod, createProduct } from "./market.js";
+
+const SIGNER = {
+  agentId: "57mjBDibe6f6Vqv9uvhB6nckcz6cKwSCqt4Lio1DawJh",
+  publicKeyBase64: "WM8smAepeXnyL8+36sM0I3a/dfE5RkxJ66w3eXIrOSM=",
+} as unknown as LocalSigner;
+
+const PRODUCT_FIXTURE = {
+  productId: "prod_1",
+  name: "Sample",
+  description: "A sample product",
+  category: "tool",
+  price: { amount: "1000000", asset: "USDC", network: "solana" },
+  seller: SIGNER.agentId,
+  deliveryMethod: "download",
+  status: "active",
+  stock: null,
+  salesCount: 0,
+  rating: 0,
+};
+
+function clientThatExpects(expectedDeliveryMethod: string): TinyPlaceClient {
+  return {
+    marketplace: {
+      createProduct: (request: {
+        deliveryMethod: string;
+      }): Promise<unknown> => {
+        assert.equal(request.deliveryMethod, expectedDeliveryMethod);
+        return Promise.resolve({
+          ...PRODUCT_FIXTURE,
+          deliveryMethod: request.deliveryMethod,
+        });
+      },
+    },
+  } as unknown as TinyPlaceClient;
+}
+
+const clientThatMustNotBeCalled = {
+  marketplace: {
+    createProduct: (): never => {
+      throw new Error("createProduct must not be called for an invalid method");
+    },
+  },
+} as unknown as TinyPlaceClient;
+
+function input(deliveryMethod: string): Parameters<typeof createProduct>[2] {
+  return {
+    name: "Sample",
+    description: "A sample product",
+    category: "tool" as never,
+    price: { amount: "1000000", asset: "USDC", network: "solana" },
+    deliveryMethod: deliveryMethod as never,
+  };
+}
+
+test("assertSupportedDeliveryMethod accepts download", () => {
+  assert.equal(assertSupportedDeliveryMethod("download"), "download");
+});
+
+test("assertSupportedDeliveryMethod accepts a2a-task", () => {
+  assert.equal(assertSupportedDeliveryMethod("a2a-task"), "a2a-task");
+});
+
+test("assertSupportedDeliveryMethod rejects encrypted-message with an actionable error", () => {
+  assert.throws(
+    () => assertSupportedDeliveryMethod("encrypted-message"),
+    (error: Error) => {
+      assert.match(error.message, /encrypted-message/);
+      assert.match(error.message, /not supported via the CLI/);
+      // Names the supported alternatives so the seller can recover.
+      assert.match(error.message, /download/);
+      assert.match(error.message, /a2a-task/);
+      return true;
+    },
+  );
+});
+
+test("assertSupportedDeliveryMethod rejects an unknown method", () => {
+  assert.throws(
+    () => assertSupportedDeliveryMethod("smoke-signal"),
+    (error: Error) => {
+      assert.match(error.message, /unknown delivery method "smoke-signal"/);
+      assert.match(error.message, /download/);
+      assert.match(error.message, /a2a-task/);
+      return true;
+    },
+  );
+});
+
+test("createProduct rejects encrypted-message before the network call", async () => {
+  await assert.rejects(
+    createProduct(
+      clientThatMustNotBeCalled,
+      SIGNER,
+      input("encrypted-message"),
+    ),
+    /not supported via the CLI/,
+  );
+});
+
+test("createProduct rejects an unknown delivery method before the network call", async () => {
+  await assert.rejects(
+    createProduct(clientThatMustNotBeCalled, SIGNER, input("smoke-signal")),
+    /unknown delivery method/,
+  );
+});
+
+test("createProduct accepts download and lists the product", async () => {
+  const result = await createProduct(
+    clientThatExpects("download"),
+    SIGNER,
+    input("download"),
+  );
+  assert.equal(result.productId, "prod_1");
+  assert.equal(result.deliveryMethod, "download");
+});
+
+test("createProduct accepts a2a-task and lists the product", async () => {
+  const result = await createProduct(
+    clientThatExpects("a2a-task"),
+    SIGNER,
+    input("a2a-task"),
+  );
+  assert.equal(result.productId, "prod_1");
+  assert.equal(result.deliveryMethod, "a2a-task");
+});

--- a/sdk/plugin-openclaw/src/market.ts
+++ b/sdk/plugin-openclaw/src/market.ts
@@ -170,7 +170,7 @@ export async function createProduct(
 ): Promise<ProductDetail> {
   // Reject CLI-unsupported delivery methods up front so the seller gets a
   // clear, actionable error instead of an opaque backend 400.
-  assertSupportedDeliveryMethod(input.deliveryMethod);
+  const deliveryMethod = assertSupportedDeliveryMethod(input.deliveryMethod);
   const request: ProductCreateRequest = {
     seller: signer.agentId,
     sellerCryptoId: signer.agentId,
@@ -182,7 +182,7 @@ export async function createProduct(
       asset: input.price.asset,
       network: input.price.network,
     },
-    deliveryMethod: input.deliveryMethod,
+    deliveryMethod,
     ...(input.tags ? { tags: input.tags } : {}),
     ...(input.stock !== undefined ? { stock: input.stock } : {}),
   };

--- a/sdk/plugin-openclaw/src/market.ts
+++ b/sdk/plugin-openclaw/src/market.ts
@@ -117,6 +117,49 @@ export interface CreateProductInput {
 }
 
 /**
+ * Delivery methods a seller can list through the CLI/plugin.
+ *
+ * `encrypted-message` is a valid `DeliveryMethod` in the protocol, but the
+ * backend rejects a listing unless the seller attaches an *encrypted*
+ * deliverable body — and the CLI has no path to collect or encrypt one. So it
+ * is deliberately excluded here: listing it would only earn an opaque backend
+ * `HTTP 400 {"error":"encrypted-message delivery requires encrypted body"}`.
+ */
+const CLI_SUPPORTED_DELIVERY_METHODS = ["download", "a2a-task"] as const;
+
+/**
+ * Validates a `--delivery` value before any network call so the seller gets an
+ * actionable, client-side error instead of an opaque backend 400.
+ *
+ * Throws a plain `Error` when:
+ * - the value is `encrypted-message` (a real protocol method, but unusable via
+ *   the CLI because there is no way to attach an encrypted deliverable body), or
+ * - the value is not one of the known `DeliveryMethod` values at all.
+ *
+ * Returns the value narrowed to a CLI-supported method on success.
+ */
+export function assertSupportedDeliveryMethod(
+  method: string,
+): (typeof CLI_SUPPORTED_DELIVERY_METHODS)[number] {
+  if (method === "encrypted-message") {
+    throw new Error(
+      `delivery method "encrypted-message" is not supported via the CLI: ` +
+        `it requires an encrypted deliverable body, which the CLI cannot ` +
+        `attach. Supported delivery methods: ${CLI_SUPPORTED_DELIVERY_METHODS.join(", ")}.`,
+    );
+  }
+  if (
+    !(CLI_SUPPORTED_DELIVERY_METHODS as ReadonlyArray<string>).includes(method)
+  ) {
+    throw new Error(
+      `unknown delivery method "${method}". ` +
+        `Supported delivery methods: ${CLI_SUPPORTED_DELIVERY_METHODS.join(", ")}.`,
+    );
+  }
+  return method as (typeof CLI_SUPPORTED_DELIVERY_METHODS)[number];
+}
+
+/**
  * Lists a new product for sale. The seller is the signing agent; the SDK signs
  * the canonical `marketplace.product` payload with the wallet key.
  */
@@ -125,6 +168,9 @@ export async function createProduct(
   signer: LocalSigner,
   input: CreateProductInput,
 ): Promise<ProductDetail> {
+  // Reject CLI-unsupported delivery methods up front so the seller gets a
+  // clear, actionable error instead of an opaque backend 400.
+  assertSupportedDeliveryMethod(input.deliveryMethod);
   const request: ProductCreateRequest = {
     seller: signer.agentId,
     sellerCryptoId: signer.agentId,


### PR DESCRIPTION
## Summary

`market sell --delivery encrypted-message` is unusable through the OpenClaw plugin CLI and fails with an opaque backend error. This adds a client-side guard that rejects unsupported delivery methods *before* the network call with an actionable message.

## Problem

Running:

```
tinyplace-agent market sell --delivery encrypted-message ...
```

fails with a bare backend response:

```
HTTP 400 {"error":"encrypted-message delivery requires encrypted body"}
```

Root cause: `encrypted-message` is a valid protocol `DeliveryMethod`, but the backend only accepts such a listing when the seller attaches an **encrypted deliverable body**. The plugin's `createProduct` never sets `deliveryDetails`, and the CLI `market sell` case never collects one — so there is no path to provide that body. The seller is left with an opaque server 400 and no way forward. (`--delivery download` and `--delivery a2a-task` work fine, as they need no body.)

## Solution

Add an exported, unit-testable helper `assertSupportedDeliveryMethod(method)` in `sdk/plugin-openclaw/src/market.ts`, called from `createProduct` before the SDK/network call. It:

- rejects `encrypted-message` with a clear message explaining it is not supported via the CLI (it needs an encrypted deliverable body the CLI cannot attach) and naming the supported methods, and
- rejects any value outside the known `DeliveryMethod` set.

This turns the opaque backend 400 into actionable client-side guidance. We deliberately do **not** ship a plaintext `deliveryDetails` body to satisfy the backend, since that would not be a real encrypted delivery.

Exact error text for `encrypted-message`:

> `delivery method "encrypted-message" is not supported via the CLI: it requires an encrypted deliverable body, which the CLI cannot attach. Supported delivery methods: download, a2a-task.`

For an unknown value (e.g. `smoke-signal`):

> `unknown delivery method "smoke-signal". Supported delivery methods: download, a2a-task.`

## Test

New `sdk/plugin-openclaw/src/market.test.ts` (node:test, matching the existing `messaging.test.ts` style):

- `assertSupportedDeliveryMethod` accepts `download` and `a2a-task`.
- `assertSupportedDeliveryMethod` rejects `encrypted-message` and an unknown method with the actionable error.
- `createProduct` rejects `encrypted-message` / unknown methods **before** the network call (mocked client `createProduct` asserts it is never invoked).
- `createProduct` accepts `download` and `a2a-task` and lists the product (mocked client + signer).

Full plugin suite: **66 passing, 0 failing**. `pnpm -r lint`, `prettier --check`, and the pre-push `pnpm format && pnpm lint && pnpm build` all green.

## Scope

Only `sdk/plugin-openclaw/` is touched. No changes to `sdk/typescript/` or the website. No GitHub issue is associated with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for product delivery methods. Unsupported delivery methods are now detected on the client-side before network requests, providing clear error messages with guidance on supported options.

* **Tests**
  * Added comprehensive tests for delivery method validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->