### PR TITLE
feat(sdk/rust): port the bounties API module

### DIFF
--- a/sdk/rust/src/api/bounties.rs
+++ b/sdk/rust/src/api/bounties.rs
@@ -1,0 +1,227 @@
+//! Bounty platform (`/bounties`). Mirrors `sdk/typescript/src/api/bounties.ts`.
+//!
+//! Create + fund (x402 → escrow), browse, submit a URL, comment for free, run
+//! the autonomous council, and the admin-approved payout to the council-selected
+//! winner.
+
+use crate::error::Result;
+use crate::http::HttpClient;
+use crate::types::{
+    Bounty, BountyComment, BountyCommentCreateRequest, BountyCommentQueryParams,
+    BountyCommentsResponse, BountyCreateRequest, BountyFundPayment, BountyListResponse,
+    BountyQueryParams, BountySubmission, BountySubmissionCreateRequest,
+    BountySubmissionQueryParams, BountySubmissionsResponse,
+};
+use crate::util::encode;
+
+/// BountiesApi covers the bounty platform: create + fund, browse, submit, comment
+/// for free, run the autonomous council, and approve the winning payout.
+#[derive(Clone)]
+pub struct BountiesApi {
+    http: HttpClient,
+}
+
+impl BountiesApi {
+    pub(crate) fn new(http: HttpClient) -> Self {
+        Self { http }
+    }
+
+    // --- Bounties ---
+
+    /// List bounties, optionally filtered by creator/status.
+    pub async fn list(&self, params: Option<&BountyQueryParams>) -> Result<BountyListResponse> {
+        self.http.get("/bounties", &list_query(params)).await
+    }
+
+    /// Get a single bounty by id.
+    pub async fn get(&self, bounty_id: &str) -> Result<Bounty> {
+        self.http
+            .get(&format!("/bounties/{}", encode(bounty_id)), &[])
+            .await
+    }
+
+    /// Create a bounty, signed as the creator.
+    pub async fn create(&self, request: &BountyCreateRequest) -> Result<Bounty> {
+        let creator = request.creator.as_deref().unwrap_or("");
+        self.http
+            .post_directory_auth_as("/bounties", creator, Some(request))
+            .await
+    }
+
+    /// Route the creator's x402 payment into the escrow wallet. Call without a
+    /// payment first to receive the 402 challenge, then re-call with the signed
+    /// payment map.
+    pub async fn fund(
+        &self,
+        bounty_id: &str,
+        creator: &str,
+        payment: Option<&BountyFundPayment>,
+    ) -> Result<Bounty> {
+        let body = match payment {
+            Some(payment) => serde_json::json!({ "payment": payment }),
+            None => serde_json::json!({}),
+        };
+        self.http
+            .post_directory_auth_as(
+                &format!("/bounties/{}/fund", encode(bounty_id)),
+                creator,
+                Some(&body),
+            )
+            .await
+    }
+
+    /// Cancel a bounty, signed as the creator.
+    pub async fn cancel(&self, bounty_id: &str, creator: &str) -> Result<Bounty> {
+        let body = serde_json::json!({});
+        self.http
+            .post_directory_auth_as(
+                &format!("/bounties/{}/cancel", encode(bounty_id)),
+                creator,
+                Some(&body),
+            )
+            .await
+    }
+
+    // --- Submissions ---
+
+    /// Submit a URL of work to a bounty, signed as the submitter.
+    pub async fn submit(
+        &self,
+        bounty_id: &str,
+        request: &BountySubmissionCreateRequest,
+    ) -> Result<BountySubmission> {
+        let submitter = request.submitter.as_deref().unwrap_or("");
+        self.http
+            .post_directory_auth_as(
+                &format!("/bounties/{}/submissions", encode(bounty_id)),
+                submitter,
+                Some(request),
+            )
+            .await
+    }
+
+    /// List a bounty's submissions.
+    pub async fn list_submissions(
+        &self,
+        bounty_id: &str,
+        params: Option<&BountySubmissionQueryParams>,
+    ) -> Result<BountySubmissionsResponse> {
+        self.http
+            .get(
+                &format!("/bounties/{}/submissions", encode(bounty_id)),
+                &submission_query(params),
+            )
+            .await
+    }
+
+    // --- Comments (free) ---
+
+    /// Add a free comment to a bounty, signed as the author.
+    pub async fn comment(
+        &self,
+        bounty_id: &str,
+        request: &BountyCommentCreateRequest,
+    ) -> Result<BountyComment> {
+        let author = request.author.as_deref().unwrap_or("");
+        self.http
+            .post_directory_auth_as(
+                &format!("/bounties/{}/comments", encode(bounty_id)),
+                author,
+                Some(request),
+            )
+            .await
+    }
+
+    /// List a bounty's comments.
+    pub async fn list_comments(
+        &self,
+        bounty_id: &str,
+        params: Option<&BountyCommentQueryParams>,
+    ) -> Result<BountyCommentsResponse> {
+        self.http
+            .get(
+                &format!("/bounties/{}/comments", encode(bounty_id)),
+                &comment_query(params),
+            )
+            .await
+    }
+
+    // --- Council + approval ---
+
+    /// Trigger the autonomous council immediately (creator or admin); normally
+    /// the deadline scheduler runs it automatically.
+    pub async fn run_council(&self, bounty_id: &str, actor: &str) -> Result<Bounty> {
+        let body = serde_json::json!({});
+        self.http
+            .post_directory_auth_as(
+                &format!("/bounties/{}/council", encode(bounty_id)),
+                actor,
+                Some(&body),
+            )
+            .await
+    }
+
+    /// Release the escrowed reward to the winning submission's author. Requires
+    /// admin/moderator authentication; `submission_id` defaults to the council's
+    /// pick when omitted.
+    pub async fn approve(&self, bounty_id: &str, submission_id: Option<&str>) -> Result<Bounty> {
+        let body = match submission_id {
+            Some(submission_id) => serde_json::json!({ "submissionId": submission_id }),
+            None => serde_json::json!({}),
+        };
+        self.http
+            .post_admin(
+                &format!("/bounties/{}/approve", encode(bounty_id)),
+                Some(&body),
+            )
+            .await
+    }
+}
+
+fn list_query(params: Option<&BountyQueryParams>) -> Vec<(String, String)> {
+    let mut q: Vec<(String, String)> = Vec::new();
+    if let Some(p) = params {
+        if let Some(v) = &p.creator {
+            q.push(("creator".into(), v.clone()));
+        }
+        if let Some(v) = &p.status {
+            q.push(("status".into(), v.clone()));
+        }
+        if let Some(v) = p.limit {
+            q.push(("limit".into(), v.to_string()));
+        }
+        if let Some(v) = p.offset {
+            q.push(("offset".into(), v.to_string()));
+        }
+    }
+    q
+}
+
+fn submission_query(params: Option<&BountySubmissionQueryParams>) -> Vec<(String, String)> {
+    let mut q: Vec<(String, String)> = Vec::new();
+    if let Some(p) = params {
+        if let Some(v) = &p.status {
+            q.push(("status".into(), v.clone()));
+        }
+        if let Some(v) = &p.submitter {
+            q.push(("submitter".into(), v.clone()));
+        }
+        if let Some(v) = p.limit {
+            q.push(("limit".into(), v.to_string()));
+        }
+    }
+    q
+}
+
+fn comment_query(params: Option<&BountyCommentQueryParams>) -> Vec<(String, String)> {
+    let mut q: Vec<(String, String)> = Vec::new();
+    if let Some(p) = params {
+        if let Some(v) = p.limit {
+            q.push(("limit".into(), v.to_string()));
+        }
+        if let Some(v) = p.offset {
+            q.push(("offset".into(), v.to_string()));
+        }
+    }
+    q
+}

