### PR TITLE
feat(sdk/plugin-hermes): auto-settle the x402 registration fee

### DIFF
--- a/sdk/plugin-hermes/DEMO.md
+++ b/sdk/plugin-hermes/DEMO.md
@@ -26,7 +26,10 @@ hermes plugins enable tinyplace
 # 32-byte Ed25519 seed OR a Solana secret key, base58 or base64. Keep it secret.
 export TINYPLACE_AGENT_KEY=<ed25519-seed-or-solana-secret>
 export TINYPLACE_API_BASE_URL=https://staging-api.tiny.place   # optional (default)
-export TINYPLACE_SOLANA_NETWORK=mainnet-beta                   # optional
+# Set a network to auto-settle paid actions on chain (registration fee in USDC):
+export TINYPLACE_SOLANA_NETWORK=devnet                         # optional
+# export TINYPLACE_SOLANA_RPC_URL=https://api.devnet.solana.com   # optional (derived from network)
+# export TINYPLACE_SOLANA_USDC_MINT=<devnet-usdc-mint>            # optional (devnet mint differs)
 # export TINYPLACE_STATE_DIR=~/.hermes/state/tinyplace         # optional
 
 HERMES_PLUGINS_DEBUG=1 hermes plugins list   # confirm tinyplace + its 5 tools loaded
@@ -43,9 +46,15 @@ In a Hermes session, the model can call the tools directly:
 > check if @my-agent is available, and if so register it
 ```
 
-This drives `tinyplace_search_domain` → `tinyplace_register_domain`. A
-`402 Payment Required` is returned as an actionable JSON result (with the x402
-challenge), not an error.
+This drives `tinyplace_search_domain` → `tinyplace_register_domain`.
+
+- **With `TINYPLACE_SOLANA_NETWORK` set** (and a reachable RPC + funded agent
+  wallet), `tinyplace_register_domain` settles the USDC registration fee on
+  chain automatically and completes registration, returning `settled: true`
+  with the `onChainTx`.
+- **Without it**, the `402 Payment Required` is returned as an actionable JSON
+  result (with the x402 challenge) so the fee can be settled out of band — not
+  an opaque error.
 
 ## 4. Hold a conversation
 

--- a/sdk/plugin-hermes/README.md
+++ b/sdk/plugin-hermes/README.md
@@ -41,7 +41,7 @@ plugin-hermes/
 | `tinyplace_poll_inbox` | Return **new** Signal-decrypted inbound messages, tracked by a persisted cursor (only unseen messages; empty when none). |
 | `tinyplace_send_message` | Send a Signal-encrypted message to a `@handle` or raw base64 messaging address (auto X3DH on first contact). |
 | `tinyplace_search_domain` | Check whether a `@handle` is available to register. |
-| `tinyplace_register_domain` | Register a `@handle` for this agent. Surfaces a `402 Payment Required` x402 challenge actionably instead of failing opaquely. |
+| `tinyplace_register_domain` | Register a `@handle` for this agent. When a Solana network + RPC are configured it settles the x402 fee on chain (USDC) and completes registration (`settled: true`); otherwise it surfaces the `402 Payment Required` challenge actionably. |
 | `tinyplace_get_identity` | Resolve this agent's own directory identity and messaging address. |
 
 ## Configuration (`requires_env`)
@@ -50,7 +50,9 @@ plugin-hermes/
 | --- | --- | --- | --- |
 | `TINYPLACE_AGENT_KEY` | **yes** (secret) | — | The agent's signing key: a 32-byte Ed25519 seed or a Solana secret key, base58- or base64-encoded. This is the agent's identity **and** message-decryption key. It is loaded locally only — Hermes never transmits or logs it. |
 | `TINYPLACE_API_BASE_URL` | no | `https://staging-api.tiny.place` | Base URL of the tiny.place backend. |
-| `TINYPLACE_SOLANA_NETWORK` | no | — | Solana network label for payment challenges (e.g. `devnet`). Only relevant for paid domain registration. |
+| `TINYPLACE_SOLANA_NETWORK` | no | — | Solana network label (e.g. `devnet`, `mainnet-beta`). When set (with a reachable RPC), paid actions like registration settle their x402 fee on chain automatically. |
+| `TINYPLACE_SOLANA_RPC_URL` | no | public RPC for known networks | Solana RPC endpoint for submitting on-chain settlements. Required to auto-settle on a custom/private network. |
+| `TINYPLACE_SOLANA_USDC_MINT` | no | mainnet USDC mint | Overrides the USDC SPL mint. Set on devnet/custom deployments whose USDC mint differs. |
 | `TINYPLACE_STATE_DIR` | no | `~/.hermes/state/tinyplace` | Where the inbox cursor and Signal session state are persisted. |
 
 If `TINYPLACE_AGENT_KEY` is missing the plugin's tools are **gracefully

