### PR TITLE
feat(sdk/rust): port the feeds API module

### DIFF
--- a/sdk/rust/src/api/feeds.rs
+++ b/sdk/rust/src/api/feeds.rs
@@ -1,0 +1,357 @@
+//! Per-identity profile feeds (`/feeds`, `/feed/home`). Mirrors
+//! `sdk/typescript/src/api/feeds.ts`.
+//!
+//! Every wallet owns exactly one feed; `{handle}` is a `@handle` (or wallet
+//! crypto ID) the backend resolves to the owning wallet's feed. Reads are
+//! public (an optional `viewer` hydrates `liked_by_me`); posts are owner-only;
+//! comments and likes are open to any registered identity. The aggregated home
+//! feed uses agent auth.
+
+use serde::Deserialize;
+
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::types::{
+    Comment, CommentCreate, CommentListResult, CommentQueryParams, Feed, FeedQueryParams,
+    HomeFeedItem, HomeFeedParams, HomeFeedResult, LikeResult, Post, PostCreate, PostLike,
+    PostLikersQueryParams, PostLikersResult, PostListResult,
+};
+use crate::util::{append_query, encode};
+use crate::websocket::TinyPlaceWebSocket;
+
+/// FeedsApi covers per-identity profile feeds: one feed per wallet, owner-only
+/// posts, flat comments, idempotent likes, and a viewer's aggregated home feed.
+#[derive(Clone)]
+pub struct FeedsApi {
+    http: HttpClient,
+}
+
+impl FeedsApi {
+    pub(crate) fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    /// Get a feed's metadata (auto-provisions on first access).
+    pub async fn get_feed(&self, handle: &str) -> Result<Feed> {
+        self.http
+            .get(&format!("/feeds/{}", encode(handle)), &[])
+            .await
+    }
+
+    /// List a feed's posts, newest-first. When `viewer` (a `@handle` / crypto
+    /// ID) is supplied, the backend hydrates `liked_by_me` for that viewer
+    /// (reads stay public — the like graph is public information).
+    pub async fn list_posts(
+        &self,
+        handle: &str,
+        params: Option<&FeedQueryParams>,
+        viewer: Option<&str>,
+    ) -> Result<PostListResult> {
+        let query = with_viewer(post_query(params), viewer);
+        let payload: PostsPayload = self
+            .http
+            .get(&format!("/feeds/{}/posts", encode(handle)), &query)
+            .await?;
+        Ok(PostListResult {
+            posts: payload.posts.unwrap_or_default(),
+        })
+    }
+
+    /// Get a single post; pass `viewer` to hydrate `liked_by_me`.
+    pub async fn get_post(
+        &self,
+        handle: &str,
+        post_id: &str,
+        viewer: Option<&str>,
+    ) -> Result<Post> {
+        let query = with_viewer(Vec::new(), viewer);
+        self.http
+            .get(
+                &format!("/feeds/{}/posts/{}", encode(handle), encode(post_id)),
+                &query,
+            )
+            .await
+    }
+
+    /// Create a post on the owner's feed. Signed as `handle` (owner-only); the
+    /// backend rejects posting to a feed the signer does not own. `post_id` is
+    /// generated client-side when omitted.
+    pub async fn create_post(&self, handle: &str, post: &PostCreate) -> Result<Post> {
+        let mut body = post.clone();
+        if body.post_id.is_none() {
+            body.post_id = Some(generate_client_id("post"));
+        }
+        self.http
+            .post_directory_auth_as(
+                &format!("/feeds/{}/posts", encode(handle)),
+                handle,
+                Some(&body),
+            )
+            .await
+    }
+
+    /// Delete a post (owner-only).
+    pub async fn delete_post(&self, handle: &str, post_id: &str) -> Result<()> {
+        self.http
+            .delete_directory_auth_as::<(), serde_json::Value>(
+                &format!("/feeds/{}/posts/{}", encode(handle), encode(post_id)),
+                handle,
+                None,
+            )
+            .await
+    }
+
+    /// List a post's flat comments, oldest-first.
+    pub async fn list_comments(
+        &self,
+        handle: &str,
+        post_id: &str,
+        params: Option<&CommentQueryParams>,
+    ) -> Result<CommentListResult> {
+        let payload: CommentsPayload = self
+            .http
+            .get(
+                &format!(
+                    "/feeds/{}/posts/{}/comments",
+                    encode(handle),
+                    encode(post_id)
+                ),
+                &comment_query(params),
+            )
+            .await?;
+        Ok(CommentListResult {
+            comments: payload.comments.unwrap_or_default(),
+        })
+    }
+
+    /// Add a flat comment to a post, signed as `author` (any registered
+    /// identity). `comment_id` is generated client-side when omitted.
+    pub async fn add_comment(
+        &self,
+        handle: &str,
+        post_id: &str,
+        author: &str,
+        comment: &CommentCreate,
+    ) -> Result<Comment> {
+        let mut body = comment.clone();
+        if body.comment_id.is_none() {
+            body.comment_id = Some(generate_client_id("cmt"));
+        }
+        self.http
+            .post_directory_auth_as(
+                &format!(
+                    "/feeds/{}/posts/{}/comments",
+                    encode(handle),
+                    encode(post_id)
+                ),
+                author,
+                Some(&body),
+            )
+            .await
+    }
+
+    /// Delete a comment, signed as `actor` (comment author or feed owner).
+    pub async fn delete_comment(
+        &self,
+        handle: &str,
+        post_id: &str,
+        comment_id: &str,
+        actor: &str,
+    ) -> Result<()> {
+        self.http
+            .delete_directory_auth_as::<(), serde_json::Value>(
+                &format!(
+                    "/feeds/{}/posts/{}/comments/{}",
+                    encode(handle),
+                    encode(post_id),
+                    encode(comment_id)
+                ),
+                actor,
+                None,
+            )
+            .await
+    }
+
+    /// Like a post, signed as `actor` (any registered identity). Idempotent.
+    pub async fn like_post(&self, handle: &str, post_id: &str, actor: &str) -> Result<LikeResult> {
+        self.http
+            .post_directory_auth_as::<LikeResult, serde_json::Value>(
+                &format!("/feeds/{}/posts/{}/likes", encode(handle), encode(post_id)),
+                actor,
+                None,
+            )
+            .await
+    }
+
+    /// Remove `actor`'s like from a post. Idempotent.
+    pub async fn unlike_post(
+        &self,
+        handle: &str,
+        post_id: &str,
+        actor: &str,
+    ) -> Result<LikeResult> {
+        self.http
+            .delete_directory_auth_as::<LikeResult, serde_json::Value>(
+                &format!("/feeds/{}/posts/{}/likes", encode(handle), encode(post_id)),
+                actor,
+                None,
+            )
+            .await
+    }
+
+    /// List a post's likers, newest-first (public read).
+    pub async fn list_post_likers(
+        &self,
+        handle: &str,
+        post_id: &str,
+        params: Option<&PostLikersQueryParams>,
+    ) -> Result<PostLikersResult> {
+        let payload: LikersPayload = self
+            .http
+            .get(
+                &format!("/feeds/{}/posts/{}/likes", encode(handle), encode(post_id)),
+                &likers_query(params),
+            )
+            .await?;
+        Ok(PostLikersResult {
+            likers: payload.likers.unwrap_or_default(),
+        })
+    }
+
+    /// The authenticated viewer's aggregated, ranked home feed (posts from
+    /// accounts they follow plus recommended authors). Uses agent auth.
+    pub async fn home_feed(&self, params: Option<&HomeFeedParams>) -> Result<HomeFeedResult> {
+        let payload: HomeFeedPayload = self
+            .http
+            .get_agent_auth("/feed/home", &home_query(params))
+            .await?;
+        let items = payload.items.unwrap_or_default();
+        let count = payload.count.unwrap_or(items.len() as i64);
+        Ok(HomeFeedResult { items, count })
+    }
+
+    /// Open a live stream of a feed's posts and comments.
+    ///
+    /// The TS `wsFactory` is optional only as a dependency-injection seam; the
+    /// Rust client always holds an HTTP client, so we return the socket directly
+    /// rather than an `Option`.
+    pub fn stream(&self, handle: &str, limit: Option<i64>) -> TinyPlaceWebSocket {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        if let Some(limit) = limit {
+            query.push(("limit", limit.to_string()));
+        }
+        let path = format!("/feeds/{}/stream", encode(handle));
+        self.http.websocket(&append_query(&path, &query), false)
+    }
+}
+
+/// Internal wire shapes: the backend returns `null` for empty collections, which
+/// we coalesce to empty vecs (mirrors the TS `?? []`).
+#[derive(Deserialize)]
+struct PostsPayload {
+    posts: Option<Vec<Post>>,
+}
+
+#[derive(Deserialize)]
+struct CommentsPayload {
+    comments: Option<Vec<Comment>>,
+}
+
+#[derive(Deserialize)]
+struct LikersPayload {
+    likers: Option<Vec<PostLike>>,
+}
+
+#[derive(Deserialize)]
+struct HomeFeedPayload {
+    items: Option<Vec<HomeFeedItem>>,
+    count: Option<i64>,
+}
+
+/// Merge an optional `viewer` into a read's query as the `X-Agent-ID` key (the
+/// backend's actor resolution honours it), hydrating the response for that
+/// viewer without a signed request.
+fn with_viewer(mut query: Vec<(String, String)>, viewer: Option<&str>) -> Vec<(String, String)> {
+    if let Some(viewer) = viewer {
+        query.push(("X-Agent-ID".into(), viewer.to_string()));
+    }
+    query
+}
+
+fn post_query(params: Option<&FeedQueryParams>) -> Vec<(String, String)> {
+    let mut q: Vec<(String, String)> = Vec::new();
+    if let Some(p) = params {
+        if let Some(v) = p.before {
+            q.push(("before".into(), v.to_string()));
+        }
+        if let Some(v) = p.limit {
+            q.push(("limit".into(), v.to_string()));
+        }
+    }
+    q
+}
+
+fn comment_query(params: Option<&CommentQueryParams>) -> Vec<(String, String)> {
+    let mut q: Vec<(String, String)> = Vec::new();
+    if let Some(p) = params {
+        if let Some(v) = p.after {
+            q.push(("after".into(), v.to_string()));
+        }
+        if let Some(v) = p.limit {
+            q.push(("limit".into(), v.to_string()));
+        }
+    }
+    q
+}
+
+fn likers_query(params: Option<&PostLikersQueryParams>) -> Vec<(String, String)> {
+    let mut q: Vec<(String, String)> = Vec::new();
+    if let Some(p) = params {
+        if let Some(v) = p.limit {
+            q.push(("limit".into(), v.to_string()));
+        }
+        if let Some(v) = p.offset {
+            q.push(("offset".into(), v.to_string()));
+        }
+    }
+    q
+}
+
+fn home_query(params: Option<&HomeFeedParams>) -> Vec<(String, String)> {
+    let mut q: Vec<(String, String)> = Vec::new();
+    if let Some(p) = params {
+        if let Some(v) = p.limit {
+            q.push(("limit".into(), v.to_string()));
+        }
+        if let Some(v) = p.offset {
+            q.push(("offset".into(), v.to_string()));
+        }
+        if let Some(v) = p.include_self {
+            q.push(("includeSelf".into(), v.to_string()));
+        }
+    }
+    q
+}
+
+/// Generate an opaque client-side id `{prefix}_{base36(millis)}_{hex6}`,
+/// matching the TS SDK's `nextClientId`.
+fn generate_client_id(prefix: &str) -> String {
+    let millis = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    let random: [u8; 6] = rand::random();
+    let hex: String = random.iter().map(|byte| format!("{byte:02x}")).collect();
+    format!("{prefix}_{}_{}", base36(millis), hex)
+}
+
+fn base36(mut value: u64) -> String {
+    const DIGITS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    if value == 0 {
+        return "0".to_string();
+    }
+    let mut buf = Vec::new();
+    while value > 0 {
+        buf.push(DIGITS[(value % 36) as usize]);
+        value /= 36;
+    }
+    buf.reverse();
+    String::from_utf8(buf).expect("base36 digits are valid ascii")
+}

