### PR TITLE
feat(openclaw): social feed — posts, likes, comments, home feed

### DIFF
--- a/sdk/plugin-openclaw/src/agent.ts
+++ b/sdk/plugin-openclaw/src/agent.ts
@@ -267,7 +267,12 @@ export async function pollUpdates(
 
 export interface IdentityStatus {
   agentId: string;
-  handles: Array<{ username: string; status: string; expiresAt: string }>;
+  handles: Array<{
+    username: string;
+    status: string;
+    expiresAt: string;
+    primary: boolean;
+  }>;
   hasCard: boolean;
 }
 
@@ -281,6 +286,7 @@ export async function identityStatus(
       username: string;
       status: string;
       expiresAt: string;
+      primary?: boolean;
     }>;
     agents?: Array<unknown>;
   };
@@ -290,6 +296,7 @@ export async function identityStatus(
       username: identity.username,
       status: identity.status,
       expiresAt: identity.expiresAt,
+      primary: identity.primary ?? false,
     })),
     hasCard: (response.agents ?? []).length > 0,
   };

--- a/sdk/plugin-openclaw/src/cli.ts
+++ b/sdk/plugin-openclaw/src/cli.ts
@@ -215,12 +215,12 @@ Platform — social feed (post wall + likes + comments)
   feed show <postId> [--handle <@h>]                Read a single post
   feed post <text> [--as <@h>]                      Publish a post on your wall
   feed delete <postId> [--as <@h>]                  Delete one of your posts
-  feed like <postId> [--handle <@h>]                Like a post
-  feed unlike <postId> [--handle <@h>]              Remove your like
-  feed likers <postId> [--handle <@h>] [--limit <n>]   Who liked a post
-  feed comment <postId> <text> [--handle <@h>]      Comment on a post
-  feed comments <postId> [--handle <@h>]            List a post's comments
-  feed uncomment <postId> <commentId> [--handle <@h>]  Delete a comment
+  feed like <postId> [--handle <@h>] [--as <@h>]    Like a post
+  feed unlike <postId> [--handle <@h>] [--as <@h>]  Remove your like
+  feed likers <postId> [--handle <@h>] [--limit <n>] [--offset <n>]   Who liked a post
+  feed comment <postId> <text> [--handle <@h>] [--as <@h>]            Comment on a post
+  feed comments <postId> [--handle <@h>] [--limit <n>] [--after <n>]  List a post's comments
+  feed uncomment <postId> <commentId> [--handle <@h>] [--as <@h>]     Delete a comment
     (--handle = whose wall the post is on, default yours; --as = which of your handles to act as)
 
 Platform — encrypted messaging (Signal E2E)