--- a/sdk/plugin-hermes/src/tinyplace/config.py
+++ b/sdk/plugin-hermes/src/tinyplace/config.py
@@ -14,10 +14,21 @@ from pathlib import Path
 
 DEFAULT_API_BASE_URL = "https://staging-api.tiny.place"
 
+# Public Solana RPC endpoints keyed by the network label, used to settle x402
+# payments on chain when no explicit RPC URL is configured.
+_DEFAULT_RPC_BY_NETWORK = {
+    "devnet": "https://api.devnet.solana.com",
+    "testnet": "https://api.testnet.solana.com",
+    "mainnet": "https://api.mainnet-beta.solana.com",
+    "mainnet-beta": "https://api.mainnet-beta.solana.com",
+}
+
 # Environment variable names (mirrors plugin.yaml ``requires_env``).
 ENV_AGENT_KEY = "TINYPLACE_AGENT_KEY"
 ENV_API_BASE_URL = "TINYPLACE_API_BASE_URL"
 ENV_SOLANA_NETWORK = "TINYPLACE_SOLANA_NETWORK"
+ENV_SOLANA_RPC_URL = "TINYPLACE_SOLANA_RPC_URL"
+ENV_SOLANA_USDC_MINT = "TINYPLACE_SOLANA_USDC_MINT"
 ENV_STATE_DIR = "TINYPLACE_STATE_DIR"
 
 
@@ -27,12 +38,21 @@ class PluginConfig:
 
     ``agent_key`` is the raw secret material (never logged). ``state_dir`` is
     where the inbox cursor and Signal session state are persisted between runs.
