### PR TITLE
feat(sdk/python): SPL/USDC x402 payments + paid registration

### DIFF
--- a/sdk/python/src/tinyplace/__init__.py
+++ b/sdk/python/src/tinyplace/__init__.py
@@ -23,6 +23,7 @@ from .signer import LocalSigner, Signer
 from .solana import (
     SOLANA_MAINNET_NETWORK,
     SOLANA_NATIVE_ASSET,
+    SOLANA_USDC_MINT,
     execute_solana_payment,
     execute_solana_x402_payment,
 )
@@ -46,6 +47,7 @@ __all__ = [
     "PaymentRequiredChallenge",
     "SOLANA_MAINNET_NETWORK",
     "SOLANA_NATIVE_ASSET",
+    "SOLANA_USDC_MINT",
     "SDK_VERSION",
     "Signer",
     "TinyPlaceClient",

--- a/sdk/python/src/tinyplace/api/registry.py
+++ b/sdk/python/src/tinyplace/api/registry.py
@@ -7,7 +7,12 @@ from ..auth import sign_fresh_canonical_payload
 from ..crypto import canonical_payload
 from ..http import HttpClient, TinyPlaceError, encode
 from ..signer import Signer
-from ..solana import SOLANA_MAINNET_NETWORK, USDC_DECIMALS, execute_solana_x402_payment
+from ..solana import (
+    SOLANA_MAINNET_NETWORK,
+    SOLANA_USDC_MINT,
+    USDC_DECIMALS,
+    execute_solana_x402_payment,
+)
 from ..types import Json, JsonDict
 
 DEFAULT_REGISTRATION_ATTEMPTS = 30
@@ -62,7 +67,11 @@ class RegistryApi:
             signer=self._signer,
             rpc_url=rpc_url,
             secret_key=secret_key,
-            mint=mint,
+            # The registration fee is USDC: default to the USDC mint so a
+            # challenge that names the asset by its SPL mint address (rather than
+            # the literal "USDC" symbol) still settles. Callers override for
+            # devnet / custom deployments.
+            mint=mint or SOLANA_USDC_MINT,
             decimals=decimals,
             payment={
                 "scheme": challenge.get("scheme", "exact"),
@@ -81,14 +90,38 @@ class RegistryApi:
                 "publicKeyBase64": normalized.get("publicKey"),
             },
         )
-        identity = await self._register_retrying_payment(
-            {**normalized, "payment": execution["payment"]}, attempts, interval_ms
-        )
+        try:
+            identity = await self._register_retrying_payment(
+                {**normalized, "payment": execution["payment"]}, attempts, interval_ms
+            )
+        except TinyPlaceError as exc:
+            # The payment is already on chain. A 5xx can still come back after
+            # the identity was persisted, so check whether the handle now exists
+            # before failing — re-driving the flow would otherwise risk paying
+            # twice. Re-raise (with the payment attached) only if it truly wasn't
+            # created.
+            identity = await self._recover_registered_identity(normalized["username"], exc)
+            if identity is None:
+                raise
         return {
             "identity": identity,
             "payment": execution["payment"],
             "onChainTx": execution["signature"],
         }
+
+    async def _recover_registered_identity(
+        self, username: str, exc: TinyPlaceError
+    ) -> Json | None:
+        """Return the identity if a post-payment 5xx still created the handle."""
+        if exc.status < 500:
+            return None
+        try:
+            result = await self.get(username)
+        except TinyPlaceError:
+            return None
+        if isinstance(result, dict) and result.get("available") is False:
+            return result.get("identity")
+        return None
 
     async def _registration_payment_challenge(self, request: JsonDict) -> dict[str, Any]:
         try:

--- a/sdk/python/src/tinyplace/api/registry.py
+++ b/sdk/python/src/tinyplace/api/registry.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from ..auth import sign_fresh_canonical_payload
 from ..crypto import canonical_payload
-from ..http import HttpClient, encode
+from ..http import HttpClient, TinyPlaceError, encode
 from ..signer import Signer
+from ..solana import SOLANA_MAINNET_NETWORK, USDC_DECIMALS, execute_solana_x402_payment
 from ..types import Json, JsonDict
