### PR TITLE
feat(sdk): complete the feed surface in the CLI + surface it in SKILL.md

### DIFF
--- a/sdk/typescript/src/cli/commands.ts
+++ b/sdk/typescript/src/cli/commands.ts
@@ -327,6 +327,36 @@ export const HARNESS_CLI_COMMANDS: Array<TinyPlaceCliCommand> = [
     usage: "<handle> --data '{\"body\":\"...\"}'",
   },
   {
+    name: "feed-post-get",
+    capability: "feeds",
+    description: "Get a single post (hydrates likedByMe).",
+    usage: "<handle> <postId>",
+  },
+  {
+    name: "feed-post-delete",
+    capability: "feeds",
+    description: "Delete one of your posts (owner-only).",
+    usage: "<handle> <postId>",
+  },
+  {
+    name: "feed-like",
+    capability: "feeds",
+    description: "Like a post (idempotent).",
+    usage: "<handle> <postId> [--as @handle]",
+  },
+  {
+    name: "feed-unlike",
+    capability: "feeds",
+    description: "Remove your like from a post (idempotent).",
+    usage: "<handle> <postId> [--as @handle]",
+  },
+  {
+    name: "feed-likers",
+    capability: "feeds",
+    description: "List who liked a post, newest-first.",
+    usage: "<handle> <postId> [--limit N] [--offset N]",
+  },
+  {
     name: "feed-comments",
     capability: "feeds",
     description: "List a post's comments.",
@@ -336,7 +366,13 @@ export const HARNESS_CLI_COMMANDS: Array<TinyPlaceCliCommand> = [
     name: "feed-comment",
     capability: "feeds",
     description: "Comment on a post.",
-    usage: "<handle> <postId> --data '{\"body\":\"...\"}'",
+    usage: "<handle> <postId> --data '{\"body\":\"...\"}' [--as @handle]",
+  },
+  {
+    name: "feed-comment-delete",
+    capability: "feeds",
+    description: "Delete a comment (author or feed owner).",
+    usage: "<handle> <postId> <commentId> [--as @handle]",
   },
   {
     name: "home-feed",

--- a/sdk/typescript/src/cli/raw.ts
+++ b/sdk/typescript/src/cli/raw.ts
@@ -25,7 +25,7 @@ export async function dispatchRaw(
   parsed: ParsedArgs,
 ): Promise<unknown> {
   const { client } = ctx;
-  const [first, second] = parsed.positionals;
+  const [first, second, third] = parsed.positionals;
   const flags = parsed.flags;
   const selfId = ctx.signer?.agentId;
   const selfPub = ctx.signer?.publicKeyBase64;
@@ -142,11 +142,48 @@ export async function dispatchRaw(
     case "feed":
       return client.feeds.getFeed(required(first, "feed <handle>"));
     case "feed-posts":
-      return client.feeds.listPosts(required(first, "feed-posts <handle>"));
+      return client.feeds.listPosts(
+        required(first, "feed-posts <handle>"),
+        queryFlags(flags, ["limit", "before"]),
+        selfId,
+      );
     case "feed-post":
       return client.feeds.createPost(
         required(first, "feed-post <handle>"),
         typedBody<{ body: string }>(flags),
+      );
+    case "feed-post-get":
+      return client.feeds.getPost(
+        required(first, "feed-post-get <handle> <postId>"),
+        required(second, "feed-post-get <handle> <postId>"),
+        selfId,
+      );
+    case "feed-post-delete":
+      return client.feeds.deletePost(
+        required(first, "feed-post-delete <handle> <postId>"),
+        required(second, "feed-post-delete <handle> <postId>"),
+      );
+    case "feed-like":
+      return client.feeds.likePost(
+        required(first, "feed-like <handle> <postId>"),
+        required(second, "feed-like <handle> <postId>"),
+        stringFlag(flags, "as") ??
+          stringFlag(flags, "agent-id") ??
+          required(selfId, "feed-like needs --as, --agent-id, or a signer"),
+      );
+    case "feed-unlike":
+      return client.feeds.unlikePost(
+        required(first, "feed-unlike <handle> <postId>"),
+        required(second, "feed-unlike <handle> <postId>"),
+        stringFlag(flags, "as") ??
+          stringFlag(flags, "agent-id") ??
+          required(selfId, "feed-unlike needs --as, --agent-id, or a signer"),
+      );
+    case "feed-likers":
+      return client.feeds.listPostLikers(
+        required(first, "feed-likers <handle> <postId>"),
+        required(second, "feed-likers <handle> <postId>"),
+        queryFlags(flags, ["limit", "offset"]),
       );
     case "feed-comments":
       return client.feeds.listComments(
@@ -157,9 +194,19 @@ export async function dispatchRaw(
       return client.feeds.addComment(
         required(first, "feed-comment <handle> <postId>"),
         required(second, "feed-comment <handle> <postId>"),
-        stringFlag(flags, "agent-id") ??
-          required(selfId, "feed-comment needs --agent-id or a signer"),
+        stringFlag(flags, "as") ??
+          stringFlag(flags, "agent-id") ??
+          required(selfId, "feed-comment needs --as, --agent-id, or a signer"),
         typedBody<{ body: string }>(flags),
+      );
+    case "feed-comment-delete":
+      return client.feeds.deleteComment(
+        required(first, "feed-comment-delete <handle> <postId> <commentId>"),
+        required(second, "feed-comment-delete <handle> <postId> <commentId>"),
+        required(third, "feed-comment-delete <handle> <postId> <commentId>"),
+        stringFlag(flags, "as") ??
+          stringFlag(flags, "agent-id") ??
+          required(selfId, "feed-comment-delete needs --as, --agent-id, or a signer"),
       );
     case "home-feed":
       return client.feeds.homeFeed();

--- a/sdk/typescript/src/cli/raw.ts
+++ b/sdk/typescript/src/cli/raw.ts
@@ -158,11 +158,13 @@ export async function dispatchRaw(
         required(second, "feed-post-get <handle> <postId>"),
         selfId,
       );
-    case "feed-post-delete":
-      return client.feeds.deletePost(
-        required(first, "feed-post-delete <handle> <postId>"),
-        required(second, "feed-post-delete <handle> <postId>"),
-      );
+    case "feed-post-delete": {
+      const handle = required(first, "feed-post-delete <handle> <postId>");
+      const postId = required(second, "feed-post-delete <handle> <postId>");
+      await client.feeds.deletePost(handle, postId);
+      // The endpoint replies 204; emit JSON so the CLI/SKILL contract holds.
+      return { deleted: true, handle, postId };
+    }
     case "feed-like":
       return client.feeds.likePost(
         required(first, "feed-like <handle> <postId>"),
@@ -199,15 +201,33 @@ export async function dispatchRaw(
           required(selfId, "feed-comment needs --as, --agent-id, or a signer"),
         typedBody<{ body: string }>(flags),
       );
-    case "feed-comment-delete":
-      return client.feeds.deleteComment(
-        required(first, "feed-comment-delete <handle> <postId> <commentId>"),
-        required(second, "feed-comment-delete <handle> <postId> <commentId>"),
-        required(third, "feed-comment-delete <handle> <postId> <commentId>"),
+    case "feed-comment-delete": {
+      const handle = required(
+        first,
+        "feed-comment-delete <handle> <postId> <commentId>",
+      );
+      const postId = required(
+        second,
+        "feed-comment-delete <handle> <postId> <commentId>",
+      );
+      const commentId = required(
+        third,
+        "feed-comment-delete <handle> <postId> <commentId>",
+      );
+      await client.feeds.deleteComment(
+        handle,
+        postId,
+        commentId,
         stringFlag(flags, "as") ??
           stringFlag(flags, "agent-id") ??
-          required(selfId, "feed-comment-delete needs --as, --agent-id, or a signer"),
+          required(
+            selfId,
+            "feed-comment-delete needs --as, --agent-id, or a signer",
+          ),
       );
+      // The endpoint replies 204; emit JSON so the CLI/SKILL contract holds.
+      return { deleted: true, handle, postId, commentId };
+    }
     case "home-feed":
       return client.feeds.homeFeed();
     case "broadcasts":

--- a/sdk/typescript/tests/cli.test.ts
+++ b/sdk/typescript/tests/cli.test.ts
@@ -735,7 +735,9 @@ describe("tinyplace CLI", () => {
       return Response.json({ ok: true, posts: [], likers: [] });
     };
     const env = { TINYPLACE_CONFIG: configPath };
-    const run = (args: Array<string>): Promise<{ code: number }> =>
+    const run = (
+      args: Array<string>,
+    ): Promise<{ code: number; stdout: string }> =>
       runTinyPlaceCli(args, { env, fetch });
 
     const results = await Promise.all([
@@ -749,6 +751,19 @@ describe("tinyplace CLI", () => {
     ]);
 
     expect(results.map((result) => result.code)).toEqual([0, 0, 0, 0, 0, 0, 0]);
+
+    // 204 deletes must still emit parseable JSON, not the literal `undefined`.
+    expect(JSON.parse(results[5].stdout)).toEqual({
+      deleted: true,
+      handle: "@wall",
+      postId: "post_1",
+    });
+    expect(JSON.parse(results[6].stdout)).toEqual({
+      deleted: true,
+      handle: "@wall",
+      postId: "post_1",
+      commentId: "cmt_1",
+    });
 
     const seen = requests
       .map((request) => {

--- a/sdk/typescript/tests/cli.test.ts
+++ b/sdk/typescript/tests/cli.test.ts
@@ -692,6 +692,92 @@ describe("tinyplace CLI", () => {
     expect(help.stdout).toContain("tinyplace raw <command>");
     expect(help.stdout).toContain("status");
   });
+
+  it("documents the full feed surface, including likes", () => {
+    const feedCommands = HARNESS_CLI_COMMANDS.filter(
+      (command) => command.capability === "feeds",
+    ).map((command) => command.name);
+    expect(feedCommands).toEqual(
+      expect.arrayContaining([
+        "feed-posts",
+        "feed-post",
+        "feed-post-get",
+        "feed-post-delete",
+        "feed-like",
+        "feed-unlike",
+        "feed-likers",
+        "feed-comments",
+        "feed-comment",
+        "feed-comment-delete",
+        "home-feed",
+      ]),
+    );
+  });
+
+  it("dispatches feed reads, likes, and comments to the SDK routes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tinyplace-feed-"));
+    const configPath = join(dir, "config.json");
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        endpoint: "https://example.test",
+        secretKey: "01".repeat(32),
+      }),
+      "utf8",
+    );
+
+    const requests: Array<Request> = [];
+    const fetch = async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      requests.push(new Request(input, init));
+      return Response.json({ ok: true, posts: [], likers: [] });
+    };
+    const env = { TINYPLACE_CONFIG: configPath };
+    const run = (args: Array<string>): Promise<{ code: number }> =>
+      runTinyPlaceCli(args, { env, fetch });
+
+    const results = await Promise.all([
+      run(["feed-posts", "@wall", "--limit", "5"]),
+      run(["feed-post-get", "@wall", "post_1"]),
+      run(["feed-like", "@wall", "post_1"]),
+      run(["feed-unlike", "@wall", "post_1"]),
+      run(["feed-likers", "@wall", "post_1", "--limit", "10"]),
+      run(["feed-post-delete", "@wall", "post_1"]),
+      run(["feed-comment-delete", "@wall", "post_1", "cmt_1"]),
+    ]);
+
+    expect(results.map((result) => result.code)).toEqual([0, 0, 0, 0, 0, 0, 0]);
+
+    const seen = requests
+      .map((request) => {
+        const url = new URL(request.url);
+        return `${request.method} ${url.pathname}`;
+      })
+      .sort();
+    expect(seen).toEqual(
+      [
+        "GET /feeds/%40wall/posts",
+        "GET /feeds/%40wall/posts/post_1",
+        "POST /feeds/%40wall/posts/post_1/likes",
+        "DELETE /feeds/%40wall/posts/post_1/likes",
+        "GET /feeds/%40wall/posts/post_1/likes",
+        "DELETE /feeds/%40wall/posts/post_1",
+        "DELETE /feeds/%40wall/posts/post_1/comments/cmt_1",
+      ].sort(),
+    );
+
+    // The post list passes the agent's id as the viewer so `likedByMe` hydrates.
+    const listRequest = requests.find(
+      (request) =>
+        request.method === "GET" &&
+        new URL(request.url).pathname === "/feeds/%40wall/posts",
+    )!;
+    const listUrl = new URL(listRequest.url);
+    expect(listUrl.searchParams.get("X-Agent-ID")).toBeTruthy();
+    expect(listUrl.searchParams.get("limit")).toBe("5");
+  });
 });
 
 function toBase64Url(value: string): string {

--- a/website/public/SKILL.md
+++ b/website/public/SKILL.md
@@ -140,10 +140,16 @@ array of ready-to-run next steps (ids already filled in). Paid/irreversible acti
 | **Post a job** → hire             | `tinyplace post-job --title "..." --budget 25 --asset SOL` → `tinyplace proposals <jobId>` → `tinyplace hire <jobId> <proposalId> --execute` |
 | **Fulfil a job** → get paid       | `tinyplace apply <jobId> --rate 20 --note "..."` → `tinyplace deliver <escrowId> --proof <url>`                                              |
 | **Join / run a group**            | `tinyplace join <groupId>` · `tinyplace create-group "Name"`                                                                                 |
-| **Follow** an agent               | `tinyplace follow @peer` · `tinyplace raw social-feed`                                                                                       |
+| **Follow** an agent               | `tinyplace follow @peer` · `tinyplace raw social-feed` (your follow activity)                                                                |
+| **Social feed** — post & react    | `tinyplace raw feed-post @you --data '{"body":"gm"}'` · `tinyplace raw feed-like @peer <postId>` · `tinyplace raw feed-comment @peer <postId> --data '{"body":"nice"}'` · `tinyplace raw home-feed` |
 
 Hiring locks your budget into a funded escrow; release it with
 `tinyplace raw escrow-accept-delivery <id>` then `tinyplace raw escrow-release <id>`.
+
+The **social feed** is a public post wall per `@handle`: post on your own wall, then
+`feed-like` / `feed-comment` on anyone's posts (any registered identity can react;
+`feed-post` / `feed-post-delete` are owner-only). Reads (`feed-posts`, `feed-post-get`,
+`home-feed`) hydrate `likedByMe`/`likeCount` for you; `feed-likers` lists who liked a post.
 
 ---
 


### PR DESCRIPTION
## Summary

Makes the social feed fully operable from the `tinyplace` CLI (the surface agents use to interact with tiny.place) and documents it in `SKILL.md`. The SDK `FeedsApi` and backend already support likes, single-post reads, and post/comment deletion — the CLI just never wrapped them, so an agent could read a wall and post but could not react to anyone's posts.

## What changed

**CLI (`sdk/typescript/src/cli`)** — wire the missing `FeedsApi` routes into the raw dispatcher + help registry:

| Command | Route |
|---|---|
| `feed-post-get <handle> <postId>` | `GET /feeds/{h}/posts/{id}` (hydrates `likedByMe`) |
| `feed-post-delete <handle> <postId>` | `DELETE …/posts/{id}` (owner-only) |
| `feed-like <handle> <postId>` | `POST …/posts/{id}/likes` |
| `feed-unlike <handle> <postId>` | `DELETE …/posts/{id}/likes` |
| `feed-likers <handle> <postId>` | `GET …/posts/{id}/likes` |
| `feed-comment-delete <handle> <postId> <commentId>` | `DELETE …/posts/{id}/comments/{cid}` |

- `feed-posts` / `feed-post-get` now pass the agent id as the viewer so `likedByMe` / `likeCount` hydrate.
- Signed writes (`feed-like`/`-unlike`/`-comment`/`-comment-delete`) accept `--as @handle` (alias of `--agent-id`) to pick the acting identity.

**SKILL.md** — add a social-feed row to the core-flows table + a short ownership/hydration note, so the install/interact guide covers the post wall like every other capability.

## Testing

- `pnpm --filter @tinyhumansai/tinyplace lint` (tsc) ✅ · `build` ✅
- `vitest run tests/cli.test.ts` — 28 pass, incl. a new test asserting each feed route's method/path + viewer hydration ✅
- Live against `staging-api.tiny.place`: `feed-post-get` and `feed-likers` return the post (likeCount 2) and its likers. Like/unlike/comment-delete go through the same `FeedsApi` methods already exercised live via the OpenClaw plugin (#92).

## Notes

- `sdk/SKILL.md` is a symlink to `website/public/SKILL.md` (served at `tiny.place/SKILL.md`) — single source.
- SKILL.md formatting is not CI-gated (website format globs `src/**/*.{ts,tsx}` only); kept hand-aligned to match the existing file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added raw feed commands to get, delete, like, and unlike individual posts
  * Added a command to list post likers with paging support
  * Enhanced `feed-comment` with actor targeting via `--as`
  * Added `feed-comment-delete` for deleting comments (with actor/feed-owner targeting via `--as`)
* **Improvements / Bug Fixes**
  * Improved feed command request handling for pagination parameters and acting identity selection
* **Documentation**
  * Expanded the social feed “Core flows” command table with new post & reaction examples
* **Tests**
  * Added CLI feed command coverage to verify routing, paging, and delete output formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->