+    ``solana_rpc_url`` / ``usdc_mint`` enable on-chain x402 settlement of paid
+    actions (e.g. domain registration) when a ``solana_network`` is set.
     """
 
     agent_key: str
     api_base_url: str
     solana_network: str | None
+    solana_rpc_url: str | None
+    usdc_mint: str | None
     state_dir: Path
+
+    @property
+    def can_settle_payments(self) -> bool:
+        """True when enough is configured to settle an x402 payment on chain."""
+        return bool(self.solana_network and self.solana_rpc_url)
 
 
 def default_state_dir() -> Path:
@@ -70,12 +90,26 @@ def load_config() -> PluginConfig:
         os.environ.get(ENV_API_BASE_URL, "").strip() or DEFAULT_API_BASE_URL
     ).rstrip("/")
     solana_network = os.environ.get(ENV_SOLANA_NETWORK, "").strip() or None
+    solana_rpc_url = (
+        os.environ.get(ENV_SOLANA_RPC_URL, "").strip()
+        or _default_rpc_url(solana_network)
+    )
+    usdc_mint = os.environ.get(ENV_SOLANA_USDC_MINT, "").strip() or None
     return PluginConfig(
         agent_key=agent_key,
         api_base_url=api_base_url,
         solana_network=solana_network,
+        solana_rpc_url=solana_rpc_url,
+        usdc_mint=usdc_mint,
         state_dir=default_state_dir(),
     )
+
+
+def _default_rpc_url(network: str | None) -> str | None:
+    """Public Solana RPC endpoint for a known network label, else ``None``."""
+    if not network:
+        return None
+    return _DEFAULT_RPC_BY_NETWORK.get(network.strip().lower())
 
 
 def decode_key_material(agent_key: str) -> bytes:

--- a/sdk/plugin-hermes/src/tinyplace/plugin.yaml
+++ b/sdk/plugin-hermes/src/tinyplace/plugin.yaml
@@ -25,5 +25,16 @@ requires_env:
     url: https://staging-api.tiny.place
   - name: TINYPLACE_SOLANA_NETWORK
     description: >-
-      Solana network label used for payment challenges (e.g. devnet,
-      mainnet-beta). Optional; only relevant for paid domain registration.
+      Solana network label (e.g. devnet, mainnet-beta). When set (together with
+      a reachable RPC), paid actions such as domain registration settle their
+      x402 fee on chain automatically instead of surfacing a 402 challenge.
+  - name: TINYPLACE_SOLANA_RPC_URL
+    description: >-
+      Solana RPC endpoint used to submit on-chain x402 settlements. Optional;
+      defaults to the public RPC for known networks (devnet, testnet,
+      mainnet-beta). Required to auto-settle on a custom/private network.
+  - name: TINYPLACE_SOLANA_USDC_MINT
+    description: >-
+      Overrides the USDC SPL mint used for settlement. Optional; defaults to the
+      mainnet USDC mint. Set this on devnet/custom deployments whose USDC mint
+      differs.

--- a/sdk/plugin-hermes/src/tinyplace/runtime.py
+++ b/sdk/plugin-hermes/src/tinyplace/runtime.py
@@ -196,6 +196,23 @@ class TinyPlaceRuntime:
             return address if isinstance(address, str) else None
         return None
 
+    def payment_settlement(self) -> dict[str, Any] | None:
+        """On-chain x402 settlement params for paid actions, or ``None``.
+
+        Returns the Solana RPC URL, the agent's secret key (for signing the
+        on-chain transfer), the optional USDC mint override and the network
+        label — but only when a network + RPC are configured. ``None`` means
+        paid actions should surface their 402 challenge instead of settling.
+        """
+        if not self._config.can_settle_payments:
+            return None
+        return {
+            "rpc_url": self._config.solana_rpc_url,
+            "secret_key": decode_key_material(self._config.agent_key),
+            "mint": self._config.usdc_mint,
+            "network": self._config.solana_network,
+        }
+
     # --- Cursor persistence -------------------------------------------------
 
     def read_cursor(self) -> str | None:

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -219,6 +219,16 @@ def register_domain(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     async def _run() -> Any:
         client = await runtime.get_client()
         if settlement is not None:
+            if not hasattr(client, "register_domain_with_solana_payment"):
+                # Auto-settlement was requested but the installed SDK predates
+                # the on-chain settlement helper. Fail with an actionable message
+                # rather than a cryptic AttributeError.
+                raise RuntimeError(
+                    "on-chain settlement needs a tiny.place Python SDK that "
+                    "provides register_domain_with_solana_payment; upgrade the "
+                    "SDK, or unset TINYPLACE_SOLANA_NETWORK to surface the 402 "
+                    "challenge for out-of-band settlement instead."
+                )
             return await client.register_domain_with_solana_payment(
                 domain,
                 rpc_url=settlement["rpc_url"],

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -211,11 +211,31 @@ def register_domain(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     if isinstance(actor_type, str) and actor_type:
         fields["actorType"] = actor_type
 
+    # When a Solana network + RPC are configured, settle the x402 registration
+    # fee on chain automatically and complete the registration; otherwise leave
+    # the 402 challenge to be surfaced to the model (via _tinyplace_error).
+    settlement = runtime.payment_settlement()
+
     async def _run() -> Any:
         client = await runtime.get_client()
+        if settlement is not None:
+            return await client.register_domain_with_solana_payment(
+                domain,
+                rpc_url=settlement["rpc_url"],
+                secret_key=settlement["secret_key"],
+                mint=settlement["mint"],
+                network=settlement["network"],
+                **fields,
+            )
         return await client.register_domain(domain, **fields)
 
-    return _ok({"domain": domain, "record": runtime.run(_run())})
+    return _ok(
+        {
+            "domain": domain,
+            "settled": settlement is not None,
+            "record": runtime.run(_run()),
+        }
+    )
 
 
 @_guard

--- a/sdk/plugin-hermes/tests/test_config.py
+++ b/sdk/plugin-hermes/tests/test_config.py
@@ -13,10 +13,15 @@ def test_load_config_defaults(monkeypatch, tmp_path):
     monkeypatch.setenv(cfg.ENV_AGENT_KEY, "key")
     monkeypatch.delenv(cfg.ENV_API_BASE_URL, raising=False)
     monkeypatch.delenv(cfg.ENV_SOLANA_NETWORK, raising=False)
+    monkeypatch.delenv(cfg.ENV_SOLANA_RPC_URL, raising=False)
+    monkeypatch.delenv(cfg.ENV_SOLANA_USDC_MINT, raising=False)
     monkeypatch.setenv(cfg.ENV_STATE_DIR, str(tmp_path))
     config = cfg.load_config()
     assert config.api_base_url == cfg.DEFAULT_API_BASE_URL
     assert config.solana_network is None
+    assert config.solana_rpc_url is None
+    assert config.usdc_mint is None
+    assert config.can_settle_payments is False
     assert config.agent_key == "key"
 
 
@@ -24,10 +29,38 @@ def test_load_config_overrides(monkeypatch, tmp_path):
     monkeypatch.setenv(cfg.ENV_AGENT_KEY, "key")
     monkeypatch.setenv(cfg.ENV_API_BASE_URL, "https://example.test/")
     monkeypatch.setenv(cfg.ENV_SOLANA_NETWORK, "devnet")
+    monkeypatch.delenv(cfg.ENV_SOLANA_RPC_URL, raising=False)
     monkeypatch.setenv(cfg.ENV_STATE_DIR, str(tmp_path))
     config = cfg.load_config()
     assert config.api_base_url == "https://example.test"  # trailing slash trimmed
     assert config.solana_network == "devnet"
+    # An RPC URL is derived from the known network label -> settlement enabled.
+    assert config.solana_rpc_url == "https://api.devnet.solana.com"
+    assert config.can_settle_payments is True
+
+
+def test_load_config_explicit_solana_rpc_and_mint(monkeypatch, tmp_path):
+    monkeypatch.setenv(cfg.ENV_AGENT_KEY, "key")
+    monkeypatch.setenv(cfg.ENV_SOLANA_NETWORK, "mainnet-beta")
+    monkeypatch.setenv(cfg.ENV_SOLANA_RPC_URL, "https://my-rpc.example/")
+    monkeypatch.setenv(cfg.ENV_SOLANA_USDC_MINT, "MintPubkey1111111111111111111111111111111111")
+    monkeypatch.setenv(cfg.ENV_STATE_DIR, str(tmp_path))
+    config = cfg.load_config()
+    # An explicit RPC URL overrides the per-network default.
+    assert config.solana_rpc_url == "https://my-rpc.example/"
+    assert config.usdc_mint == "MintPubkey1111111111111111111111111111111111"
+    assert config.can_settle_payments is True
+
+
+def test_load_config_unknown_network_has_no_default_rpc(monkeypatch, tmp_path):
+    monkeypatch.setenv(cfg.ENV_AGENT_KEY, "key")
+    monkeypatch.setenv(cfg.ENV_SOLANA_NETWORK, "some-private-net")
+    monkeypatch.delenv(cfg.ENV_SOLANA_RPC_URL, raising=False)
+    monkeypatch.setenv(cfg.ENV_STATE_DIR, str(tmp_path))
+    config = cfg.load_config()
+    # Unknown network + no explicit RPC -> can't settle; the 402 is surfaced.
+    assert config.solana_rpc_url is None
+    assert config.can_settle_payments is False
 
 
 def test_is_configured(monkeypatch):

--- a/sdk/plugin-hermes/tests/test_tools.py
+++ b/sdk/plugin-hermes/tests/test_tools.py
@@ -132,6 +132,35 @@ def test_register_domain_payment_required(tmp_path, monkeypatch):
     assert out["status"] == 402
     assert out["payment_required"]["payment"]["amount"] == "100"
     assert "x402" in out["hint"]
+    # No Solana network configured -> the challenge is surfaced, not settled.
+    assert "settled" not in out
+
+
+def test_register_domain_auto_settles_when_solana_configured(tmp_path, monkeypatch):
+    monkeypatch.setenv("TINYPLACE_SOLANA_NETWORK", "devnet")
+    monkeypatch.setenv("TINYPLACE_SOLANA_RPC_URL", "https://rpc.example.test")
+    monkeypatch.setenv("TINYPLACE_SOLANA_USDC_MINT", "DevnetUsdcMint11111111111111111111111111111")
+    rt = _make_runtime(tmp_path, monkeypatch)
+
+    captured: dict = {}
+
+    async def fake_paid(domain, **kwargs):
+        captured["domain"] = domain
+        captured["kwargs"] = kwargs
+        return {"identity": {"username": domain}, "onChainTx": "onchain-sig", "payment": {}}
+
+    rt._client.register_domain_with_solana_payment = fake_paid
+
+    out = json.loads(tools.register_domain({"domain": "@paid"}, runtime=rt))
+    assert out["ok"] is True
+    assert out["settled"] is True
+    assert out["record"]["onChainTx"] == "onchain-sig"
+    # The runtime handed the SDK the configured RPC/mint/network + a secret key.
+    assert captured["domain"] == "@paid"
+    assert captured["kwargs"]["rpc_url"] == "https://rpc.example.test"
+    assert captured["kwargs"]["network"] == "devnet"
+    assert captured["kwargs"]["mint"] == "DevnetUsdcMint11111111111111111111111111111"
+    assert isinstance(captured["kwargs"]["secret_key"], (bytes, bytearray))
 
 
 def test_poll_inbox_returns_every_decrypted_message(tmp_path, monkeypatch):

--- a/sdk/plugin-hermes/tests/test_tools.py
+++ b/sdk/plugin-hermes/tests/test_tools.py
@@ -163,6 +163,20 @@ def test_register_domain_auto_settles_when_solana_configured(tmp_path, monkeypat
     assert isinstance(captured["kwargs"]["secret_key"], (bytes, bytearray))
 
 
+def test_register_domain_auto_settle_without_sdk_support_errors_clearly(tmp_path, monkeypatch):
+    monkeypatch.setenv("TINYPLACE_SOLANA_NETWORK", "devnet")
+    monkeypatch.setenv("TINYPLACE_SOLANA_RPC_URL", "https://rpc.example.test")
+    rt = _make_runtime(tmp_path, monkeypatch)
+    # The fake client has no register_domain_with_solana_payment (an SDK that
+    # predates on-chain settlement) -> actionable error, not a raw AttributeError.
+    assert not hasattr(rt._client, "register_domain_with_solana_payment")
+
+    out = json.loads(tools.register_domain({"domain": "@paid"}, runtime=rt))
+    assert out["ok"] is False
+    assert "AttributeError" not in out["error"]
+    assert "register_domain_with_solana_payment" in out["error"]
+
+
 def test_poll_inbox_returns_every_decrypted_message(tmp_path, monkeypatch):
     rt = _make_runtime(tmp_path, monkeypatch)
     rt._client.messages._decrypted = [


### PR DESCRIPTION
## What
Part 2 of 2 for Phase 1 / #94 — the **plugin layer**. When a Solana network + RPC are configured, `tinyplace_register_domain` now settles the USDC registration fee on chain and completes registration (`settled: true` + `onChainTx`) instead of only surfacing the 402 challenge. Unconfigured behavior is unchanged — the challenge is still surfaced actionably.

## Changes (`sdk/plugin-hermes`)
- **`config.py`** — `TINYPLACE_SOLANA_RPC_URL` + `TINYPLACE_SOLANA_USDC_MINT`; RPC URL derived from the network label for known networks (devnet/testnet/mainnet-beta); `can_settle_payments` gate.
- **`runtime.py`** — `payment_settlement()` exposes `rpc_url` / `secret_key` / `mint` / `network`.
- **`tools.py`** — `register_domain` routes through the SDK's `register_domain_with_solana_payment` when settlement is configured.
- Manifest (`plugin.yaml`) + README/DEMO updated.

## Tests
Plugin tests cover both the **auto-settle** path (asserts RPC/mint/network/secret-key handed to the SDK) and the **surfaced-challenge** path (unchanged when no network is set), plus config RPC-derivation. **30 passed.**

## Depends on
⚠️ **#103** (the SDK's `register_domain_with_solana_payment`). Merge #103 first — at runtime this PR calls that method. The plugin tests pass independently (they inject a fake client), so CI is green on its own.

## Notes
Not yet exercised end-to-end on devnet (needs a funded wallet); on devnet set `TINYPLACE_SOLANA_USDC_MINT` since the devnet USDC mint differs.

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic on-chain settlement for domain registration fees via Solana when network and RPC configuration are available.
  * Enhanced paid-action handling to expose a `settled` outcome and return actionable payment-required results.

* **Documentation**
  * Updated Hermes demo/runbook and tool docs to clarify Solana auto-settlement vs `402 Payment Required` behavior.
  * Expanded configuration guidance with Solana network defaults and optional RPC/mint environment variables.

* **Tests**
  * Added/expanded coverage for config resolution and domain registration settlement outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->