### PR TITLE
fix(sdk/plugin-hermes): address agents by cryptoId (relay-auth + send recipient)

### DIFF
--- a/sdk/plugin-hermes/src/tinyplace/runtime.py
+++ b/sdk/plugin-hermes/src/tinyplace/runtime.py
@@ -146,7 +146,11 @@ class TinyPlaceRuntime:
         rather than skipping forever and leaving peers unable to message us.
         """
         client, _ = await self._client_session()
-        if self._keys_ready or self._keys_published_path.exists():
+        # Only skip when keys were published for the CURRENT address. An install
+        # that published under a previous address (e.g. the old base64 form) must
+        # re-publish under the new one, or peers fetching /keys/<address>/bundle
+        # find nothing and cannot start an X3DH session.
+        if self._keys_ready or self._published_address() == self.address:
             self._keys_ready = True
             return
 
@@ -172,12 +176,25 @@ class TinyPlaceRuntime:
                 self.address,
                 build_pre_keys_request(pre_keys, identity_key),
             )
-        # Only now — after both server calls succeeded — record publication.
+        # Only now — after both server calls succeeded — record publication,
+        # tagged with the address it was published under (so a later address
+        # change forces a re-publish).
         self._keys_published_path.parent.mkdir(parents=True, exist_ok=True)
         self._keys_published_path.write_text(
-            json.dumps({"published": True}), "utf-8"
+            json.dumps({"published": True, "address": self.address}), "utf-8"
         )
         self._keys_ready = True
+
+    def _published_address(self) -> str | None:
+        """Return the address the prekeys were last published under, if any."""
+        try:
+            data = json.loads(self._keys_published_path.read_text("utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if isinstance(data, dict) and data.get("published"):
+            address = data.get("address")
+            return address if isinstance(address, str) else None
+        return None
 
     # --- Cursor persistence -------------------------------------------------
 

--- a/sdk/plugin-hermes/src/tinyplace/runtime.py
+++ b/sdk/plugin-hermes/src/tinyplace/runtime.py
@@ -80,10 +80,12 @@ class TinyPlaceRuntime:
         self._cursor_path = config.state_dir / _CURSOR_FILE
         self._keys_published_path = config.state_dir / _KEYS_PUBLISHED_FILE
 
-        # The agent's messaging address is its base64 Ed25519 encryption public
-        # key (== signer.public_key_base64), used as both mailbox key and the
-        # sender/recipient address in envelopes.
-        self.address = self._signer.public_key_base64
+        # The agent's messaging address is its base58 cryptoId (== signer.agent_id),
+        # used as the mailbox key, the /keys path id, and the sender/recipient
+        # address in envelopes. The cryptoId is URL-safe; the base64 public key
+        # would carry '/' and '=' that break the relay's signed-write auth on
+        # path/query-addressed routes (e.g. PUT /keys/{id}/signed-prekey).
+        self.address = self._signer.agent_id
 
         self._loop = asyncio.new_event_loop()
         self._thread = threading.Thread(

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -20,6 +20,7 @@ from ._sdk import sdk_import
 from .runtime import TinyPlaceRuntime, get_runtime
 
 TinyPlaceError = sdk_import("http").TinyPlaceError
+_decode_agent_address = sdk_import("api.messages").decode_agent_address
 
 # Agent-card metadata key the directory advertises the messaging key under
 # (mirrors website/src/common/encryption-discovery.ts).
@@ -240,7 +241,7 @@ async def _resolve_address(runtime: TinyPlaceRuntime, to: str) -> str:
     card's ``encryptionPublicKey`` metadata, falling back to its ``publicKey``
     (single-key agents). Mirrors website/src/common/encryption-discovery.ts.
     """
-    if not to.startswith("@") and _looks_like_base64_key(to):
+    if not to.startswith("@") and _is_messaging_address(to):
         return to
 
     client = await runtime.get_client()
@@ -271,14 +272,18 @@ def _agent_card(resolved: Any) -> dict[str, Any]:
     return resolved
 
 
-def _looks_like_base64_key(value: str) -> bool:
-    import base64
+def _is_messaging_address(value: str) -> bool:
+    """True if ``value`` is a raw messaging address, not a handle to resolve.
 
+    A messaging address is the agent's 32-byte Ed25519 key encoded as a base58
+    cryptoId (the canonical form) or base64. Anything else (e.g. a bare handle
+    like ``alice``) is resolved through the directory.
+    """
     try:
-        decoded = base64.b64decode(value, validate=True)
-    except Exception:  # noqa: BLE001
+        _decode_agent_address(value)
+        return True
+    except Exception:  # noqa: BLE001 - not a 32-byte address; treat as a handle
         return False