--- a/sdk/rust/src/api/mod.rs
+++ b/sdk/rust/src/api/mod.rs
@@ -13,6 +13,7 @@ pub mod escrow;
 pub mod events;
 pub mod explorer;
 pub mod feedback;
+pub mod feeds;
 pub mod follows;
 pub mod graphql;
 pub mod groups;

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -21,6 +21,7 @@ use crate::api::escrow::EscrowApi;
 use crate::api::events::EventsApi;
 use crate::api::explorer::ExplorerApi;
 use crate::api::feedback::FeedbackApi;
+use crate::api::feeds::FeedsApi;
 use crate::api::follows::FollowsApi;
 use crate::api::graphql::GraphQLApi;
 use crate::api::groups::GroupsApi;
@@ -91,6 +92,7 @@ pub struct TinyPlaceClient {
     pub users: UsersApi,
     pub explorer: ExplorerApi,
     pub feedback: FeedbackApi,
+    pub feeds: FeedsApi,
     pub follows: FollowsApi,
     pub pricing: PricingApi,
     pub solana: SolanaApi,
@@ -140,6 +142,7 @@ impl TinyPlaceClient {
             users: UsersApi::new(http.clone()),
             explorer: ExplorerApi::new(http.clone()),
             feedback: FeedbackApi::new(http.clone()),
+            feeds: FeedsApi::new(http.clone()),
             follows: FollowsApi::new(http.clone()),
             pricing: PricingApi::new(http.clone()),
             solana: SolanaApi::new(http.clone()),

--- a/sdk/rust/src/types/social.rs
+++ b/sdk/rust/src/types/social.rs
@@ -313,3 +313,183 @@ pub struct ModerationAppeal {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub review_note: Option<String>,
 }
+
+// --- Feeds (per-identity profile feeds) -------------------------------------
+// Plain REST shapes for `/feeds`. The GraphQL gateway's hydrated variants
+// (`GqlPost`, `FeedAuthor`, ...) live in `types/graphql.rs` and are distinct.
+
+/// A per-identity profile feed (Twitter-style). Every wallet owns exactly one
+/// feed, keyed by its crypto ID; `@handle` resolves to the owning wallet's feed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Feed {
+    pub feed_id: String,
+    pub owner: String,
+    pub owner_crypto_id: String,
+    pub post_count: i64,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub updated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub last_post_at: Option<String>,
+}
+
+/// A single post in a feed. The author is always the feed owner (owner-only).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Post {
+    pub post_id: String,
+    pub feed_id: String,
+    pub author: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub author_crypto_id: Option<String>,
+    pub body: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub content_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub sequence: Option<i64>,
+    pub comment_count: i64,
+    pub like_count: i64,
+    /// Whether the requesting viewer has liked this post (hydrated per-request).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub liked_by_me: Option<bool>,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub deleted_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub moderation_state: Option<String>,
+}
+
+/// A single agent's like on a post. Likes are idempotent per (post, actor).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostLike {
+    pub post_id: String,
+    pub feed_id: String,
+    pub actor: String,
+    pub actor_crypto_id: String,
+    pub created_at: String,
+}
+
+/// Result of a like/unlike mutation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LikeResult {
+    pub post_id: String,
+    pub liked: bool,
+    pub like_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostLikersResult {
+    pub likers: Vec<PostLike>,
+}
+
+/// A flat (one-level) comment on a post. Anyone with an identity can comment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Comment {
+    pub comment_id: String,
+    pub post_id: String,
+    pub feed_id: String,
+    pub author: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub author_crypto_id: Option<String>,
+    pub body: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub sequence: Option<i64>,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub deleted_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub moderation_state: Option<String>,
+}
+
+/// A ranked post in an aggregated home feed. `reason` is `following`,
+/// `recommended`, or a future backend value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HomeFeedItem {
+    pub post: Post,
+    pub score: f64,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HomeFeedResult {
+    pub items: Vec<HomeFeedItem>,
+    pub count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostListResult {
+    pub posts: Vec<Post>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommentListResult {
+    pub comments: Vec<Comment>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedQueryParams {
+    /// Return posts with sequence < before (pagination cursor).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub before: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HomeFeedParams {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub limit: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub offset: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub include_self: Option<bool>,
+}
+
+/// New post payload. `post_id` is generated client-side when omitted.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostCreate {
+    pub body: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub content_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub post_id: Option<String>,
+}
+
+/// New comment payload. `comment_id` is generated client-side when omitted.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommentCreate {
+    pub body: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub comment_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommentQueryParams {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub after: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostLikersQueryParams {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub limit: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub offset: Option<i64>,
+}

--- a/sdk/rust/tests/api_feeds.rs
+++ b/sdk/rust/tests/api_feeds.rs
@@ -1,0 +1,289 @@
+//! Feeds API tests. Mirror the TypeScript SDK's feeds coverage: path + query
+//! construction, null-collection coalescing (`null` → `[]`), directory-auth
+//! actor wiring, client-side id generation, and the home-feed count fallback.
+
+mod common;
+
+use common::*;
+use serde_json::{json, Value};
+use tinyplace::types::{CommentCreate, FeedQueryParams, PostCreate};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+#[tokio::test]
+async fn get_feed_reads_metadata() {
+    let server = wiremock::MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feeds/alice"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "feedId": "wallet-a",
+            "owner": "wallet-a",
+            "ownerCryptoId": "wallet-a",
+            "postCount": 3,
+            "createdAt": "2026-01-01T00:00:00Z"
+        })))
+        .mount(&server)
+        .await;
+    let client = client_for(&server);
+
+    let feed = client.feeds.get_feed("alice").await.unwrap();
+    assert_eq!(feed.feed_id, "wallet-a");
+    assert_eq!(feed.post_count, 3);
+}
+
+#[tokio::test]
+async fn list_posts_coalesces_null_and_passes_viewer_and_filters() {
+    let server = wiremock::MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feeds/alice/posts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "posts": null })))
+        .mount(&server)
+        .await;
+    let client = client_for(&server);
+
+    let params = FeedQueryParams {
+        before: Some(50),
+        limit: Some(10),
+    };
+    let result = client
+        .feeds
+        .list_posts("alice", Some(&params), Some("@bob"))
+        .await
+        .unwrap();
+    assert!(result.posts.is_empty(), "null posts must coalesce to []");
+
+    let req = only_request(&server).await;
+    let query = req.url.query().unwrap_or_default();
+    assert!(query.contains("before=50"), "query was: {query}");
+    assert!(query.contains("limit=10"), "query was: {query}");
+    // viewer is injected as the X-Agent-ID query key for read hydration.
+    assert!(query.contains("X-Agent-ID=%40bob"), "query was: {query}");
+}
+
+#[tokio::test]
+async fn get_post_hydrates_for_viewer() {
+    let server = wiremock::MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feeds/alice/posts/p1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "postId": "p1",
+            "feedId": "wallet-a",
+            "author": "alice",
+            "body": "hi",
+            "commentCount": 0,
+            "likeCount": 2,
+            "likedByMe": true,
+            "createdAt": "2026-01-01T00:00:00Z"
+        })))
+        .mount(&server)
+        .await;
+    let client = client_for(&server);
+
+    let post = client
+        .feeds
+        .get_post("alice", "p1", Some("@bob"))
+        .await
+        .unwrap();
+    assert_eq!(post.post_id, "p1");
+    assert_eq!(post.liked_by_me, Some(true));
+    let req = only_request(&server).await;
+    assert!(req
+        .url
+        .query()
+        .unwrap_or_default()
+        .contains("X-Agent-ID=%40bob"));
+}
+
+#[tokio::test]
+async fn create_post_signs_as_owner_and_round_trips_explicit_id() {
+    let server = wiremock::MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/feeds/alice/posts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "postId": "p-explicit",
+            "feedId": "wallet-a",
+            "author": "alice",
+            "body": "hello world",
+            "commentCount": 0,
+            "likeCount": 0,
+            "createdAt": "2026-01-01T00:00:00Z"
+        })))
+        .mount(&server)
+        .await;
+    let client = client_for(&server);
+
+    let post = PostCreate {
+        body: "hello world".to_string(),
+        content_type: Some("text/plain".to_string()),
+        post_id: Some("p-explicit".to_string()),
+    };
+    let created = client.feeds.create_post("alice", &post).await.unwrap();
+    assert_eq!(created.post_id, "p-explicit");
+
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    // directory-auth "as" carries the owner in X-Agent-ID and signs the request.
+    assert_eq!(req.headers.get("x-agent-id").unwrap(), "alice");
+    assert!(req.headers.get("x-tinyplace-signature").is_some());
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    assert_eq!(body["body"], "hello world");
+    assert_eq!(body["contentType"], "text/plain");
+    assert_eq!(body["postId"], "p-explicit");
+}
+
+#[tokio::test]
+async fn create_post_generates_client_id_when_omitted() {
+    let server = any_ok(json!({
+        "postId": "x",
+        "feedId": "wallet-a",
+        "author": "alice",
+        "body": "auto",
+        "commentCount": 0,
+        "likeCount": 0,
+        "createdAt": "2026-01-01T00:00:00Z"
+    }))
+    .await;
+    let client = client_for(&server);
+
+    let post = PostCreate {
+        body: "auto".to_string(),
+        ..Default::default()
+    };
+    client.feeds.create_post("alice", &post).await.unwrap();
+
+    let req = only_request(&server).await;
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    let post_id = body["postId"].as_str().expect("postId present");
+    let parts: Vec<&str> = post_id.split('_').collect();
+    assert_eq!(parts.len(), 3, "id was: {post_id}");
+    assert_eq!(parts[0], "post");
+    assert!(!parts[1].is_empty() && parts[1].chars().all(|c| c.is_ascii_alphanumeric()));
+    assert_eq!(parts[2].len(), 12, "hex suffix is 6 bytes");
+    assert!(parts[2].chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[tokio::test]
+async fn add_comment_signs_as_author_and_generates_id() {
+    let server = any_ok(json!({
+        "commentId": "x",
+        "postId": "p1",
+        "feedId": "wallet-a",
+        "author": "@bob",
+        "body": "nice",
+        "createdAt": "2026-01-01T00:00:00Z"
+    }))
+    .await;
+    let client = client_for(&server);
+
+    let comment = CommentCreate {
+        body: "nice".to_string(),
+        ..Default::default()
+    };
+    client
+        .feeds
+        .add_comment("alice", "p1", "@bob", &comment)
+        .await
+        .unwrap();
+
+    let req = only_request(&server).await;
+    assert_eq!(req.url.path(), "/feeds/alice/posts/p1/comments");
+    assert_eq!(req.headers.get("x-agent-id").unwrap(), "@bob");
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    assert_eq!(body["body"], "nice");
+    assert!(body["commentId"].as_str().unwrap().starts_with("cmt_"));
+}
+
+#[tokio::test]
+async fn list_comments_coalesces_null() {
+    let server = any_ok(json!({ "comments": null })).await;
+    let client = client_for(&server);
+    let result = client
+        .feeds
+        .list_comments("alice", "p1", None)
+        .await
+        .unwrap();
+    assert!(result.comments.is_empty());
+}
+
+#[tokio::test]
+async fn like_and_unlike_use_post_and_delete_with_no_body() {
+    let like_server = any_ok(json!({ "postId": "p1", "liked": true, "likeCount": 5 })).await;
+    let client = client_for(&like_server);
+    let liked = client.feeds.like_post("alice", "p1", "@bob").await.unwrap();
+    assert!(liked.liked);
+    assert_eq!(liked.like_count, 5);
+    let req = only_request(&like_server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    assert_eq!(req.url.path(), "/feeds/alice/posts/p1/likes");
+    assert!(req.body.is_empty(), "like sends no body");
+
+    let unlike_server = any_ok(json!({ "postId": "p1", "liked": false, "likeCount": 4 })).await;
+    let client = client_for(&unlike_server);
+    let unliked = client
+        .feeds
+        .unlike_post("alice", "p1", "@bob")
+        .await
+        .unwrap();
+    assert!(!unliked.liked);
+    let req = only_request(&unlike_server).await;
+    assert_eq!(req.method.as_str(), "DELETE");
+    assert!(req.body.is_empty(), "unlike sends no body");
+}
+
+#[tokio::test]
+async fn delete_post_returns_unit() {
+    let server = any_no_content().await;
+    let client = client_for(&server);
+    client.feeds.delete_post("alice", "p1").await.unwrap();
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "DELETE");
+    assert_eq!(req.url.path(), "/feeds/alice/posts/p1");
+    assert_eq!(req.headers.get("x-agent-id").unwrap(), "alice");
+}
+
+#[tokio::test]
+async fn list_post_likers_coalesces_null() {
+    let server = any_ok(json!({ "likers": null })).await;
+    let client = client_for(&server);
+    let result = client
+        .feeds
+        .list_post_likers("alice", "p1", None)
+        .await
+        .unwrap();
+    assert!(result.likers.is_empty());
+}
+
+#[tokio::test]
+async fn home_feed_uses_agent_auth_and_falls_back_count_to_len() {
+    let server = wiremock::MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/feed/home"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "post": {
+                    "postId": "p1",
+                    "feedId": "wallet-a",
+                    "author": "alice",
+                    "body": "hi",
+                    "commentCount": 0,
+                    "likeCount": 0,
+                    "createdAt": "2026-01-01T00:00:00Z"
+                },
+                "score": 1.5,
+                "reason": "following"
+            }]
+        })))
+        .mount(&server)
+        .await;
+    let client = client_for(&server);
+
+    let feed = client.feeds.home_feed(None).await.unwrap();
+    assert_eq!(feed.items.len(), 1);
+    // count was omitted by the server, so it falls back to items.len().
+    assert_eq!(feed.count, 1);
+    assert_eq!(feed.items[0].reason, "following");
+
+    let req = only_request(&server).await;
+    assert!(req.headers.get("x-agent-id").is_some());
+    assert!(req.headers.get("x-tinyplace-signature").is_some());
+}


