### PR TITLE
fix(openclaw): record harness key best-effort so domain buy survives a profile-write failure

### DIFF
--- a/sdk/plugin-openclaw/src/agent.test.ts
+++ b/sdk/plugin-openclaw/src/agent.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { LocalSigner, TinyPlaceClient } from "@tinyhumansai/tinyplace";
+
+import { buyDomain } from "./agent.js";
+
+const SIGNER = {
+  agentId: "4S3656ssvbVpaD9yGMtwVj3e7qMZNuSSxuQuhXKccrQj",
+  publicKeyBase64: "Mvzw9tEbDl4wl36Z5Yhg83IQTMwyzB8AWgBkf2EMjKw=",
+} as unknown as LocalSigner;
+
+const IDENTITY = {
+  username: "@openclawtest",
+  cryptoId: SIGNER.agentId,
+  status: "active",
+  registeredAt: "2026-06-17T00:00:00.000Z",
+  expiresAt: "2027-06-17T00:00:00.000Z",
+};
+
+/** Runs `fn` with process.stderr.write captured; returns what was written. */
+async function captureStderr(fn: () => Promise<void>): Promise<string> {
+  const original = process.stderr.write.bind(process.stderr);
+  let captured = "";
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === "string" ? chunk : chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return captured;
+}
+
+test("buyDomain returns the registration result even when recordHarness fails", async () => {
+  let registerCalls = 0;
+  const client = {
+    registry: {
+      register: (): Promise<unknown> => {
+        registerCalls += 1;
+        return Promise.resolve(IDENTITY);
+      },
+    },
+    users: {
+      // The profile-write the harness telemetry uses; reject it as staging does.
+      updateProfile: (): Promise<never> =>
+        Promise.reject(new Error("HTTP 401: invalid signature")),
+    },
+  } as unknown as TinyPlaceClient;
+
+  let result: Awaited<ReturnType<typeof buyDomain>> | undefined;
+  const warnings = await captureStderr(async (): Promise<void> => {
+    result = await buyDomain(client, SIGNER, "openclawtest");
+  });
+
+  // The successful registration must survive a failed harness write.
+  assert.equal(registerCalls, 1);
+  assert.equal(result?.username, "@openclawtest");
+  assert.equal(result?.status, "active");
+  // ...and the failure is surfaced as a non-fatal warning, not thrown.
+  assert.match(warnings, /could not record harness key/);
+  assert.match(warnings, /invalid signature/);
+});
+
+test("buyDomain succeeds silently when recordHarness succeeds", async () => {
+  const client = {
+    registry: { register: (): Promise<unknown> => Promise.resolve(IDENTITY) },
+    users: { updateProfile: (): Promise<unknown> => Promise.resolve({}) },
+  } as unknown as TinyPlaceClient;
+
+  const warnings = await captureStderr(async (): Promise<void> => {
+    const result = await buyDomain(client, SIGNER, "openclawtest");
+    assert.equal(result.username, "@openclawtest");
+  });
+  assert.equal(warnings, "");
+});

--- a/sdk/plugin-openclaw/src/agent.ts
+++ b/sdk/plugin-openclaw/src/agent.ts
@@ -124,11 +124,23 @@ export async function buyDomain(
   };
 }
 
+/**
+ * Records this client's harness key on the wallet profile. This is best-effort
+ * telemetry, never load-bearing: a failure here (e.g. the profile endpoint
+ * rejecting the write) must NOT abort a registration that already succeeded —
+ * otherwise a successful (and possibly paid) `domain buy` reports a false
+ * failure. The error is swallowed with a warning rather than propagated.
+ */
 async function recordHarness(
   client: TinyPlaceClient,
   signer: LocalSigner,
 ): Promise<void> {
-  await client.users.updateProfile(signer.agentId, {});
+  try {
+    await client.users.updateProfile(signer.agentId, {});
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`warning: could not record harness key: ${reason}\n`);
+  }
 }
 
 function summarize(identity: {


### PR DESCRIPTION
## Summary
`domain buy` reported a false failure when the post-registration harness-key telemetry write failed — even though the handle was already registered (and, on the paid path, already paid for).

## Problem
`buyDomain` calls `recordHarness()` immediately after a successful `registry.register()` (both the free and paid paths). `recordHarness` did:

```ts
await client.users.updateProfile(signer.agentId, {});
```

and let any error propagate. That profile-write currently fails on staging with `HTTP 401: invalid signature`, so a successful registration was thrown away and surfaced to the user as a hard error. On the free path the thrown error isn't a payment challenge, so `buyDomain`'s `catch` re-throws it; on the paid path it propagates straight out — after the on-chain payment.

Reproduced live on staging: `domain buy openclawpaidtest` returned `HTTP 401 .../profile`, yet `resolve @openclawpaidtest` showed the handle `active` and owned. The registration landed; only the telemetry write failed.

## Solution
Make `recordHarness` best-effort: catch the error, emit a non-fatal warning to stderr, and never propagate. A successful (and possibly paid) registration is now always returned. The underlying profile-endpoint `401` is a separate, server-side issue tracked independently; this change stops it from masking a working core flow.

## Submission Checklist
- [x] Fix scoped to `sdk/plugin-openclaw` only
- [x] Unit tests added (`agent.test.ts`): `buyDomain` returns the registration result + emits a warning when the harness write fails; succeeds silently when it doesn't
- [x] Full plugin test suite green (60 passing, 0 failing)
- [x] `tsc` lint + build clean; pre-push hook (format/lint/build) passed
- [ ] N/A: no GitHub issue — surfaced during live staging E2E testing

## Impact
`domain buy` no longer fails when the harness-key write is rejected; users get the real registration result. No behavior change when the write succeeds.

## Related
Surfaced while E2E-testing the OpenClaw plugin against staging. The root-cause `PUT /users/<cryptoId>/profile` → `401 invalid signature` (which also breaks `profile set`) is server-side and tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Domain registration now continues successfully even when harness key recording encounters issues, with non-fatal warnings logged instead of blocking the operation.

* **Tests**
  * Added test coverage for domain registration error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->