+
+DEFAULT_REGISTRATION_ATTEMPTS = 30
+DEFAULT_REGISTRATION_INTERVAL_MS = 3000
+DEFAULT_REGISTRATION_RETRY_ERRORS = ["transaction not found", "insufficient confirmations"]
 
 
 class RegistryApi:
@@ -22,6 +28,90 @@ class RegistryApi:
                 _registration_signature_payload(request),
             )
         return await self._http.post_public("/registry/names", request)
+
+    async def register_with_solana_payment(
+        self,
+        request: JsonDict,
+        *,
+        rpc_url: str,
+        secret_key: str | bytes,
+        mint: str | None = None,
+        decimals: int = USDC_DECIMALS,
+        network: str | None = None,
+        attempts: int = DEFAULT_REGISTRATION_ATTEMPTS,
+        interval_ms: int = DEFAULT_REGISTRATION_INTERVAL_MS,
+    ) -> JsonDict:
+        """Register ``request``, settling the x402 fee with an on-chain Solana payment.
+
+        Probes the registration to read the 402 payment challenge, executes the
+        SPL/USDC (or native-SOL) transfer on chain, then retries the
+        registration with the signed x402 payment map attached — polling through
+        the brief window where the chain hasn't yet confirmed the transfer.
+        Mirrors the TS SDK's ``registerWithSolanaPayment``.
+        """
+        if self._signer is None:
+            raise ValueError("register_with_solana_payment requires a signer")
+        normalized = {**request, "username": _normalize_handle(str(request["username"]))}
+        challenge = await self._registration_payment_challenge(normalized)
+        amount = challenge.get("amount")
+        recipient = challenge.get("to")
+        if not amount or not recipient:
+            raise ValueError("registration payment challenge is missing amount or recipient")
+
+        execution = await execute_solana_x402_payment(
+            signer=self._signer,
+            rpc_url=rpc_url,
+            secret_key=secret_key,
+            mint=mint,
+            decimals=decimals,
+            payment={
+                "scheme": challenge.get("scheme", "exact"),
+                "network": challenge.get("network") or network or SOLANA_MAINNET_NETWORK,
+                "asset": challenge.get("asset") or "USDC",
+                "amount": amount,
+                "from": normalized.get("cryptoId") or self._signer.agent_id,
+                "to": recipient,
+                "nonce": challenge.get("nonce"),
+                "expiresAt": challenge.get("expiresAt"),
+                "metadata": {
+                    **(challenge.get("metadata") or {}),
+                    "identity": normalized["username"],
+                    "purpose": "registration",
+                },
+                "publicKeyBase64": normalized.get("publicKey"),
+            },
+        )
+        identity = await self._register_retrying_payment(
+            {**normalized, "payment": execution["payment"]}, attempts, interval_ms
+        )
+        return {
+            "identity": identity,
+            "payment": execution["payment"],
+            "onChainTx": execution["signature"],
+        }
+
+    async def _registration_payment_challenge(self, request: JsonDict) -> dict[str, Any]:
+        try:
+            await self.register(request)
+        except TinyPlaceError as exc:
+            if exc.status == 402 and exc.payment_required is not None:
+                return exc.payment_required.payment
+            raise
+        raise ValueError("registration did not return a payment challenge")
+
+    async def _register_retrying_payment(
+        self, request: JsonDict, attempts: int, interval_ms: int
+    ) -> Json:
+        attempts = max(1, attempts)
+        for attempt in range(attempts):
+            try:
+                return await self.register(request)
+            except TinyPlaceError as exc:
+                if attempt == attempts - 1 or not _should_retry_registration(exc):
+                    raise
+            if interval_ms > 0:
+                await asyncio.sleep(interval_ms / 1000)
+        raise RuntimeError("unreachable: registration retry loop exhausted")
 
     async def get(self, name: str) -> Json:
         return await self._http.get(f"/registry/names/{encode(name)}")
@@ -164,6 +254,12 @@ class RegistryApi:
 
 def _normalize_handle(username: str) -> str:
     return username if username.startswith("@") else f"@{username}"