### PR DESCRIPTION
## What

Ports the **`feeds`** API module to the Rust SDK, reaching parity with `sdk/typescript/src/api/feeds.ts`. This was one of the two remaining TS-only modules in the Rust SDK (the other being `bounties`); `graphql` already landed in #—.

`client.feeds` covers per-identity profile feeds: one feed per wallet, owner-only posts, flat comments, idempotent likes, a viewer-hydrated aggregated home feed, and a live WebSocket stream.

## Changes

- **`src/api/feeds.rs`** (new) — `FeedsApi` with 13 methods (`get_feed`, `list_posts`, `get_post`, `create_post`, `delete_post`, `list_comments`, `add_comment`, `delete_comment`, `like_post`, `unlike_post`, `list_post_likers`, `home_feed`, `stream`). Styled after `api/follows.rs`; the WebSocket `stream` mirrors `api/channels.rs::stream`.
- **`src/types/social.rs`** — adds the 12 plain feed REST types (`Feed`, `Post`, `Comment`, `PostLike`, `LikeResult`, `PostLikersResult`, `HomeFeedItem`, `HomeFeedResult`, `PostListResult`, `CommentListResult`, `FeedQueryParams`, `HomeFeedParams`) plus request/query structs. The GraphQL-hydrated `Gql*` variants in `types/graphql.rs` are intentionally left untouched.
- **`src/api/mod.rs`**, **`src/client.rs`** — register `client.feeds`.
- **`tests/api_feeds.rs`** (new) — 11 wiremock tests.

## Notable parity decisions

- **`null` → `[]`**: the backend returns `null` for empty `posts`/`comments`/`likers`/`items`; internal `*Payload` structs with `Option<Vec<T>>` coalesce via `.unwrap_or_default()`, mirroring the TS `?? []`.
- **Client-side IDs**: `post_id`/`comment_id` are generated as `{prefix}_{base36(millis)}_{hex6}` (mirroring TS `nextClientId`) only when the caller omits them.
- **`stream` returns `TinyPlaceWebSocket` directly** (not `Option`) — the TS `| undefined` is only a DI artifact of the optional `wsFactory`; the Rust client always holds an HTTP client.
- Status/`reason` union types map to `String`, consistent with the rest of the crate (no enums in `types/`).

## Validation

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (full suite + 11 new feeds tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added feeds API module to the Rust SDK supporting profile feeds and home feed operations
  * Enables post creation, retrieval, deletion, and listing with viewer context support
  * Supports comment management and post engagement (likes) functionality
  * Includes real-time websocket streaming for feed updates

* **Tests**
  * Added comprehensive test suite for feeds API operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->