### PR TITLE
feat(sdk/python): add the platform notifications InboxApi

### DIFF
--- a/sdk/python/src/tinyplace/api/__init__.py
+++ b/sdk/python/src/tinyplace/api/__init__.py
@@ -1,5 +1,6 @@
 from .directory import DirectoryApi
 from .docs import DocsApi
+from .inbox import InboxApi
 from .keys import KeysApi
 from .messages import InboxPage, MessagesApi
 from .payments import PaymentsApi
@@ -9,6 +10,7 @@ from .search import SearchApi
 __all__ = [
     "DirectoryApi",
     "DocsApi",
+    "InboxApi",
     "InboxPage",
     "KeysApi",
     "MessagesApi",

--- a/sdk/python/src/tinyplace/api/inbox.py
+++ b/sdk/python/src/tinyplace/api/inbox.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from ..http import HttpClient, encode
+from ..types import Json, JsonDict, Query
+
+
+class InboxApi:
+    """The platform notifications inbox.
+
+    Surfaces platform events for an agent — escrow updates, follows, mentions,
+    group activity, etc. This is distinct from :class:`MessagesApi`, which is the
+    encrypted agent-to-agent message relay.
+
+    Every operation is agent-authenticated by default. Pass ``owner`` (a managed
+    agent's cryptoId) to act on that agent's inbox via directory auth instead,
+    mirroring the TS SDK's ``InboxApi``.
+    """
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    async def list(self, params: Query = None, owner: str | None = None) -> JsonDict:
+        if owner:
+            return await self._http.get_directory_auth_as("/inbox", owner, params)
+        return await self._http.get_agent_auth("/inbox", params)
+
+    async def get(self, item_id: str, owner: str | None = None) -> Json:
+        path = f"/inbox/{encode(item_id)}"
+        if owner:
+            return await self._http.get_directory_auth_as(path, owner)
+        return await self._http.get_agent_auth(path)
+
+    async def search(self, query: str, owner: str | None = None) -> Json:
+        if owner:
+            return await self._http.get_directory_auth_as("/inbox/search", owner, {"q": query})
+        return await self._http.get_agent_auth("/inbox/search", {"q": query})
+
+    async def counts(self, owner: str | None = None) -> Json:
+        if owner:
+            return await self._http.get_directory_auth_as("/inbox/counts", owner)
+        return await self._http.get_agent_auth("/inbox/counts")
+
+    async def mark_read(self, item_id: str, owner: str | None = None) -> Json:
+        path = f"/inbox/{encode(item_id)}/read"
+        if owner:
+            return await self._http.put_directory_auth_as(path, owner, {})
+        return await self._http.put_agent_auth(path, {})
+
+    async def mark_read_bulk(self, item_ids: list[str], owner: str | None = None) -> Json:
+        if owner:
+            return await self._http.put_directory_auth_as("/inbox/read", owner, {"itemIds": item_ids})
+        return await self._http.put_agent_auth("/inbox/read", {"itemIds": item_ids})
+
+    async def mark_all_read(self, params: JsonDict | None = None, owner: str | None = None) -> Json:
+        if owner:
+            return await self._http.put_directory_auth_as("/inbox/read-all", owner, params or {})
+        return await self._http.put_agent_auth("/inbox/read-all", params or {})
+
+    async def archive(self, item_id: str, owner: str | None = None) -> Json:
+        path = f"/inbox/{encode(item_id)}/archive"
+        if owner:
+            return await self._http.put_directory_auth_as(path, owner, {})
+        return await self._http.put_agent_auth(path, {})
+
+    async def archive_bulk(self, item_ids: list[str], owner: str | None = None) -> Json:
+        if owner:
+            return await self._http.put_directory_auth_as("/inbox/archive", owner, {"itemIds": item_ids})
+        return await self._http.put_agent_auth("/inbox/archive", {"itemIds": item_ids})
+
+    async def unarchive(self, item_id: str, owner: str | None = None) -> Json:
+        path = f"/inbox/{encode(item_id)}/unarchive"
+        if owner:
+            return await self._http.put_directory_auth_as(path, owner, {})
+        return await self._http.put_agent_auth(path, {})
+
+    async def remove(self, item_id: str, owner: str | None = None) -> None:
+        path = f"/inbox/{encode(item_id)}"
+        if owner:
+            await self._http.delete_directory_auth_as(path, owner, {})
+            return
+        await self._http.delete_agent_auth(path, {})
+
+    async def remove_bulk(self, item_ids: list[str], owner: str | None = None) -> None:
+        if owner:
+            await self._http.delete_directory_auth_as("/inbox", owner, {"itemIds": item_ids})
+            return
+        await self._http.delete_agent_auth("/inbox", {"itemIds": item_ids})
+
+    async def clear(self, params: JsonDict | None = None, owner: str | None = None) -> Json:
+        if owner:
+            return await self._http.delete_directory_auth_as("/inbox/clear", owner, params or {})
+        return await self._http.delete_agent_auth("/inbox/clear", params or {})

--- a/sdk/python/src/tinyplace/api/inbox.py
+++ b/sdk/python/src/tinyplace/api/inbox.py
@@ -13,80 +13,103 @@ class InboxApi:
 
     Every operation is agent-authenticated by default. Pass ``owner`` (a managed
     agent's cryptoId) to act on that agent's inbox via directory auth instead,
-    mirroring the TS SDK's ``InboxApi``.
+    mirroring the TS SDK's ``InboxApi``. A blank ``owner`` is rejected rather than
+    silently falling back to agent auth, so a mutation never runs in the wrong
+    authentication context.
     """
 
     def __init__(self, http: HttpClient) -> None:
         self._http = http
 
+    @staticmethod
+    def _owner(owner: str | None) -> str | None:
+        if owner is None:
+            return None
+        if not owner.strip():
+            raise ValueError("owner must be a non-empty cryptoId")
+        return owner
+
     async def list(self, params: Query = None, owner: str | None = None) -> JsonDict:
-        if owner:
+        owner = self._owner(owner)
+        if owner is not None:
             return await self._http.get_directory_auth_as("/inbox", owner, params)
         return await self._http.get_agent_auth("/inbox", params)
 
     async def get(self, item_id: str, owner: str | None = None) -> Json:
+        owner = self._owner(owner)
         path = f"/inbox/{encode(item_id)}"
-        if owner:
+        if owner is not None:
             return await self._http.get_directory_auth_as(path, owner)
         return await self._http.get_agent_auth(path)
 
     async def search(self, query: str, owner: str | None = None) -> Json:
-        if owner:
+        owner = self._owner(owner)
+        if owner is not None:
             return await self._http.get_directory_auth_as("/inbox/search", owner, {"q": query})
         return await self._http.get_agent_auth("/inbox/search", {"q": query})
 
     async def counts(self, owner: str | None = None) -> Json:
-        if owner:
+        owner = self._owner(owner)
+        if owner is not None:
             return await self._http.get_directory_auth_as("/inbox/counts", owner)
         return await self._http.get_agent_auth("/inbox/counts")
 
     async def mark_read(self, item_id: str, owner: str | None = None) -> Json:
+        owner = self._owner(owner)
         path = f"/inbox/{encode(item_id)}/read"
-        if owner:
+        if owner is not None:
             return await self._http.put_directory_auth_as(path, owner, {})
         return await self._http.put_agent_auth(path, {})
 
     async def mark_read_bulk(self, item_ids: list[str], owner: str | None = None) -> Json:
-        if owner:
+        owner = self._owner(owner)
+        if owner is not None:
             return await self._http.put_directory_auth_as("/inbox/read", owner, {"itemIds": item_ids})
         return await self._http.put_agent_auth("/inbox/read", {"itemIds": item_ids})
 
     async def mark_all_read(self, params: JsonDict | None = None, owner: str | None = None) -> Json:
-        if owner:
+        owner = self._owner(owner)
+        if owner is not None:
             return await self._http.put_directory_auth_as("/inbox/read-all", owner, params or {})
         return await self._http.put_agent_auth("/inbox/read-all", params or {})
 
     async def archive(self, item_id: str, owner: str | None = None) -> Json:
+        owner = self._owner(owner)
         path = f"/inbox/{encode(item_id)}/archive"
-        if owner:
+        if owner is not None:
             return await self._http.put_directory_auth_as(path, owner, {})
         return await self._http.put_agent_auth(path, {})
 
     async def archive_bulk(self, item_ids: list[str], owner: str | None = None) -> Json:
-        if owner:
+        owner = self._owner(owner)
+        if owner is not None:
             return await self._http.put_directory_auth_as("/inbox/archive", owner, {"itemIds": item_ids})
         return await self._http.put_agent_auth("/inbox/archive", {"itemIds": item_ids})
 
     async def unarchive(self, item_id: str, owner: str | None = None) -> Json:
+        owner = self._owner(owner)
         path = f"/inbox/{encode(item_id)}/unarchive"
-        if owner:
+        if owner is not None:
             return await self._http.put_directory_auth_as(path, owner, {})
         return await self._http.put_agent_auth(path, {})
 
     async def remove(self, item_id: str, owner: str | None = None) -> None:
+        owner = self._owner(owner)
         path = f"/inbox/{encode(item_id)}"
-        if owner:
+        if owner is not None:
             await self._http.delete_directory_auth_as(path, owner, {})
             return
         await self._http.delete_agent_auth(path, {})
 
     async def remove_bulk(self, item_ids: list[str], owner: str | None = None) -> None:
-        if owner:
+        owner = self._owner(owner)
+        if owner is not None:
             await self._http.delete_directory_auth_as("/inbox", owner, {"itemIds": item_ids})
             return
         await self._http.delete_agent_auth("/inbox", {"itemIds": item_ids})
 
     async def clear(self, params: JsonDict | None = None, owner: str | None = None) -> Json:
-        if owner:
+        owner = self._owner(owner)
+        if owner is not None:
             return await self._http.delete_directory_auth_as("/inbox/clear", owner, params or {})
         return await self._http.delete_agent_auth("/inbox/clear", params or {})

--- a/sdk/python/src/tinyplace/client.py
+++ b/sdk/python/src/tinyplace/client.py
@@ -4,7 +4,16 @@ from typing import Any
 
 import aiohttp
 
-from .api import DirectoryApi, DocsApi, KeysApi, MessagesApi, PaymentsApi, RegistryApi, SearchApi
+from .api import (
+    DirectoryApi,
+    DocsApi,
+    InboxApi,
+    KeysApi,
+    MessagesApi,
+    PaymentsApi,
+    RegistryApi,
+    SearchApi,
+)
 from .auth import AdminSigningOptions
 from .http import AuthInvalidHook, HttpClient
 from .signer import Signer
@@ -38,6 +47,7 @@ class TinyPlaceClient:
         self.payments = PaymentsApi(self.http, signer)
         self.search = SearchApi(self.http)
         self.docs = DocsApi(self.http)
+        self.inbox = InboxApi(self.http)
 
     async def __aenter__(self) -> "TinyPlaceClient":
         return self

--- a/sdk/python/tests/test_inbox.py
+++ b/sdk/python/tests/test_inbox.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+
+from tinyplace import LocalSigner, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer: LocalSigner, session: FakeSession) -> TinyPlaceClient:
+    return TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+
+async def test_inbox_list_agent_auth_with_params() -> None:
+    signer = LocalSigner.from_seed(bytes([41]) * 32)
+    session = FakeSession([FakeResponse(200, {"items": [], "unreadCount": 0})])
+    client = _client(signer, session)
+
+    await client.inbox.list({"status": "unread", "limit": 10})
+
+    req = session.requests[0]
+    assert req["method"] == "GET"
+    assert req["url"].startswith("https://api.example.test/inbox?")
+    assert "status=unread" in req["url"] and "limit=10" in req["url"]
+    # No owner -> agent auth: X-Agent-ID is the caller's own cryptoId.
+    assert req["headers"]["X-Agent-ID"] == signer.agent_id
+
+
+async def test_inbox_list_with_owner_uses_directory_auth() -> None:
+    signer = LocalSigner.from_seed(bytes([42]) * 32)
+    session = FakeSession([FakeResponse(200, {"items": []})])
+    client = _client(signer, session)
+
+    await client.inbox.list(None, owner="OwnerCryptoId")
+
+    req = session.requests[0]
+    assert req["method"] == "GET"
+    assert req["url"].endswith("/inbox")
+    # owner -> directory auth as that managed agent.
+    assert req["headers"]["X-Agent-ID"] == "OwnerCryptoId"
+
+
+async def test_inbox_counts_mark_read_remove_and_mark_all() -> None:
+    signer = LocalSigner.from_seed(bytes([43]) * 32)
+    session = FakeSession(
+        [
+            FakeResponse(200, {"unreadCount": 3}),
+            FakeResponse(200, {"ok": True}),
+            FakeResponse(204, None),
+            FakeResponse(200, {"updated": 5}),
+        ]
+    )
+    client = _client(signer, session)
+
+    await client.inbox.counts()
+    await client.inbox.mark_read("item-1")
+    await client.inbox.remove("item-2")
+    await client.inbox.mark_all_read({"type": "ESCROW_EVENT"})
+
+    calls = [(r["method"], r["url"]) for r in session.requests]
+    base = "https://api.example.test"
+    assert calls[0] == ("GET", f"{base}/inbox/counts")
+    assert calls[1] == ("PUT", f"{base}/inbox/item-1/read")
+    assert calls[2] == ("DELETE", f"{base}/inbox/item-2")
+    assert calls[3] == ("PUT", f"{base}/inbox/read-all")
+    # mark_all_read forwards its filter as the request body.
+    assert json.loads(session.requests[3]["data"]) == {"type": "ESCROW_EVENT"}
+
+
+async def test_inbox_bulk_operations() -> None:
+    signer = LocalSigner.from_seed(bytes([44]) * 32)
+    session = FakeSession([FakeResponse(200, {"ok": True}), FakeResponse(204, None)])
+    client = _client(signer, session)
+
+    await client.inbox.mark_read_bulk(["a", "b"])
+    await client.inbox.remove_bulk(["c", "d"])
+
+    assert session.requests[0]["url"].endswith("/inbox/read")
+    assert json.loads(session.requests[0]["data"]) == {"itemIds": ["a", "b"]}
+    assert session.requests[1]["method"] == "DELETE"
+    assert session.requests[1]["url"].endswith("/inbox")
+    assert json.loads(session.requests[1]["data"]) == {"itemIds": ["c", "d"]}

--- a/sdk/python/tests/test_inbox.py
+++ b/sdk/python/tests/test_inbox.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from tinyplace import LocalSigner, TinyPlaceClient
 
 from .helpers import FakeResponse, FakeSession
@@ -84,3 +86,16 @@ async def test_inbox_bulk_operations() -> None:
     assert session.requests[1]["method"] == "DELETE"
     assert session.requests[1]["url"].endswith("/inbox")
     assert json.loads(session.requests[1]["data"]) == {"itemIds": ["c", "d"]}
+
+
+async def test_inbox_blank_owner_is_rejected() -> None:
+    signer = LocalSigner.from_seed(bytes([45]) * 32)
+    session = FakeSession([])
+    client = _client(signer, session)
+
+    # A blank owner must raise rather than silently falling back to agent auth
+    # (which would run a mutation in the wrong authentication context).
+    with pytest.raises(ValueError, match="owner must be a non-empty"):
+        await client.inbox.mark_read("item-1", owner="   ")
+    # Nothing was sent.
+    assert session.requests == []


### PR DESCRIPTION
## What
Part 1 of 2 for Phase 2 / #95 — the **SDK foundation**. Ports the TS SDK's `InboxApi` to the Python SDK so clients can read and triage the **platform notifications inbox** (escrow updates, follows, mentions, group activity). This is distinct from `MessagesApi` (the encrypted agent-to-agent message relay).

## Changes (`sdk/python`)
- **`api/inbox.py`** (`InboxApi`): `list`, `get`, `search`, `counts`, `mark_read` / `mark_read_bulk`, `mark_all_read`, `archive` / `archive_bulk` / `unarchive`, `remove` / `remove_bulk`, `clear`. Agent-authenticated by default; pass `owner` (a managed agent's cryptoId) to act via directory auth. Returns raw `Json`, matching the SDK's other namespaces.
- Wired `self.inbox` on `TinyPlaceClient`; exported `InboxApi` from the `api` package.

## Tests
`test_inbox.py` covers agent-auth vs owner/directory-auth routing, query params, and the mark/remove/bulk operations. **185 SDK tests pass.**

## Notes
The plugin tools that consume this are a **separate PR** (`tinyplace_notifications` / `tinyplace_mark_notifications_read`).

Part of #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `InboxApi` client to the Python SDK with inbox operations including listing, searching, counts, read/archive/unarchive, and remove—supporting both single and bulk actions.
  * Exposed `InboxApi` publicly and added an `inbox` handle on `TinyPlaceClient`.
* **Bug Fixes / Validation**
  * Rejects blank or whitespace `owner` values to prevent unintended authentication behavior.
* **Tests**
  * Expanded inbox test coverage for request construction, authentication selection, and bulk payload formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->