+
+
+def _should_retry_registration(exc: TinyPlaceError) -> bool:
+    """True when a registration failed only because the payment isn't confirmed yet."""
+    haystack = f"{exc} {exc.body}".lower()
+    return any(error in haystack for error in DEFAULT_REGISTRATION_RETRY_ERRORS)
 
 
 def _registration_signature_payload(request: JsonDict) -> str:

--- a/sdk/python/src/tinyplace/client.py
+++ b/sdk/python/src/tinyplace/client.py
@@ -82,11 +82,42 @@ class TinyPlaceClient:
         Extra registration fields (``actorType``, ``paymentMethods``, ...) may
         be passed as keyword arguments.
         """
+        return await self.registry.register(self._registration_request(domain, **fields))
+
+    async def register_domain_with_solana_payment(
+        self,
+        domain: str,
+        *,
+        rpc_url: str,
+        secret_key: str | bytes,
+        mint: str | None = None,
+        decimals: int = 6,
+        network: str | None = None,
+        **fields: Any,
+    ) -> Json:
+        """Register a ``@handle`` and settle its x402 fee on Solana automatically.
+
+        Reads the registration's 402 payment challenge, pays the fee on chain
+        (USDC by default, or native SOL) and retries the registration with the
+        signed payment attached. ``rpc_url`` is the Solana RPC endpoint and
+        ``secret_key`` the agent's Solana keypair (32-byte seed or 64-byte
+        secret). ``mint`` overrides the USDC mint (e.g. on devnet).
+        """
+        return await self.registry.register_with_solana_payment(
+            self._registration_request(domain, **fields),
+            rpc_url=rpc_url,
+            secret_key=secret_key,
+            mint=mint,
+            decimals=decimals,
+            network=network,
+        )
+
+    def _registration_request(self, domain: str, **fields: Any) -> JsonDict:
         request: JsonDict = {**fields, "username": domain}
         if self._signer is not None:
             request.setdefault("cryptoId", self._signer.agent_id)
             request.setdefault("publicKey", self._signer.public_key_base64)
-        return await self.registry.register(request)
+        return request
 
     async def get_identity(self) -> Json:
         """Resolve the signing agent's own directory identity (reverse lookup)."""

--- a/sdk/python/src/tinyplace/http.py
+++ b/sdk/python/src/tinyplace/http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
@@ -264,10 +265,24 @@ def _payment_required_from_header(headers: Headers) -> PaymentRequiredChallenge 
     value = headers.get("X-Payment-Required") or headers.get("x-payment-required")
     if not value:
         return None
-    try:
-        parsed = json.loads(value)
-    except json.JSONDecodeError:
-        return None
+    parsed = _decode_payment_header(value)
     if isinstance(parsed, dict) and isinstance(parsed.get("payment"), dict):
         return PaymentRequiredChallenge(error=parsed.get("error"), payment=parsed["payment"])
     return None
+
+
+def _decode_payment_header(value: str) -> Any:
+    """Decode an ``X-Payment-Required`` header to its JSON object.
+
+    The backend sends base64url-encoded JSON (matching the TS SDK's
+    ``base64UrlDecode`` + ``JSON.parse``); fall back to raw JSON for resilience.
+    """
+    try:
+        padded = value + "=" * (-len(value) % 4)
+        return json.loads(base64.urlsafe_b64decode(padded))
+    except (ValueError, json.JSONDecodeError):
+        pass
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None

--- a/sdk/python/src/tinyplace/solana.py
+++ b/sdk/python/src/tinyplace/solana.py
@@ -6,6 +6,7 @@ from typing import Any, Awaitable, Callable
 
 import aiohttp
 from solders.hash import Hash
+from solders.instruction import AccountMeta, Instruction
 from solders.keypair import Keypair
 from solders.message import Message
 from solders.pubkey import Pubkey
@@ -18,6 +19,11 @@ from .x402 import build_x402_payment_map
 
 SOLANA_MAINNET_NETWORK = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
 SOLANA_NATIVE_ASSET = "SOL"