-    return len(decoded) == 32
 
 
 def _decode_text(plaintext: bytes) -> str:

--- a/sdk/plugin-hermes/tests/test_address_resolution.py
+++ b/sdk/plugin-hermes/tests/test_address_resolution.py
@@ -1,0 +1,23 @@
+"""send_message must treat a raw messaging address (cryptoId/base64) as-is.
+
+Regression: after addressing switched to base58 cryptoIds, _resolve_address
+mis-classified a cryptoId as a @handle and hit /directory/resolve/@<cryptoId>
+(404). A raw 32-byte address must be used directly; only handles resolve.
+"""
+
+from __future__ import annotations
+
+from conftest import tools
+from tinyplace import LocalSigner
+
+
+def test_cryptoid_and_base64_are_recognized_as_addresses() -> None:
+    signer = LocalSigner.from_seed(bytes(range(32)))
+    assert tools._is_messaging_address(signer.agent_id) is True            # base58 cryptoId
+    assert tools._is_messaging_address(signer.public_key_base64) is True    # base64 key
+
+
+def test_handles_are_not_addresses() -> None:
+    assert tools._is_messaging_address("alice") is False
+    assert tools._is_messaging_address("@alice") is False
+    assert tools._is_messaging_address("") is False

--- a/sdk/plugin-hermes/tests/test_bootstrap.py
+++ b/sdk/plugin-hermes/tests/test_bootstrap.py
@@ -8,6 +8,7 @@ agent with local Signal keys but no server bundle for peers to fetch.
 from __future__ import annotations
 
 import base64
+import json
 
 import pytest
 
@@ -66,6 +67,33 @@ def test_bootstrap_retries_publication_until_it_succeeds(tmp_path, monkeypatch):
     assert keys.rotate_calls == 2  # retried after the first failure
     assert keys.upload_calls == 1  # only ran once publication got past rotate
 
-    # A subsequent run is a no-op now that the marker exists.
+    # A subsequent run is a no-op now that the marker exists for this address.
     rt.run(rt.ensure_messaging_keys())
     assert keys.rotate_calls == 2
+
+
+def test_republishes_when_address_changes(tmp_path, monkeypatch):
+    # A marker left by a previous run under a DIFFERENT address (e.g. the old
+    # base64 form) must not suppress publication under the current address.
+    monkeypatch.setenv(cfg.ENV_AGENT_KEY, _SEED)
+    monkeypatch.setenv(cfg.ENV_STATE_DIR, str(tmp_path))
+    rt = runtime_mod.load_runtime()
+    keys = _FakeKeys()
+    rt._client = _FakeClient(keys)
+    rt._session = object()
+
+    # Simulate a stale marker written under a now-defunct address.
+    rt._keys_published_path.parent.mkdir(parents=True, exist_ok=True)
+    rt._keys_published_path.write_text(
+        json.dumps({"published": True, "address": "OLD_BASE64_ADDRESS"}), "utf-8"
+    )
+
+    rt.run(rt.ensure_messaging_keys())
+
+    # It re-published under the current address and rewrote the marker.
+    assert keys.rotate_calls == 1
+    assert json.loads(rt._keys_published_path.read_text())["address"] == rt.address
+
+    # Now it's a no-op for the current address.
+    rt.run(rt.ensure_messaging_keys())
+    assert keys.rotate_calls == 1


### PR DESCRIPTION
## Why

These two plugin fixes were pushed to the #75 branch **after** #75 had already merged, so they never landed on `main`. Without them the Hermes plugin still uses the **base64 public key** as the agent address — which fails the relay's signed-write auth (`403`) and mis-resolves cryptoId recipients as `@handle`s (`404`). (The corresponding SDK fix is already in `main` via #76.)

## What

- **runtime.py**: address the agent by its base58 **cryptoId** (`signer.agent_id`), not the base64 pubkey. The base64 form's `/`/`=` break the relay's path/query-addressed signed writes (prekey publish, inbox poll → `403 relay signature required`).
- **tools.py**: `send_message` recognizes a base58 cryptoId (or base64) as a **raw messaging address** via the SDK's `decode_agent_address`, instead of mis-classifying it as a `@handle` and hitting `/directory/resolve/@<cryptoId>` → `404`.

## Verification

Verified end-to-end against staging on a real Hermes install: two agents publish prekeys, exchange an X3DH-bootstrapped encrypted message, and reply. 26 plugin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address resolution to correctly recognize raw messaging identifiers (and avoid false positives).
  * Updated messaging key publication behavior to track the previously published address, republish when it changes, and keep subsequent runs as a no-op.

* **Tests**
  * Added regression tests covering address recognition and ensuring publication is idempotent unless the address differs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->