--- a/sdk/rust/src/api/mod.rs
+++ b/sdk/rust/src/api/mod.rs
@@ -4,6 +4,7 @@ pub mod a2a;
 pub mod activity;
 pub mod admin;
 pub mod artifacts;
+pub mod bounties;
 pub mod broadcasts;
 pub mod channels;
 pub mod conversations;

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -12,6 +12,7 @@ use crate::api::a2a::A2AApi;
 use crate::api::activity::ActivityApi;
 use crate::api::admin::AdminApi;
 use crate::api::artifacts::ArtifactsApi;
+use crate::api::bounties::BountiesApi;
 use crate::api::broadcasts::BroadcastsApi;
 use crate::api::channels::ChannelsApi;
 use crate::api::conversations::ConversationsApi;
@@ -82,6 +83,7 @@ pub struct TinyPlaceClient {
     pub channels: ChannelsApi,
     pub conversations: ConversationsApi,
     pub broadcasts: BroadcastsApi,
+    pub bounties: BountiesApi,
     pub events: EventsApi,
     pub marketplace: MarketplaceApi,
     pub escrow: EscrowApi,
@@ -132,6 +134,7 @@ impl TinyPlaceClient {
             channels: ChannelsApi::new(http.clone()),
             conversations: ConversationsApi::new(http.clone()),
             broadcasts: BroadcastsApi::new(http.clone()),
+            bounties: BountiesApi::new(http.clone()),
             events: EventsApi::new(http.clone()),
             marketplace: MarketplaceApi::new(http.clone()),
             escrow: EscrowApi::new(http.clone()),

--- a/sdk/rust/src/types/bounties.rs
+++ b/sdk/rust/src/types/bounties.rs
@@ -1,0 +1,242 @@
+//! Bounty platform types. A creator funds a time-boxed reward into the custodial
+//! escrow wallet (x402), agents submit a URL of their work for free, a council of
+//! LLM judges autonomously selects the best submission after the deadline, and an
+//! admin/moderator approves the council's pick to release the reward.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Lifecycle state of a bounty (`draft`, `open`, `judging`, `review`,
+/// `awarded`, `refunded`, `cancelled`).
+pub type BountyStatus = String;
+/// State of a submission (`submitted`, `winner`, `rejected`).
+pub type BountySubmissionStatus = String;
+/// Reward asset (`CASH`, `USDC`, `WSOL`).
+pub type BountyAsset = String;
+/// Council run state (`pending`, `complete`, `failed`).
+pub type BountyCouncilStatus = String;
+
+/// The signed x402 payment map echoed back to fund a bounty.
+pub type BountyFundPayment = HashMap<String, String>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyReward {
+    /// Base-unit decimal (the asset's smallest unit); format with the asset's
+    /// decimals for display.
+    pub amount: String,
+    pub asset: String,
+    pub network: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyThumbnail {
+    pub width: i64,
+    pub height: i64,
+    pub mime_type: String,
+    pub size: i64,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyCouncilVote {
+    pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub winner_submission_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reasoning: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyCouncil {
+    pub status: BountyCouncilStatus,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub ran_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub winner_submission_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub judge_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub presided: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reasoning: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub votes: Option<Vec<BountyCouncilVote>>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Bounty {
+    pub bounty_id: String,
+    pub creator: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub creator_crypto_id: Option<String>,
+    pub title: String,
+    pub description: String,
+    pub reward: BountyReward,
+    pub status: BountyStatus,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub thumbnail: Option<BountyThumbnail>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub escrow_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub funding_tx_sig: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub funding_ledger_tx_id: Option<String>,
+    pub submission_count: i64,
+    pub comment_count: i64,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub council: Option<BountyCouncil>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub winner_submission_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub winner_agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub approved_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub approved_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub payout_tx_sig: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub payout_ledger_tx_id: Option<String>,
+    pub start_at: String,
+    pub deadline: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountySubmission {
+    pub submission_id: String,
+    pub bounty_id: String,
+    pub submitter: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub submitter_crypto_id: Option<String>,
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub note: Option<String>,
+    pub status: BountySubmissionStatus,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyComment {
+    pub comment_id: String,
+    pub bounty_id: String,
+    pub author: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub author_crypto_id: Option<String>,
+    pub body: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyCreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub creator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub creator_crypto_id: Option<String>,
+    pub title: String,
+    pub description: String,
+    /// Human-decimal amount in the asset's units (e.g. "10").
+    pub amount: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub asset: Option<BountyAsset>,
+    /// Either an explicit RFC3339 deadline or a number of days from now.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub deadline: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub duration_days: Option<i64>,
+    /// Signed x402 payment map echoed back to fund the bounty at creation time.
+    /// Omit on the first call to receive the 402 challenge.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub payment: Option<BountyFundPayment>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountySubmissionCreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub submitter: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub submitter_crypto_id: Option<String>,
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyCommentCreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub author: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub author_crypto_id: Option<String>,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyQueryParams {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub creator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub status: Option<BountyStatus>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub limit: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountySubmissionQueryParams {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub submitter: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyCommentQueryParams {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub limit: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyListResponse {
+    pub bounties: Vec<Bounty>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountySubmissionsResponse {
+    pub submissions: Vec<BountySubmission>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BountyCommentsResponse {
+    pub comments: Vec<BountyComment>,
+}

--- a/sdk/rust/src/types/mod.rs
+++ b/sdk/rust/src/types/mod.rs
@@ -7,6 +7,7 @@
 
 mod activity;
 mod artifacts;
+mod bounties;
 mod broadcasts;
 mod commerce;
 mod conversations;
@@ -37,6 +38,7 @@ mod user;
 
 pub use activity::*;
 pub use artifacts::*;
+pub use bounties::*;
 pub use broadcasts::*;
 pub use commerce::*;
 pub use conversations::*;

--- a/sdk/rust/tests/api_bounties.rs
+++ b/sdk/rust/tests/api_bounties.rs
@@ -1,0 +1,251 @@
+//! Bounties API tests. Mirror the TypeScript SDK's coverage: path + query
+//! construction, directory-auth actor wiring, the x402 fund body (omitted vs
+//! present), and the admin-approved payout.
+
+mod common;
+
+use common::*;
+use serde_json::{json, Value};
+use tinyplace::types::{BountyCreateRequest, BountyFundPayment, BountyQueryParams};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+fn bounty_json() -> Value {
+    json!({
+        "bountyId": "b1",
+        "creator": "@alice",
+        "title": "Build a thing",
+        "description": "Do the work",
+        "reward": {"amount": "10000000", "asset": "USDC", "network": "solana"},
+        "status": "open",
+        "submissionCount": 0,
+        "commentCount": 0,
+        "startAt": "2026-01-01T00:00:00Z",
+        "deadline": "2026-01-08T00:00:00Z",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    })
+}
+
+#[tokio::test]
+async fn list_sends_filters_and_unwraps() {
+    let server = wiremock::MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/bounties"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "bounties": [bounty_json()] })),
+        )
+        .mount(&server)
+        .await;
+    let client = client_for(&server);
+
+    let params = BountyQueryParams {
+        status: Some("open".to_string()),
+        limit: Some(10),
+        ..Default::default()
+    };
+    let result = client.bounties.list(Some(&params)).await.unwrap();
+    assert_eq!(result.bounties.len(), 1);
+    assert_eq!(result.bounties[0].bounty_id, "b1");
+
+    let query = only_request(&server)
+        .await
+        .url
+        .query()
+        .unwrap_or_default()
+        .to_string();
+    assert!(query.contains("status=open"), "query was: {query}");
+    assert!(query.contains("limit=10"), "query was: {query}");
+}
+
+#[tokio::test]
+async fn get_reads_single_bounty() {
+    let server = wiremock::MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/bounties/b1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(bounty_json()))
+        .mount(&server)
+        .await;
+    let client = client_for(&server);
+
+    let bounty = client.bounties.get("b1").await.unwrap();
+    assert_eq!(bounty.bounty_id, "b1");
+    assert_eq!(bounty.reward.asset, "USDC");
+    assert_eq!(bounty.status, "open");
+}
+
+#[tokio::test]
+async fn create_signs_as_creator_and_round_trips_body() {
+    let server = any_ok(bounty_json()).await;
+    let client = client_for(&server);
+
+    let request = BountyCreateRequest {
+        creator: Some("@alice".to_string()),
+        title: "Build a thing".to_string(),
+        description: "Do the work".to_string(),
+        amount: "10".to_string(),
+        asset: Some("USDC".to_string()),
+        duration_days: Some(7),
+        ..Default::default()
+    };
+    client.bounties.create(&request).await.unwrap();
+
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    assert_eq!(req.url.path(), "/bounties");
+    // directory-auth "as" carries the creator in X-Agent-ID and signs the request.
+    assert_eq!(req.headers.get("x-agent-id").unwrap(), "@alice");
+    assert!(req.headers.get("x-tinyplace-signature").is_some());
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    assert_eq!(body["title"], "Build a thing");
+    assert_eq!(body["amount"], "10");
+    assert_eq!(body["durationDays"], 7);
+}
+
+#[tokio::test]
+async fn fund_omits_payment_then_includes_it() {
+    // First call: no payment → body is an empty object (receives the 402 challenge).
+    let server = any_ok(bounty_json()).await;
+    let client = client_for(&server);
+    client.bounties.fund("b1", "@alice", None).await.unwrap();
+    let req = only_request(&server).await;
+    assert_eq!(req.url.path(), "/bounties/b1/fund");
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    assert_eq!(body, json!({}), "no payment → empty body");
+
+    // Second call: signed payment map echoed back under "payment".
+    let server = any_ok(bounty_json()).await;
+    let client = client_for(&server);
+    let mut payment: BountyFundPayment = BountyFundPayment::new();
+    payment.insert("signature".to_string(), "sig123".to_string());
+    client
+        .bounties
+        .fund("b1", "@alice", Some(&payment))
+        .await
+        .unwrap();
+    let req = only_request(&server).await;
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    assert_eq!(body["payment"]["signature"], "sig123");
+}
+
+#[tokio::test]
+async fn cancel_posts_empty_body_as_creator() {
+    let server = any_ok(bounty_json()).await;
+    let client = client_for(&server);
+    client.bounties.cancel("b1", "@alice").await.unwrap();
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    assert_eq!(req.url.path(), "/bounties/b1/cancel");
+    assert_eq!(req.headers.get("x-agent-id").unwrap(), "@alice");
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    assert_eq!(body, json!({}));
+}
+
+#[tokio::test]
+async fn run_council_posts_empty_body() {
+    let server = any_ok(bounty_json()).await;
+    let client = client_for(&server);
+    client.bounties.run_council("b1", "@alice").await.unwrap();
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    assert_eq!(req.url.path(), "/bounties/b1/council");
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    assert_eq!(body, json!({}));
+}
+
+#[tokio::test]
+async fn submit_signs_as_submitter() {
+    let server = any_ok(json!({
+        "submissionId": "s1",
+        "bountyId": "b1",
+        "submitter": "@bob",
+        "url": "https://example.com/work",
+        "status": "submitted",
+        "createdAt": "2026-01-02T00:00:00Z",
+        "updatedAt": "2026-01-02T00:00:00Z"
+    }))
+    .await;
+    let client = client_for(&server);
+
+    let request = tinyplace::types::BountySubmissionCreateRequest {
+        submitter: Some("@bob".to_string()),
+        url: "https://example.com/work".to_string(),
+        ..Default::default()
+    };
+    let submission = client.bounties.submit("b1", &request).await.unwrap();
+    assert_eq!(submission.submission_id, "s1");
+
+    let req = only_request(&server).await;
+    assert_eq!(req.url.path(), "/bounties/b1/submissions");
+    assert_eq!(req.headers.get("x-agent-id").unwrap(), "@bob");
+}
+
+#[tokio::test]
+async fn list_submissions_sends_filters() {
+    let server = any_ok(json!({ "submissions": [] })).await;
+    let client = client_for(&server);
+    let params = tinyplace::types::BountySubmissionQueryParams {
+        status: Some("winner".to_string()),
+        ..Default::default()
+    };
+    let result = client
+        .bounties
+        .list_submissions("b1", Some(&params))
+        .await
+        .unwrap();
+    assert!(result.submissions.is_empty());
+    let query = only_request(&server)
+        .await
+        .url
+        .query()
+        .unwrap_or_default()
+        .to_string();
+    assert!(query.contains("status=winner"), "query was: {query}");
+}
+
+#[tokio::test]
+async fn comment_signs_as_author() {
+    let server = any_ok(json!({
+        "commentId": "c1",
+        "bountyId": "b1",
+        "author": "@bob",
+        "body": "great bounty",
+        "createdAt": "2026-01-02T00:00:00Z"
+    }))
+    .await;
+    let client = client_for(&server);
+
+    let request = tinyplace::types::BountyCommentCreateRequest {
+        author: Some("@bob".to_string()),
+        body: "great bounty".to_string(),
+        ..Default::default()
+    };
+    let comment = client.bounties.comment("b1", &request).await.unwrap();
+    assert_eq!(comment.comment_id, "c1");
+    let req = only_request(&server).await;
+    assert_eq!(req.url.path(), "/bounties/b1/comments");
+    assert_eq!(req.headers.get("x-agent-id").unwrap(), "@bob");
+}
+
+#[tokio::test]
+async fn approve_uses_admin_auth_and_conditional_submission_id() {
+    // With an explicit submission id.
+    let server = any_ok(bounty_json()).await;
+    let client = client_for(&server);
+    client.bounties.approve("b1", Some("s1")).await.unwrap();
+    let req = only_request(&server).await;
+    assert_eq!(req.method.as_str(), "POST");
+    assert_eq!(req.url.path(), "/bounties/b1/approve");
+    // admin auth uses the TinyPlace-Admin Authorization header.
+    assert!(req.headers.get("authorization").is_some());
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    assert_eq!(body["submissionId"], "s1");
+
+    // Without one → empty body (defaults to the council's pick).
+    let server = any_ok(bounty_json()).await;
+    let client = client_for(&server);
+    client.bounties.approve("b1", None).await.unwrap();
+    let req = only_request(&server).await;
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    assert_eq!(body, json!({}));
+}


### PR DESCRIPTION
## What

Ports the **`bounties`** API module to the Rust SDK, reaching parity with `sdk/typescript/src/api/bounties.ts`. This was the **last** TS-only module missing from the Rust SDK (after `graphql` and `feeds` (#100)).

`client.bounties` covers the bounty platform: create + fund (x402 → escrow), browse, submit a URL of work, comment for free, run the autonomous LLM council, and the admin-approved payout to the council-selected winner.

## Changes

- **`src/api/bounties.rs`** (new) — `BountiesApi` with 11 methods (`list`, `get`, `create`, `fund`, `cancel`, `submit`, `list_submissions`, `comment`, `list_comments`, `run_council`, `approve`). Styled after `api/follows.rs`.
- **`src/types/bounties.rs`** (new) — the bounty type set. Status/union types are `String` aliases (no enums), consistent with the rest of the crate.
- **`src/api/mod.rs`**, **`src/types/mod.rs`**, **`src/client.rs`** — register `client.bounties`.
- **`tests/api_bounties.rs`** (new) — 10 wiremock tests.

## Notable parity decisions

- **x402 `fund` flow**: the first call omits the payment and sends `{}` (to receive the 402 challenge); re-calling with a signed payment map sends `{"payment": …}`. Both cases are tested.
- **`approve`** uses admin auth and sends `{"submissionId": …}` when given, else `{}` (defaults to the council's pick).
- Empty/conditional POST bodies use `serde_json::json!({})` — the existing `groups.rs`/`inbox.rs` convention (`body_string` serializes it to `{}`), not `None`, matching the TS bodies.

## Validation

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (full suite + 10 new bounties tests)

With this merged, the Rust SDK is at full API-module parity with the TypeScript SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)