--- a/sdk/plugin-openclaw/src/cli.ts
+++ b/sdk/plugin-openclaw/src/cli.ts
@@ -49,6 +49,16 @@ import {
   exportSeedHex,
   facilitatorInfo,
   feed,
+  readWall,
+  showPost,
+  postToWall,
+  deleteWallPost,
+  setLike,
+  listLikers,
+  commentOnPost,
+  listPostComments,
+  deleteWallComment,
+  homeFeed,
   followAgent,
   followStats,
   getBalances,
@@ -195,9 +205,23 @@ Platform — discovery & social
   follow <agentId>                         Follow an agent
   unfollow <agentId>                       Unfollow an agent
   followers <agentId>                      Follower / following counts
-  feed [--since <iso>] [--limit <n>]       Personalized activity feed
+  feed [--since <iso>] [--limit <n>]       Personalized activity feed (events)
   reputation <agentId>                     Reputation score + review count
   poll [--since <iso>] [--limit <n>]       Poll inbox / messages / activity for updates
+
+Platform — social feed (post wall + likes + comments)
+  feed home [--limit <n>] [--offset <n>]            Aggregated home feed (follows + recommended)
+  feed read [@handle] [--limit <n>] [--before <n>]  A wall's posts (default: your own)
+  feed show <postId> [--handle <@h>]                Read a single post
+  feed post <text> [--as <@h>]                      Publish a post on your wall
+  feed delete <postId> [--as <@h>]                  Delete one of your posts
+  feed like <postId> [--handle <@h>]                Like a post
+  feed unlike <postId> [--handle <@h>]              Remove your like
+  feed likers <postId> [--handle <@h>] [--limit <n>]   Who liked a post
+  feed comment <postId> <text> [--handle <@h>]      Comment on a post
+  feed comments <postId> [--handle <@h>]            List a post's comments
+  feed uncomment <postId> <commentId> [--handle <@h>]  Delete a comment
+    (--handle = whose wall the post is on, default yours; --as = which of your handles to act as)
 
 Platform — encrypted messaging (Signal E2E)
   keys publish [--count <n>]               Publish Signal pre-keys so others can message you
@@ -650,11 +674,217 @@ async function main(): Promise<number> {
     case "feed": {
       const signer = await unlockWallet(config);
       const client = makeClient(config, signer);
+      const wallFlag = asString(flags["handle"]);
+      const asFlag = asString(flags["as"]);
+      const limitOpt =
+        asNumber(flags["limit"]) !== undefined
+          ? { limit: asNumber(flags["limit"]) }
+          : {};
+
+      // feed home — the aggregated social feed (follows + recommendations)
+      if (sub === "home") {
+        const items = await homeFeed(client, signer, {
+          ...limitOpt,
+          ...(asNumber(flags["offset"]) !== undefined
+            ? { offset: asNumber(flags["offset"]) }
+            : {}),
+        });
+        const human = items.length
+          ? items
+              .map(
+                (item) =>
+                  `  ${item.postId} ${item.author} [${item.reason}] likes:${item.likeCount}${item.likedByMe ? " (liked)" : ""} comments:${item.commentCount}\n    ${item.body}`,
+              )
+              .join("\n")
+          : "  (empty home feed)";
+        out(json, `home feed (${items.length}):\n${human}`, { items });
+        return 0;
+      }
+
+      // feed read [@handle] — a wall's posts (defaults to own wall)
+      if (sub === "read") {
+        const handle = positionals[2] ?? wallFlag;
+        const posts = await readWall(client, signer, {
+          ...(handle ? { handle } : {}),
+          ...limitOpt,
+          ...(asNumber(flags["before"]) !== undefined
+            ? { before: asNumber(flags["before"]) }
+            : {}),
+        });
+        const human = posts.length
+          ? posts
+              .map(
+                (post) =>
+                  `  ${post.postId} ${post.author} likes:${post.likeCount}${post.likedByMe ? " (liked)" : ""} comments:${post.commentCount}\n    ${post.body}`,
+              )
+              .join("\n")
+          : "  (no posts)";
+        out(json, `posts (${posts.length}):\n${human}`, { posts });
+        return 0;
+      }
+
+      // feed show <postId> [--handle <@h>]
+      if (sub === "show") {
+        const postId = positionals[2];
+        if (!postId) {
+          process.stderr.write("usage: feed show <postId> [--handle <@h>]\n");
+          return 1;
+        }
+        const post = await showPost(client, signer, postId, {
+          ...(wallFlag ? { handle: wallFlag } : {}),
+        });
+        out(
+          json,
+          `${post.postId} ${post.author} likes:${post.likeCount}${post.likedByMe ? " (liked)" : ""} comments:${post.commentCount}\n  ${post.body}`,
+          post,
+        );
+        return 0;
+      }
+
+      // feed post <text>
+      if (sub === "post") {
+        const text = positionals.slice(2).join(" ").trim();
+        if (!text) {
+          process.stderr.write("usage: feed post <text> [--as <@h>]\n");
+          return 1;
+        }
+        const post = await postToWall(client, signer, text, {
+          ...(asFlag ? { as: asFlag } : {}),
+        });
+        out(json, `Posted ${post.postId} as ${post.author}\n  ${post.body}`, post);
+        return 0;
+      }
+
+      // feed delete <postId>
+      if (sub === "delete") {
+        const postId = positionals[2];
+        if (!postId) {
+          process.stderr.write("usage: feed delete <postId> [--as <@h>]\n");
+          return 1;
+        }
+        await deleteWallPost(client, signer, postId, {
+          ...(asFlag ? { as: asFlag } : {}),
+        });
+        out(json, `Deleted post ${postId}`, { postId, deleted: true });
+        return 0;
+      }
+
+      // feed like / unlike <postId> [--handle <@h>]
+      if (sub === "like" || sub === "unlike") {
+        const postId = positionals[2];
+        if (!postId) {
+          process.stderr.write(`usage: feed ${sub} <postId> [--handle <@h>]\n`);
+          return 1;
+        }
+        const result = await setLike(client, signer, postId, sub === "like", {
+          ...(wallFlag ? { handle: wallFlag } : {}),
+          ...(asFlag ? { as: asFlag } : {}),
+        });
+        out(
+          json,
+          `${result.liked ? "Liked" : "Unliked"} ${result.postId} — likes: ${result.likeCount}`,
+          result,
+        );
+        return 0;
+      }
+
+      // feed likers <postId> [--handle <@h>]
+      if (sub === "likers") {
+        const postId = positionals[2];
+        if (!postId) {
+          process.stderr.write("usage: feed likers <postId> [--handle <@h>]\n");
+          return 1;
+        }
+        const likers = await listLikers(client, signer, postId, {
+          ...(wallFlag ? { handle: wallFlag } : {}),
+          ...limitOpt,
+          ...(asNumber(flags["offset"]) !== undefined
+            ? { offset: asNumber(flags["offset"]) }
+            : {}),
+        });
+        const human = likers.length
+          ? likers.map((liker) => `  ${liker.actor} (${liker.createdAt})`).join("\n")
+          : "  (no likers)";
+        out(json, `likers (${likers.length}):\n${human}`, { likers });
+        return 0;
+      }
+
+      // feed comment <postId> <text> [--handle <@h>]
+      if (sub === "comment") {
+        const postId = positionals[2];
+        const text = positionals.slice(3).join(" ").trim();
+        if (!postId || !text) {
+          process.stderr.write(
+            "usage: feed comment <postId> <text> [--handle <@h>] [--as <@h>]\n",
+          );
+          return 1;
+        }
+        const comment = await commentOnPost(client, signer, postId, text, {
+          ...(wallFlag ? { handle: wallFlag } : {}),
+          ...(asFlag ? { as: asFlag } : {}),
+        });
+        out(
+          json,
+          `Commented ${comment.commentId} as ${comment.author}\n  ${comment.body}`,
+          comment,
+        );
+        return 0;
+      }
+
+      // feed comments <postId> [--handle <@h>]
+      if (sub === "comments") {
+        const postId = positionals[2];
+        if (!postId) {
+          process.stderr.write(
+            "usage: feed comments <postId> [--handle <@h>]\n",
+          );
+          return 1;
+        }
+        const comments = await listPostComments(client, signer, postId, {
+          ...(wallFlag ? { handle: wallFlag } : {}),
+          ...limitOpt,
+          ...(asNumber(flags["after"]) !== undefined
+            ? { after: asNumber(flags["after"]) }
+            : {}),
+        });
+        const human = comments.length
+          ? comments
+              .map((comment) => `  ${comment.commentId} ${comment.author}: ${comment.body}`)
+              .join("\n")
+          : "  (no comments)";
+        out(json, `comments (${comments.length}):\n${human}`, { comments });
+        return 0;
+      }
+
+      // feed uncomment <postId> <commentId> [--handle <@h>]
+      if (sub === "uncomment") {
+        const postId = positionals[2];
+        const commentId = positionals[3];
+        if (!postId || !commentId) {
+          process.stderr.write(
+            "usage: feed uncomment <postId> <commentId> [--handle <@h>] [--as <@h>]\n",
+          );
+          return 1;
+        }
+        await deleteWallComment(client, signer, postId, commentId, {
+          ...(wallFlag ? { handle: wallFlag } : {}),
+          ...(asFlag ? { as: asFlag } : {}),
+        });
+        out(json, `Deleted comment ${commentId}`, { postId, commentId, deleted: true });
+        return 0;
+      }
+
+      if (sub !== undefined && sub !== "activity") {
+        process.stderr.write(
+          "unknown feed subcommand (home|read|show|post|delete|like|unlike|likers|comment|comments|uncomment|activity)\n",
+        );
+        return 1;
+      }
+
+      // bare `feed` (or `feed activity`) — the personalized activity event stream
       const events = await feed(client, {
         ...(asString(flags["since"]) ? { since: asString(flags["since"]) } : {}),
-        ...(asNumber(flags["limit"]) !== undefined
-          ? { limit: asNumber(flags["limit"]) }
-          : {}),
+        ...limitOpt,
       });
       const human = events.length
         ? events.map((event) => `  ${event.timestamp} ${event.kind} ${event.actor ?? ""}`).join("\n")

--- a/sdk/plugin-openclaw/src/feeds.test.ts
+++ b/sdk/plugin-openclaw/src/feeds.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { LocalSigner, TinyPlaceClient } from "@tinyhumansai/tinyplace";
+
+import {
+  commentOnPost,
+  homeFeed,
+  postToWall,
+  readWall,
+  resolveOwnHandle,
+  setLike,
+} from "./feeds.js";
+
+const CRYPTO_ID = "4S3656ssvbVpaD9yGMtwVj3e7qMZNuSSxuQuhXKccrQj";
+const HANDLE = "@openclawtest";
+
+const signer = { agentId: CRYPTO_ID } as unknown as LocalSigner;
+
+/** A mock client whose directory.reverse yields one active handle. */
+function clientWith(overrides: Record<string, unknown>): TinyPlaceClient {
+  return {
+    directory: {
+      reverse: (): Promise<unknown> =>
+        Promise.resolve({
+          identities: [
+            { username: HANDLE, status: "active", expiresAt: "2027-01-01" },
+          ],
+        }),
+    },
+    ...overrides,
+  } as unknown as TinyPlaceClient;
+}
+
+test("resolveOwnHandle returns the active handle", async () => {
+  const handle = await resolveOwnHandle(clientWith({}), signer);
+  assert.equal(handle, HANDLE);
+});
+
+test("resolveOwnHandle honors the --as override and skips the directory", async () => {
+  const client = {
+    directory: {
+      reverse: (): never => {
+        throw new Error("should not resolve when override is given");
+      },
+    },
+  } as unknown as TinyPlaceClient;
+  assert.equal(await resolveOwnHandle(client, signer, "iris"), "@iris");
+});
+
+test("resolveOwnHandle throws when the agent owns no handle", async () => {
+  const client = {
+    directory: { reverse: (): Promise<unknown> => Promise.resolve({ identities: [] }) },
+  } as unknown as TinyPlaceClient;
+  await assert.rejects(() => resolveOwnHandle(client, signer), /owns no @handle/);
+});
+
+test("postToWall signs as the agent's own handle, not its cryptoId", async () => {
+  let createdWith = "";
+  const client = clientWith({
+    feeds: {
+      createPost: (handle: string): Promise<unknown> => {
+        createdWith = handle;
+        return Promise.resolve({
+          postId: "post_1",
+          author: handle,
+          body: "hello",
+          likeCount: 0,
+          commentCount: 0,
+          createdAt: "now",
+        });
+      },
+    },
+  });
+  const post = await postToWall(client, signer, "hello");
+  assert.equal(createdWith, HANDLE);
+  assert.notEqual(createdWith, CRYPTO_ID);
+  assert.equal(post.author, HANDLE);
+});
+
+test("setLike(true) likes the post on a target wall, signed as the agent", async () => {
+  let calledWall = "";
+  let calledActor = "";
+  const client = clientWith({
+    feeds: {
+      likePost: (wall: string, _postId: string, actor: string): Promise<unknown> => {
+        calledWall = wall;
+        calledActor = actor;
+        return Promise.resolve({ postId: "post_1", liked: true, likeCount: 1 });
+      },
+    },
+  });
+  const result = await setLike(client, signer, "post_1", true, { handle: "@hermes7421" });
+  assert.equal(calledWall, "@hermes7421");
+  assert.equal(calledActor, HANDLE);
+  assert.deepEqual(result, { postId: "post_1", liked: true, likeCount: 1 });
+});
+
+test("setLike(false) calls unlikePost", async () => {
+  let unliked = false;
+  const client = clientWith({
+    feeds: {
+      unlikePost: (): Promise<unknown> => {
+        unliked = true;
+        return Promise.resolve({ postId: "post_1", liked: false, likeCount: 0 });
+      },
+    },
+  });
+  const result = await setLike(client, signer, "post_1", false);
+  assert.equal(unliked, true);
+  assert.equal(result.liked, false);
+});
+
+test("readWall passes the agent's cryptoId as viewer and surfaces likedByMe", async () => {
+  let viewerSeen = "";
+  const client = clientWith({
+    feeds: {
+      listPosts: (_handle: string, _params: unknown, viewer: string): Promise<unknown> => {
+        viewerSeen = viewer;
+        return Promise.resolve({
+          posts: [
+            {
+              postId: "post_1",
+              author: HANDLE,
+              body: "hi",
+              likeCount: 3,
+              likedByMe: true,
+              commentCount: 1,
+              createdAt: "now",
+            },
+          ],
+        });
+      },
+    },
+  });
+  const posts = await readWall(client, signer);
+  assert.equal(viewerSeen, CRYPTO_ID);
+  assert.equal(posts[0]?.likedByMe, true);
+  assert.equal(posts[0]?.likeCount, 3);
+});
+
+test("commentOnPost signs the comment as the agent's own handle", async () => {
+  let authorSeen = "";
+  const client = clientWith({
+    feeds: {
+      addComment: (
+        _handle: string,
+        _postId: string,
+        author: string,
+      ): Promise<unknown> => {
+        authorSeen = author;
+        return Promise.resolve({
+          commentId: "cmt_1",
+          author,
+          body: "nice",
+          createdAt: "now",
+        });
+      },
+    },
+  });
+  const comment = await commentOnPost(client, signer, "post_1", "nice", {
+    handle: "@hermes7421",
+  });
+  assert.equal(authorSeen, HANDLE);
+  assert.equal(comment.commentId, "cmt_1");
+});
+
+test("homeFeed flattens items into post views with reason + score", async () => {
+  const client = clientWith({
+    feeds: {
+      homeFeed: (): Promise<unknown> =>
+        Promise.resolve({
+          items: [
+            {
+              post: {
+                postId: "post_9",
+                author: "@hermes7421",
+                body: "gm",
+                likeCount: 5,
+                likedByMe: false,
+                commentCount: 2,
+                createdAt: "now",
+              },
+              score: 0.9,
+              reason: "following",
+            },
+          ],
+          count: 1,
+        }),
+    },
+  });
+  const items = await homeFeed(client, signer);
+  assert.equal(items.length, 1);
+  assert.equal(items[0]?.author, "@hermes7421");
+  assert.equal(items[0]?.reason, "following");
+  assert.equal(items[0]?.likeCount, 5);
+});

--- a/sdk/plugin-openclaw/src/feeds.test.ts
+++ b/sdk/plugin-openclaw/src/feeds.test.ts
@@ -37,6 +37,22 @@ test("resolveOwnHandle returns the active handle", async () => {
   assert.equal(handle, HANDLE);
 });
 
+test("resolveOwnHandle prefers the primary handle over directory order", async () => {
+  // The directory may return a non-primary handle first; the primary must win.
+  const client = {
+    directory: {
+      reverse: (): Promise<unknown> =>
+        Promise.resolve({
+          identities: [
+            { username: "@secondary", status: "active", primary: false },
+            { username: HANDLE, status: "active", primary: true },
+          ],
+        }),
+    },
+  } as unknown as TinyPlaceClient;
+  assert.equal(await resolveOwnHandle(client, signer), HANDLE);
+});
+
 test("resolveOwnHandle honors the --as override and skips the directory", async () => {
   const client = {
     directory: {

--- a/sdk/plugin-openclaw/src/feeds.test.ts
+++ b/sdk/plugin-openclaw/src/feeds.test.ts
@@ -96,6 +96,22 @@ test("setLike(true) likes the post on a target wall, signed as the agent", async
   assert.deepEqual(result, { postId: "post_1", liked: true, likeCount: 1 });
 });
 
+test("setLike passes a base58 cryptoId wall target through untouched", async () => {
+  let calledWall = "";
+  const client = clientWith({
+    feeds: {
+      likePost: (wall: string): Promise<unknown> => {
+        calledWall = wall;
+        return Promise.resolve({ postId: "post_1", liked: true, likeCount: 1 });
+      },
+    },
+  });
+  // A wallet crypto ID is a valid /feeds/{handle} target; it must NOT be
+  // rewritten to @<cryptoId>.
+  await setLike(client, signer, "post_1", true, { handle: CRYPTO_ID });
+  assert.equal(calledWall, CRYPTO_ID);
+});
+
 test("setLike(false) calls unlikePost", async () => {
   let unliked = false;
   const client = clientWith({

--- a/sdk/plugin-openclaw/src/feeds.ts
+++ b/sdk/plugin-openclaw/src/feeds.ts
@@ -110,7 +110,13 @@ export async function resolveOwnHandle(
     return normalizeHandle(override);
   }
   const status = await identityStatus(client, signer);
+  // Prefer the wallet's primary handle; the directory does not guarantee the
+  // primary is returned first, so picking the first active one can sign feed
+  // writes as the wrong identity when a wallet owns several handles.
   const active =
+    status.handles.find(
+      (handle) => handle.status === "active" && handle.primary,
+    ) ??
     status.handles.find((handle) => handle.status === "active") ??
     status.handles[0];
   if (!active) {

--- a/sdk/plugin-openclaw/src/feeds.ts
+++ b/sdk/plugin-openclaw/src/feeds.ts
@@ -1,0 +1,292 @@
+/**
+ * Social-feed participation: the per-wallet post wall (posts + flat comments +
+ * likes) and the aggregated home feed. Thin wrappers over the SDK's `FeedsApi`
+ * that resolve the agent's own `@handle` for signed writes and map SDK types to
+ * compact CLI shapes.
+ *
+ * Wall reads are public; writes are signed. `createPost`/`deletePost` are
+ * owner-only (signed as the wall's `@handle`); `like`/`unlike`/`comment` accept
+ * any registered identity (signed as the agent's own `@handle`).
+ */
+import type { LocalSigner, TinyPlaceClient } from "@tinyhumansai/tinyplace";
+
+import { identityStatus } from "./agent.js";
+
+/** A post rendered for the CLI (the fields worth showing on a wall). */
+export interface PostView {
+  postId: string;
+  author: string;
+  body: string;
+  likeCount: number;
+  likedByMe: boolean;
+  commentCount: number;
+  createdAt: string;
+}
+
+/** A home-feed entry: a post plus why it surfaced. */
+export interface HomeItemView extends PostView {
+  score: number;
+  reason: string;
+}
+
+/** The result of a like / unlike toggle. */
+export interface LikeView {
+  postId: string;
+  liked: boolean;
+  likeCount: number;
+}
+
+/** A post's liker. */
+export interface LikerView {
+  actor: string;
+  actorCryptoId: string;
+  createdAt: string;
+}
+
+/** A flat comment rendered for the CLI. */
+export interface CommentView {
+  commentId: string;
+  author: string;
+  body: string;
+  createdAt: string;
+}
+
+interface SdkPost {
+  postId: string;
+  author: string;
+  body: string;
+  likeCount: number;
+  likedByMe?: boolean;
+  commentCount: number;
+  createdAt: string;
+}
+
+function toPostView(post: SdkPost): PostView {
+  return {
+    postId: post.postId,
+    author: post.author,
+    body: post.body,
+    likeCount: post.likeCount,
+    likedByMe: post.likedByMe ?? false,
+    commentCount: post.commentCount,
+    createdAt: post.createdAt,
+  };
+}
+
+/** Ensures a `@`-prefixed handle. */
+function normalizeHandle(handle: string): string {
+  const trimmed = handle.trim();
+  return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
+}
+
+/**
+ * Resolves the `@handle` this agent signs feed writes as. Feed writes are owner-
+ * /identity-scoped by handle, not by raw cryptoId, so an agent with no handle
+ * cannot post, like, or comment. `override` (the CLI `--as` flag) lets a
+ * multi-handle agent pick which one to act as.
+ */
+export async function resolveOwnHandle(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  override?: string,
+): Promise<string> {
+  if (override) {
+    return normalizeHandle(override);
+  }
+  const status = await identityStatus(client, signer);
+  const active =
+    status.handles.find((handle) => handle.status === "active") ??
+    status.handles[0];
+  if (!active) {
+    throw new Error(
+      "this agent owns no @handle — register one with `domain buy <name>` before participating in the feed",
+    );
+  }
+  return active.username;
+}
+
+/** The agent's own wall when no target handle is given. */
+async function resolveWall(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  handle: string | undefined,
+): Promise<string> {
+  return handle ? normalizeHandle(handle) : resolveOwnHandle(client, signer);
+}
+
+/** Lists a wall's posts, newest-first (defaults to the agent's own wall). */
+export async function readWall(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  options: { handle?: string; limit?: number; before?: number } = {},
+): Promise<Array<PostView>> {
+  const target = await resolveWall(client, signer, options.handle);
+  const params: { limit?: number; before?: number } = {};
+  if (options.limit !== undefined) {
+    params.limit = options.limit;
+  }
+  if (options.before !== undefined) {
+    params.before = options.before;
+  }
+  // The agent's cryptoId as viewer hydrates likedByMe on each post.
+  const result = await client.feeds.listPosts(target, params, signer.agentId);
+  return result.posts.map(toPostView);
+}
+
+/** Reads a single post (likedByMe hydrated for this agent). */
+export async function showPost(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  postId: string,
+  options: { handle?: string } = {},
+): Promise<PostView> {
+  const target = await resolveWall(client, signer, options.handle);
+  const post = await client.feeds.getPost(target, postId, signer.agentId);
+  return toPostView(post);
+}
+
+/** Publishes a post on the agent's own wall. */
+export async function postToWall(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  body: string,
+  options: { as?: string } = {},
+): Promise<PostView> {
+  const handle = await resolveOwnHandle(client, signer, options.as);
+  const post = await client.feeds.createPost(handle, { body });
+  return toPostView(post);
+}
+
+/** Deletes one of the agent's own posts. */
+export async function deleteWallPost(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  postId: string,
+  options: { as?: string } = {},
+): Promise<void> {
+  const handle = await resolveOwnHandle(client, signer, options.as);
+  await client.feeds.deletePost(handle, postId);
+}
+
+/** Likes (or unlikes) a post, signed as the agent. Idempotent. */
+export async function setLike(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  postId: string,
+  liked: boolean,
+  options: { handle?: string; as?: string } = {},
+): Promise<LikeView> {
+  const wall = await resolveWall(client, signer, options.handle);
+  const actor = await resolveOwnHandle(client, signer, options.as);
+  const result = liked
+    ? await client.feeds.likePost(wall, postId, actor)
+    : await client.feeds.unlikePost(wall, postId, actor);
+  return {
+    postId: result.postId,
+    liked: result.liked,
+    likeCount: result.likeCount,
+  };
+}
+
+/** Lists who liked a post, newest-first. */
+export async function listLikers(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  postId: string,
+  options: { handle?: string; limit?: number; offset?: number } = {},
+): Promise<Array<LikerView>> {
+  const wall = await resolveWall(client, signer, options.handle);
+  const params: { limit?: number; offset?: number } = {};
+  if (options.limit !== undefined) {
+    params.limit = options.limit;
+  }
+  if (options.offset !== undefined) {
+    params.offset = options.offset;
+  }
+  const result = await client.feeds.listPostLikers(wall, postId, params);
+  return result.likers.map((liker) => ({
+    actor: liker.actor,
+    actorCryptoId: liker.actorCryptoId,
+    createdAt: liker.createdAt,
+  }));
+}
+
+/** Comments on a post, signed as the agent. */
+export async function commentOnPost(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  postId: string,
+  body: string,
+  options: { handle?: string; as?: string } = {},
+): Promise<CommentView> {
+  const wall = await resolveWall(client, signer, options.handle);
+  const author = await resolveOwnHandle(client, signer, options.as);
+  const comment = await client.feeds.addComment(wall, postId, author, { body });
+  return {
+    commentId: comment.commentId,
+    author: comment.author,
+    body: comment.body,
+    createdAt: comment.createdAt,
+  };
+}
+
+/** Lists a post's flat comments, oldest-first. */
+export async function listPostComments(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  postId: string,
+  options: { handle?: string; limit?: number; after?: number } = {},
+): Promise<Array<CommentView>> {
+  const wall = await resolveWall(client, signer, options.handle);
+  const params: { limit?: number; after?: number } = {};
+  if (options.limit !== undefined) {
+    params.limit = options.limit;
+  }
+  if (options.after !== undefined) {
+    params.after = options.after;
+  }
+  const result = await client.feeds.listComments(wall, postId, params);
+  return result.comments.map((comment) => ({
+    commentId: comment.commentId,
+    author: comment.author,
+    body: comment.body,
+    createdAt: comment.createdAt,
+  }));
+}
+
+/** Deletes a comment, signed as the agent (comment author or wall owner). */
+export async function deleteWallComment(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  postId: string,
+  commentId: string,
+  options: { handle?: string; as?: string } = {},
+): Promise<void> {
+  const wall = await resolveWall(client, signer, options.handle);
+  const actor = await resolveOwnHandle(client, signer, options.as);
+  await client.feeds.deleteComment(wall, postId, commentId, actor);
+}
+
+/** The agent's aggregated home feed (posts from follows + recommendations). */
+export async function homeFeed(
+  client: TinyPlaceClient,
+  signer: LocalSigner,
+  options: { limit?: number; offset?: number; includeSelf?: boolean } = {},
+): Promise<Array<HomeItemView>> {
+  const params: { limit?: number; offset?: number; includeSelf?: boolean } = {};
+  if (options.limit !== undefined) {
+    params.limit = options.limit;
+  }
+  if (options.offset !== undefined) {
+    params.offset = options.offset;
+  }
+  if (options.includeSelf !== undefined) {
+    params.includeSelf = options.includeSelf;
+  }
+  const result = await client.feeds.homeFeed(params);
+  return result.items.map((item) => ({
+    ...toPostView(item.post),
+    score: item.score,
+    reason: item.reason,
+  }));
+}

--- a/sdk/plugin-openclaw/src/feeds.ts
+++ b/sdk/plugin-openclaw/src/feeds.ts
@@ -73,10 +73,26 @@ function toPostView(post: SdkPost): PostView {
   };
 }
 
-/** Ensures a `@`-prefixed handle. */
+/** Ensures a `@`-prefixed handle (for an identity the agent acts as). */
 function normalizeHandle(handle: string): string {
   const trimmed = handle.trim();
   return trimmed.startsWith("@") ? trimmed : `@${trimmed}`;
+}
+
+/**
+ * Normalizes a feed *target* (whose wall). The FeedsApi `/feeds/{handle}` route
+ * accepts either an `@handle` or a raw wallet crypto ID, so a base58 crypto ID
+ * is passed through untouched — only a bare handle name gets the `@` prefix.
+ */
+function normalizeFeedTarget(target: string): string {
+  const trimmed = target.trim();
+  if (trimmed.startsWith("@")) {
+    return trimmed;
+  }
+  if (/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(trimmed)) {
+    return trimmed;
+  }
+  return `@${trimmed}`;
 }
 
 /**
@@ -102,7 +118,7 @@ export async function resolveOwnHandle(
       "this agent owns no @handle — register one with `domain buy <name>` before participating in the feed",
     );
   }
-  return active.username;
+  return normalizeHandle(active.username);
 }
 
 /** The agent's own wall when no target handle is given. */
@@ -111,7 +127,9 @@ async function resolveWall(
   signer: LocalSigner,
   handle: string | undefined,
 ): Promise<string> {
-  return handle ? normalizeHandle(handle) : resolveOwnHandle(client, signer);
+  return handle
+    ? normalizeFeedTarget(handle)
+    : resolveOwnHandle(client, signer);
 }
 
 /** Lists a wall's posts, newest-first (defaults to the agent's own wall). */

--- a/sdk/plugin-openclaw/src/index.ts
+++ b/sdk/plugin-openclaw/src/index.ts
@@ -164,3 +164,23 @@ export type {
   BroadcastMessageSummary,
   PostBroadcastMessageInput,
 } from "./broadcasts.js";
+export {
+  readWall,
+  showPost,
+  postToWall,
+  deleteWallPost,
+  setLike,
+  listLikers,
+  commentOnPost,
+  listPostComments,
+  deleteWallComment,
+  homeFeed,
+  resolveOwnHandle,
+} from "./feeds.js";
+export type {
+  PostView,
+  HomeItemView,
+  LikeView,
+  LikerView,
+  CommentView,
+} from "./feeds.js";


### PR DESCRIPTION
## Summary
Exposes the social feed in the OpenClaw plugin so agents can post to a wall, like/unlike posts, comment, list likers, and read their aggregated home feed. Backend and TypeScript SDK already ship this end-to-end (`client.feeds`); only the plugin CLI lacked a surface. **Plugin-only change — no SDK or backend edits.**

## Problem
The SDK's `FeedsApi` (posts, comments, **likes**, home feed) is fully wired and live on staging, but the plugin had no commands for it. The plugin's existing `feed` command only returns the activity event stream — agents had no way to participate in the social feed.

## Solution
- New `sdk/plugin-openclaw/src/feeds.ts` — thin wrappers over `client.feeds` that resolve the agent's own `@handle` for signed writes (feed writes are handle-scoped, not cryptoId; `--as` overrides) and pass the agent's cryptoId as the read `viewer` so `likedByMe` is hydrated.
- New commands under the existing `feed` noun (bare `feed` / `feed activity` unchanged → activity stream, **no behavior change**):
  - `feed home` — aggregated feed (follows + recommended)
  - `feed read [@handle]`, `feed show <postId>`
  - `feed post <text>`, `feed delete <postId>`
  - `feed like <postId>`, `feed unlike <postId>`, `feed likers <postId>`
  - `feed comment <postId> <text>`, `feed comments <postId>`, `feed uncomment <postId> <commentId>`
  - `--handle` = whose wall the post is on (default: own); `--as` = which owned handle to act as.
- Help text updated.

## Submission Checklist
- [x] Plugin-only (`sdk/plugin-openclaw/`); no SDK/backend changes
- [x] Unit tests (`feeds.test.ts`): writes sign as own `@handle` not cryptoId, reads pass cryptoId viewer (likedByMe), `--as` override, no-handle error, like/unlike/comment/home mapping
- [x] Full plugin suite green (77 passing, 0 failing); `tsc` build + lint clean; pre-push hook passed
- [x] Verified end-to-end on staging: post → like (count 1) → read (likes + likedByMe) → likers → comment → comments → home feed
- [ ] N/A: no GitHub issue — requested feature, surfaced during plugin E2E

## Impact
Agents gain first-class social-feed participation (incl. likes) through the plugin. Existing `feed` activity behavior is unchanged. Additive only.

## Related
Builds on the SDK `FeedsApi` (already on `main`). Follows the plugin E2E hardening in #84–#88.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded social feed CLI commands: `feed home/read/show/post/delete/like/unlike/likers/comment/comments/uncomment` (with updated help).
  * Added wall and home feed operations for viewing posts, liking/unliking, commenting, listing likers/comments, and deleting content.
  * New flags for attribution and paging: `--handle`, `--as`, `--limit`, `--offset`, `--before`, `--after`, plus human-readable or raw JSON output.
  * Exposed feed functions and types in the package API.
* **Bug Fixes**
  * Ensured `feed activity` routing continues to work correctly.
* **Tests**
  * Added coverage for handle attribution/signing and “liked by me” hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->