+# Mainnet USDC SPL mint (6 decimals). Devnet / custom deployments pass an
+# explicit mint instead.
+SOLANA_USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+SOLANA_TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+USDC_DECIMALS = 6
 
 RpcRequest = Callable[[str, list[Any]], Awaitable[Any]]
 
@@ -29,6 +35,10 @@ async def execute_solana_payment(
     payment: dict[str, Any],
     network: str | None = None,
     native_asset: str = SOLANA_NATIVE_ASSET,
+    mint: str | None = None,
+    decimals: int = USDC_DECIMALS,
+    source_token_account: str | None = None,
+    destination_token_account: str | None = None,
     commitment: str = "confirmed",
     confirmation_polls: int = 20,
     rpc_request: RpcRequest | None = None,
@@ -37,43 +47,71 @@ async def execute_solana_payment(
         raise ValueError(f"Unexpected Solana network: {payment['network']} (expected {network})")
     if network is None and not str(payment["network"]).startswith("solana:"):
         raise ValueError(f"Unsupported Solana network: {payment['network']}")
-    if str(payment["asset"]).upper() != native_asset.upper():
+
+    asset = str(payment["asset"])
+    is_native = asset.upper() == native_asset.upper()
+    if not is_native and asset.upper() != "USDC" and mint is None:
         raise ValueError(
-            f'Unsupported Solana asset: {payment["asset"]} '
-            f'(Python SDK supports native "{native_asset}" transfers)'
+            f'Unsupported Solana asset: {asset} '
+            f'(provide a mint, or use the native "{native_asset}" asset)'
         )
 
     keypair = _keypair_from_secret(secret_key)
     payer = str(keypair.pubkey())
     amount = str(payment["amount"])
+    to = str(payment["to"])
     request = rpc_request or _aiohttp_rpc_request(rpc_url)
+
+    # Native SOL: a System-program lamport transfer, payer -> recipient wallet.
+    if is_native:
+        latest = await request("getLatestBlockhash", [{"commitment": commitment}])
+        tx = _native_transfer_transaction(
+            keypair=keypair,
+            to=to,
+            amount=int(amount),
+            blockhash=latest["value"]["blockhash"],
+        )
+        signature = await _send_transaction(request, tx, commitment)
+        await _confirm_signature(request, signature, commitment, confirmation_polls)
+        return {
+            "signature": signature,
+            "from": payer,
+            "to": to,
+            "mint": native_asset,
+            "amount": amount,
+            "sourceTokenAccount": payer,
+            "destinationTokenAccount": to,
+        }
+
+    # SPL token (e.g. USDC) via TransferChecked. Token-account lookups happen
+    # before the blockhash fetch to match the TS SDK's RPC ordering.
+    resolved_mint = mint or SOLANA_USDC_MINT
+    source = source_token_account or await _find_token_account(
+        request, owner=payer, mint=resolved_mint, minimum_amount=amount
+    )
+    destination = destination_token_account or await _find_token_account(
+        request, owner=to, mint=resolved_mint
+    )
     latest = await request("getLatestBlockhash", [{"commitment": commitment}])
-    blockhash = latest["value"]["blockhash"]
-    tx = _native_transfer_transaction(
+    tx = _token_transfer_checked_transaction(
         keypair=keypair,
-        to=str(payment["to"]),
+        source=source,
+        destination=destination,
+        mint=resolved_mint,
         amount=int(amount),
-        blockhash=blockhash,
+        decimals=decimals,
+        blockhash=latest["value"]["blockhash"],
     )
-    signature = await request(
-        "sendTransaction",
-        [
-            base64.b64encode(bytes(tx)).decode("ascii"),
-            {
-                "encoding": "base64",
-                "preflightCommitment": "processed" if commitment == "processed" else "confirmed",
-            },
-        ],
-    )
-    await _confirm_signature(request, str(signature), commitment, confirmation_polls)
+    signature = await _send_transaction(request, tx, commitment)
+    await _confirm_signature(request, signature, commitment, confirmation_polls)
     return {
-        "signature": str(signature),
+        "signature": signature,
         "from": payer,
-        "to": str(payment["to"]),
-        "mint": native_asset,
+        "to": to,
+        "mint": resolved_mint,
         "amount": amount,
-        "sourceTokenAccount": payer,
-        "destinationTokenAccount": str(payment["to"]),
+        "sourceTokenAccount": source,
+        "destinationTokenAccount": destination,
     }
 
 
@@ -83,6 +121,10 @@ async def execute_solana_x402_payment(
     rpc_url: str,
     secret_key: str | bytes,
     payment: dict[str, Any],
+    mint: str | None = None,
+    decimals: int = USDC_DECIMALS,
+    source_token_account: str | None = None,
+    destination_token_account: str | None = None,
     commitment: str = "confirmed",
     confirmation_polls: int = 20,
     rpc_request: RpcRequest | None = None,
@@ -91,6 +133,10 @@ async def execute_solana_x402_payment(
         rpc_url=rpc_url,
         secret_key=secret_key,
         payment=payment,
+        mint=mint,
+        decimals=decimals,
+        source_token_account=source_token_account,
+        destination_token_account=destination_token_account,
         commitment=commitment,
         confirmation_polls=confirmation_polls,
         rpc_request=rpc_request,
@@ -105,6 +151,20 @@ async def execute_solana_x402_payment(
         },
     )
     return {**execution, "payment": payment_map}
+
+
+async def _send_transaction(rpc_request: RpcRequest, tx: Transaction, commitment: str) -> str:
+    signature = await rpc_request(
+        "sendTransaction",
+        [
+            base64.b64encode(bytes(tx)).decode("ascii"),
+            {
+                "encoding": "base64",
+                "preflightCommitment": "processed" if commitment == "processed" else "confirmed",
+            },
+        ],
+    )
+    return str(signature)
 
 
 def _native_transfer_transaction(
@@ -124,6 +184,52 @@ def _native_transfer_transaction(
     recent_blockhash = Hash.from_string(blockhash)
     message = Message.new_with_blockhash([instruction], keypair.pubkey(), recent_blockhash)
     return Transaction([keypair], message, recent_blockhash)
+
+
+def _token_transfer_checked_transaction(
+    *,
+    keypair: Keypair,
+    source: str,
+    destination: str,
+    mint: str,
+    amount: int,
+    decimals: int,
+    blockhash: str,
+) -> Transaction:
+    # SPL Token TransferChecked: u8 discriminant (12) + u64 LE amount + u8 decimals.
+    # Accounts (in program order): source, mint, destination, owner/authority.
+    data = bytes([12]) + int(amount).to_bytes(8, "little") + bytes([decimals & 0xFF])
+    accounts = [
+        AccountMeta(pubkey=Pubkey.from_string(source), is_signer=False, is_writable=True),
+        AccountMeta(pubkey=Pubkey.from_string(mint), is_signer=False, is_writable=False),
+        AccountMeta(pubkey=Pubkey.from_string(destination), is_signer=False, is_writable=True),
+        AccountMeta(pubkey=keypair.pubkey(), is_signer=True, is_writable=False),
+    ]
+    instruction = Instruction(Pubkey.from_string(SOLANA_TOKEN_PROGRAM_ID), data, accounts)
+    recent_blockhash = Hash.from_string(blockhash)
+    message = Message.new_with_blockhash([instruction], keypair.pubkey(), recent_blockhash)
+    return Transaction([keypair], message, recent_blockhash)
+
+
+async def _find_token_account(
+    rpc_request: RpcRequest,
+    *,
+    owner: str,
+    mint: str,
+    minimum_amount: str | None = None,
+) -> str:
+    """Resolve ``owner``'s token account for ``mint`` (the one holding enough funds)."""
+    response = await rpc_request(
+        "getTokenAccountsByOwner",
+        [owner, {"mint": mint}, {"encoding": "jsonParsed", "commitment": "confirmed"}],
+    )
+    minimum = int(minimum_amount) if minimum_amount is not None else None
+    for account in (response.get("value") or []) if isinstance(response, dict) else []:
+        info = (((account.get("account") or {}).get("data") or {}).get("parsed") or {}).get("info") or {}
+        amount_value = (info.get("tokenAmount") or {}).get("amount") or "0"
+        if minimum is None or int(amount_value) >= minimum:
+            return str(account["pubkey"])
+    raise RuntimeError(f"No token account found for {owner} (mint {mint})")
 
 
 async def _confirm_signature(

--- a/sdk/python/tests/test_registry.py
+++ b/sdk/python/tests/test_registry.py
@@ -156,6 +156,90 @@ async def test_register_with_solana_payment_settles_then_retries(monkeypatch) ->
     assert result["onChainTx"] == "onchain-sig"
 
 
+async def test_register_with_solana_payment_decodes_header_challenge_and_defaults_mint(
+    monkeypatch,
+) -> None:
+    import base64 as _b64
+    import json as _json
+
+    signer = LocalSigner.from_seed(bytes([23]) * 32)
+    # asset given as the USDC SPL mint address (not the literal "USDC" symbol),
+    # challenge carried ONLY in the base64url X-Payment-Required header.
+    challenge = {
+        "amount": "10000000",
+        "to": "Recipient1111111111111111111111111111111111",
+        "network": SOLANA_MAINNET_NETWORK,
+        "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "nonce": "n2",
+    }
+    header = _b64.urlsafe_b64encode(_json.dumps({"payment": challenge}).encode()).decode().rstrip("=")
+    session = FakeSession(
+        [
+            FakeResponse(402, "", headers={"X-Payment-Required": header}),
+            FakeResponse(200, {"username": "@agent", "cryptoId": signer.agent_id}),
+        ]
+    )
+    client = TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+    captured: dict = {}
+
+    async def fake_execute(**kwargs):
+        captured.update(kwargs)
+        return {"signature": "sig", "payment": {"signature": "s"}}
+
+    monkeypatch.setattr("tinyplace.api.registry.execute_solana_x402_payment", fake_execute)
+
+    result = await client.register_domain_with_solana_payment(
+        "agent", rpc_url="https://rpc.example", secret_key=bytes([23]) * 32
+    )
+
+    # Header-only challenge was decoded, and the USDC mint defaulted even though
+    # the asset was the mint address rather than "USDC".
+    assert captured["payment"]["amount"] == "10000000"
+    assert captured["mint"] == "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    assert result["onChainTx"] == "sig"
+
+
+async def test_register_with_solana_payment_recovers_on_server_error(monkeypatch) -> None:
+    signer = LocalSigner.from_seed(bytes([24]) * 32)
+    challenge = {
+        "amount": "1",
+        "to": "Recipient1111111111111111111111111111111111",
+        "network": SOLANA_MAINNET_NETWORK,
+        "asset": "USDC",
+    }
+    session = FakeSession(
+        [
+            FakeResponse(402, {"payment": challenge}),  # challenge probe
+            FakeResponse(500, {"error": "boom"}),  # paid retry: 5xx after persisting
+            FakeResponse(200, {"available": False, "identity": {"username": "@agent"}}),  # get()
+        ]
+    )
+    client = TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+    async def fake_execute(**kwargs):
+        return {"signature": "sig", "payment": {}}
+
+    monkeypatch.setattr("tinyplace.api.registry.execute_solana_x402_payment", fake_execute)
+
+    result = await client.register_domain_with_solana_payment(
+        "agent", rpc_url="https://rpc.example", secret_key=bytes([24]) * 32
+    )
+
+    # The handle was created despite the 5xx, so recovery returns it instead of
+    # failing (which would risk a second payment on retry).
+    assert result["identity"]["username"] == "@agent"
+    assert result["onChainTx"] == "sig"
+
+
 def json_body(session: FakeSession) -> dict:
     return json_body_at(session, 0)
 

--- a/sdk/python/tests/test_registry.py
+++ b/sdk/python/tests/test_registry.py
@@ -4,7 +4,7 @@ import base64
 
 from nacl.signing import VerifyKey
 
-from tinyplace import LocalSigner, TinyPlaceClient, canonical_payload
+from tinyplace import LocalSigner, SOLANA_MAINNET_NETWORK, TinyPlaceClient, canonical_payload
 
 from .helpers import FakeResponse, FakeSession
 
@@ -101,6 +101,59 @@ async def test_delete_subname_uses_public_delete_with_ownership_signature() -> N
     assert request["url"].endswith("/registry/names/%40agent/subnames/bot")
     assert request["headers"]["X-TinyPlace-Public-Key"] == signer.public_key_base64
     assert request["headers"]["X-TinyPlace-Signature"].startswith("v1:")
+
+
+async def test_register_with_solana_payment_settles_then_retries(monkeypatch) -> None:
+    signer = LocalSigner.from_seed(bytes([22]) * 32)
+    challenge = {
+        "amount": "10000000",
+        "to": "Recipient1111111111111111111111111111111111",
+        "network": SOLANA_MAINNET_NETWORK,
+        "asset": "USDC",
+        "nonce": "n1",
+        "expiresAt": "2026-06-13T00:00:00Z",
+        "metadata": {"feeQuoteId": "q1"},
+    }
+    session = FakeSession(
+        [
+            FakeResponse(402, {"error": "payment required", "payment": challenge}),
+            FakeResponse(200, {"username": "@agent", "cryptoId": signer.agent_id}),
+        ]
+    )
+    client = TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+    captured: dict = {}
+
+    async def fake_execute(**kwargs):
+        captured.update(kwargs)
+        return {
+            "signature": "onchain-sig",
+            "payment": {"scheme": "exact", "amount": kwargs["payment"]["amount"], "signature": "sig"},
+        }
+
+    monkeypatch.setattr("tinyplace.api.registry.execute_solana_x402_payment", fake_execute)
+
+    result = await client.register_domain_with_solana_payment(
+        "agent",
+        rpc_url="https://rpc.example",
+        secret_key=bytes([22]) * 32,
+        network=SOLANA_MAINNET_NETWORK,
+    )
+
+    # Paid the challenge's exact amount to its recipient, tagged for registration.
+    assert captured["payment"]["amount"] == "10000000"
+    assert captured["payment"]["to"] == challenge["to"]
+    assert captured["payment"]["metadata"]["purpose"] == "registration"
+    assert captured["payment"]["metadata"]["identity"] == "@agent"
+    # The retried registration carried the signed payment map.
+    retry_body = json_body_at(session, 1)
+    assert retry_body["payment"]["signature"] == "sig"
+    assert retry_body["username"] == "@agent"
+    assert result["onChainTx"] == "onchain-sig"
 
 
 def json_body(session: FakeSession) -> dict:

--- a/sdk/python/tests/test_x402_solana.py
+++ b/sdk/python/tests/test_x402_solana.py
@@ -8,6 +8,7 @@ from nacl.signing import VerifyKey
 from tinyplace import (
     LocalSigner,
     SOLANA_MAINNET_NETWORK,
+    SOLANA_USDC_MINT,
     build_canonical_message,
     build_x402_payment_map,
     execute_solana_payment,
@@ -123,6 +124,65 @@ async def test_execute_solana_x402_payment_adds_transaction_references() -> None
     assert result["payment"]["tx"] == "sig"
 
 
+async def test_execute_solana_payment_usdc_spl_transfer() -> None:
+    signer = LocalSigner.from_seed(bytes([34]) * 32)
+    calls: list[str] = []
+    # Distinct valid base58 pubkeys stand in for the recipient wallet and the
+    # two associated token accounts. The payer is the signer's own address.
+    recipient = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+    source_ata = SOLANA_USDC_MINT
+    dest_ata = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+    async def rpc_request(method: str, params: list) -> dict | str:
+        calls.append(method)
+        if method == "getTokenAccountsByOwner":
+            owner = params[0]
+            pubkey = source_ata if owner == signer.agent_id else dest_ata
+            return {
+                "value": [
+                    {
+                        "pubkey": pubkey,
+                        "account": {
+                            "data": {"parsed": {"info": {"tokenAmount": {"amount": "5000000"}}}}
+                        },
+                    }
+                ]
+            }
+        if method == "getLatestBlockhash":
+            return {"value": {"blockhash": "11111111111111111111111111111111"}}
+        if method == "sendTransaction":
+            assert isinstance(params[0], str)
+            return "usdc-sig"
+        if method == "getSignatureStatuses":
+            return {"value": [{"confirmationStatus": "confirmed", "err": None}]}
+        raise AssertionError(method)
+
+    result = await execute_solana_payment(
+        rpc_url="https://solana.example.test",
+        secret_key=bytes([34]) * 32,
+        payment={
+            "network": SOLANA_MAINNET_NETWORK,
+            "asset": "USDC",
+            "amount": "1000000",
+            "to": recipient,
+        },
+        rpc_request=rpc_request,
+    )
+
+    assert result["signature"] == "usdc-sig"
+    assert result["mint"] == SOLANA_USDC_MINT
+    assert result["sourceTokenAccount"] == source_ata
+    assert result["destinationTokenAccount"] == dest_ata
+    # Token-account lookups precede the blockhash fetch (matches the TS SDK order).
+    assert calls == [
+        "getTokenAccountsByOwner",
+        "getTokenAccountsByOwner",
+        "getLatestBlockhash",
+        "sendTransaction",
+        "getSignatureStatuses",
+    ]
+
+
 async def test_execute_solana_payment_rejects_bad_inputs() -> None:
     with pytest.raises(ValueError, match="Unsupported Solana network"):
         await execute_solana_payment(
@@ -130,11 +190,12 @@ async def test_execute_solana_payment_rejects_bad_inputs() -> None:
             secret_key=b"0" * 32,
             payment={"network": "base", "asset": "SOL", "amount": "1", "to": "x"},
         )
+    # An unknown token without an explicit mint is still rejected.
     with pytest.raises(ValueError, match="Unsupported Solana asset"):
         await execute_solana_payment(
             rpc_url="x",
             secret_key=b"0" * 32,
-            payment={"network": SOLANA_MAINNET_NETWORK, "asset": "USDC", "amount": "1", "to": "x"},
+            payment={"network": SOLANA_MAINNET_NETWORK, "asset": "DOGE", "amount": "1", "to": "x"},
         )
     with pytest.raises(ValueError, match="32 or 64 bytes"):
         await execute_solana_payment(


### PR DESCRIPTION
## What
Part 1 of 2 for Phase 1 / #94 — the **SDK foundation**. The Python SDK's Solana layer only sent **native SOL**, so it could not settle the **USDC** x402 fees the backend charges (e.g. identity registration). This adds SPL-token support and a paid-registration convenience.

## Changes (`sdk/python`)
- **`solana.py`** — SPL `TransferChecked` transfers via `solders`, with associated-token-account resolution (`getTokenAccountsByOwner`). `execute_solana_payment` / `execute_solana_x402_payment` gain `mint` / `decimals` / token-account overrides; the native-SOL path is unchanged. New `SOLANA_USDC_MINT`, `SOLANA_TOKEN_PROGRAM_ID`.
- **`api/registry.py`** — `register_with_solana_payment`: probes the 402 challenge → pays the fee on chain → retries `register` with the signed x402 payment map, polling through the unconfirmed window. Mirrors the TS SDK's `registerWithSolanaPayment`. (`payment` is **not** part of the signed registration payload, so re-signing on retry is correct.)
- **`client.py`** — `register_domain_with_solana_payment` convenience.

## Tests
USDC SPL transfer (mocked RPC, asserts token-account lookup ordering) + the paid-registration retry flow. **179 passed, 95% coverage.**

## Notes
- The plugin side that consumes this is a **separate PR** (auto-settle wiring).
- Not yet exercised against a live devnet (needs a funded wallet + backend); fully unit-tested with mocked RPC/HTTP.

Part of #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `register_domain_with_solana_payment` for automatic Solana 402 fee settlement with retry handling.
  * Expanded Solana payments to support SPL token transfers (USDC by default) in addition to native SOL.
  * Re-exported `SOLANA_USDC_MINT` for SDK consumers.
* **Bug Fixes**
  * Improved parsing of `X-Payment-Required` to support base64url-encoded JSON challenges and more robust validation.
* **Tests**
  * Added/updated async tests covering Solana registration settlement, header challenge decoding/default minting, server-error recovery, and SPL token transfer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->