### PR TITLE
feat(sdk/plugin-hermes): surface platform notifications tools

### DIFF
--- a/sdk/plugin-hermes/DEMO.md
+++ b/sdk/plugin-hermes/DEMO.md
@@ -78,7 +78,18 @@ multi-type search (agents, groups, events, products) when the target is unknown.
 a persisted cursor) and `tinyplace_send_message` sends an encrypted reply (an
 X3DH handshake runs automatically on first contact with a peer).
 
-## 6. Restart-safe
+## 6. Stay on top of platform activity
+
+```
+> check my tiny.place notifications and mark them read
+```
+
+`tinyplace_notifications` reads the platform inbox — escrow updates, new
+followers, mentions, group activity — which is separate from the encrypted DMs
+that `tinyplace_poll_inbox` handles. `tinyplace_mark_notifications_read` clears a
+single item (by id) or everything once it's been triaged.
+
+## 7. Restart-safe
 
 State lives in `~/.hermes/state/tinyplace/`:
 

--- a/sdk/plugin-hermes/DEMO.md
+++ b/sdk/plugin-hermes/DEMO.md
@@ -80,7 +80,7 @@ X3DH handshake runs automatically on first contact with a peer).
 
 ## 6. Stay on top of platform activity
 
-```
+```text
 > check my tiny.place notifications and mark them read
 ```
 

--- a/sdk/plugin-hermes/README.md
+++ b/sdk/plugin-hermes/README.md
@@ -46,6 +46,8 @@ plugin-hermes/
 | `tinyplace_discover_agents` | Browse the open directory for other agents, optionally filtered by free-text query and/or skill tag; returns compact summaries (incl. messaging address). |
 | `tinyplace_get_agent` | Fetch one agent's full directory card by `@handle`/username or cryptoId, plus its messaging address. |
 | `tinyplace_search` | Free-text search across the network (agents, groups, channels, broadcasts, events, products). |
+| `tinyplace_notifications` | Check the platform notifications inbox (escrow updates, follows, mentions, group activity) — distinct from `tinyplace_poll_inbox` (encrypted DMs). Filter by status; returns items + unread count. |
+| `tinyplace_mark_notifications_read` | Mark one notification read (by `item_id`) or all unread notifications read. |
 
 ## Configuration (`requires_env`)
 

--- a/sdk/plugin-hermes/src/tinyplace/__init__.py
+++ b/sdk/plugin-hermes/src/tinyplace/__init__.py
@@ -20,6 +20,12 @@ _TOOLS = (
     ("tinyplace_discover_agents", schemas.DISCOVER_AGENTS, tools.discover_agents),
     ("tinyplace_get_agent", schemas.GET_AGENT, tools.get_agent),
     ("tinyplace_search", schemas.SEARCH, tools.search),
+    ("tinyplace_notifications", schemas.NOTIFICATIONS, tools.notifications),
+    (
+        "tinyplace_mark_notifications_read",
+        schemas.MARK_NOTIFICATIONS_READ,
+        tools.mark_notifications_read,
+    ),
 )
 
 

--- a/sdk/plugin-hermes/src/tinyplace/plugin.yaml
+++ b/sdk/plugin-hermes/src/tinyplace/plugin.yaml
@@ -14,6 +14,8 @@ provides_tools:
   - tinyplace_discover_agents
   - tinyplace_get_agent
   - tinyplace_search
+  - tinyplace_notifications
+  - tinyplace_mark_notifications_read
 requires_env:
   - name: TINYPLACE_AGENT_KEY
     description: >-

--- a/sdk/plugin-hermes/src/tinyplace/schemas.py
+++ b/sdk/plugin-hermes/src/tinyplace/schemas.py
@@ -192,3 +192,54 @@ SEARCH = {
         "required": ["query"],
     },
 }
+
+NOTIFICATIONS = {
+    "name": "tinyplace_notifications",
+    "description": (
+        "Check the agent's tiny.place notifications inbox — PLATFORM events such "
+        "as escrow updates, new followers, mentions, replies and group activity. "
+        "This is SEPARATE from tinyplace_poll_inbox, which reads encrypted "
+        "direct messages. By default returns unread items; pass 'status' to "
+        "change that and 'limit' to cap the count. The result includes the "
+        "inbox items and an unread count."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "string",
+                "description": (
+                    "Filter by triage state: 'unread' (default), 'read', "
+                    "'archived', or 'all'."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Optional maximum number of items to return.",
+            },
+        },
+        "required": [],
+    },
+}
+
+MARK_NOTIFICATIONS_READ = {
+    "name": "tinyplace_mark_notifications_read",
+    "description": (
+        "Mark tiny.place notification(s) as read. Provide an 'item_id' to mark "
+        "one notification read, or omit it to mark ALL unread notifications as "
+        "read. Use after reviewing items from tinyplace_notifications."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "item_id": {
+                "type": "string",
+                "description": (
+                    "Optional id of a single notification to mark read; omit to "
+                    "mark all unread notifications read."
+                ),
+            }
+        },
+        "required": [],
+    },
+}

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -320,6 +320,41 @@ def search(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     return _ok({"results": runtime.run(_run())})
 
 
+@_guard
+def notifications(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    params: dict[str, Any] = {}
+    status = args.get("status")
+    if isinstance(status, str) and status.strip():
+        params["status"] = status.strip()
+    limit = _coerce_limit(args.get("limit"))
+    if limit is not None:
+        params["limit"] = limit
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await client.inbox.list(params or None)
+
+    return _ok({"inbox": runtime.run(_run())})
+
+
+@_guard
+def mark_notifications_read(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    item = args.get("item_id")
+    item_id = item.strip() if isinstance(item, str) else ""
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        # A specific id marks that one read; omitting it marks the whole inbox.
+        if item_id:
+            return await client.inbox.mark_read(item_id)
+        return await client.inbox.mark_all_read()
+
+    result = runtime.run(_run())
+    return _ok({"scope": "item" if item_id else "all", "result": result})
+
+
 # --- helpers ----------------------------------------------------------------
 
 

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -323,17 +323,22 @@ def search(args: dict[str, Any], ctx: dict[str, Any]) -> str:
 @_guard
 def notifications(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     runtime: TinyPlaceRuntime = ctx["runtime"]
-    params: dict[str, Any] = {}
     status = args.get("status")
     if isinstance(status, str) and status.strip():
-        params["status"] = status.strip()
+        status = status.strip()
+    else:
+        # The schema advertises 'unread' as the default, but the backend's list
+        # default is broader (unread,read) — set it explicitly so a plain call
+        # doesn't keep re-surfacing already-read items.
+        status = "unread"
+    params: dict[str, Any] = {"status": status}
     limit = _coerce_limit(args.get("limit"))
     if limit is not None:
         params["limit"] = limit
 
     async def _run() -> Any:
         client = await runtime.get_client()
-        return await client.inbox.list(params or None)
+        return await _require_inbox(client).list(params)
 
     return _ok({"inbox": runtime.run(_run())})
 
@@ -341,21 +346,43 @@ def notifications(args: dict[str, Any], ctx: dict[str, Any]) -> str:
 @_guard
 def mark_notifications_read(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     runtime: TinyPlaceRuntime = ctx["runtime"]
+    # Distinguish "omitted" (mark all) from "provided but invalid" (an error) so
+    # a bad id can't silently fall through to marking the whole inbox read.
+    has_item_id = "item_id" in args
     item = args.get("item_id")
+    if has_item_id and (not isinstance(item, str) or not item.strip()):
+        return _error("'item_id' must be a non-empty string when provided")
     item_id = item.strip() if isinstance(item, str) else ""
 
     async def _run() -> Any:
         client = await runtime.get_client()
+        inbox = _require_inbox(client)
         # A specific id marks that one read; omitting it marks the whole inbox.
-        if item_id:
-            return await client.inbox.mark_read(item_id)
-        return await client.inbox.mark_all_read()
+        if has_item_id:
+            return await inbox.mark_read(item_id)
+        return await inbox.mark_all_read()
 
     result = runtime.run(_run())
-    return _ok({"scope": "item" if item_id else "all", "result": result})
+    return _ok({"scope": "item" if has_item_id else "all", "result": result})
 
 
 # --- helpers ----------------------------------------------------------------
+
+
+def _require_inbox(client: Any) -> Any:
+    """Return the SDK's inbox namespace, or a clear error if it's missing.
+
+    The notifications tools need a tiny.place Python SDK new enough to expose the
+    ``inbox`` namespace; surface an actionable message rather than a cryptic
+    ``AttributeError`` when an older SDK is installed.
+    """
+    inbox = getattr(client, "inbox", None)
+    if inbox is None:
+        raise RuntimeError(
+            "notifications need a tiny.place Python SDK that provides the 'inbox' "
+            "namespace; upgrade the installed SDK."
+        )
+    return inbox
 
 
 async def _resolve_address(runtime: TinyPlaceRuntime, to: str) -> str:

--- a/sdk/plugin-hermes/tests/test_notifications.py
+++ b/sdk/plugin-hermes/tests/test_notifications.py
@@ -1,0 +1,86 @@
+"""Notification handlers (platform inbox), returning valid JSON strings.
+
+Mirrors test_discovery.py: a fake ``TinyPlaceClient`` exposing an ``.inbox``
+namespace is injected into a real :class:`TinyPlaceRuntime`, and handlers are
+driven via the ``runtime=`` kwarg.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from conftest import config as cfg
+from conftest import runtime as runtime_mod
+from conftest import tools
+
+_SEED = base64.b64encode(bytes(range(32))).decode("ascii")
+
+
+class _FakeInbox:
+    def __init__(self) -> None:
+        self.list_params: object = "<unset>"
+        self.list_result = {
+            "items": [{"id": "n1", "type": "ESCROW_EVENT"}],
+            "unreadCount": 1,
+        }
+        self.mark_read_calls: list[str] = []
+        self.mark_all_calls = 0
+
+    async def list(self, params=None, owner=None):
+        self.list_params = params
+        return self.list_result
+
+    async def mark_read(self, item_id, owner=None):
+        self.mark_read_calls.append(item_id)
+        return {"ok": True, "id": item_id}
+
+    async def mark_all_read(self, params=None, owner=None):
+        self.mark_all_calls += 1
+        return {"updated": 7}
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.inbox = _FakeInbox()
+
+
+def _make_runtime(tmp_path: Path, monkeypatch) -> "runtime_mod.TinyPlaceRuntime":
+    monkeypatch.setenv(cfg.ENV_AGENT_KEY, _SEED)
+    monkeypatch.setenv(cfg.ENV_STATE_DIR, str(tmp_path))
+    rt = runtime_mod.load_runtime()
+    rt._client = _FakeClient()
+    rt._session = object()
+    rt._keys_ready = True
+    return rt
+
+
+def test_notifications_default_passes_no_params(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.notifications({}, runtime=rt))
+    assert out["ok"] is True
+    assert out["inbox"]["unreadCount"] == 1
+    assert rt._client.inbox.list_params is None
+
+
+def test_notifications_builds_filter_params(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    json.loads(tools.notifications({"status": "all", "limit": "5"}, runtime=rt))
+    assert rt._client.inbox.list_params == {"status": "all", "limit": 5}
+
+
+def test_mark_notifications_read_single(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.mark_notifications_read({"item_id": "n1"}, runtime=rt))
+    assert out["ok"] is True and out["scope"] == "item"
+    assert rt._client.inbox.mark_read_calls == ["n1"]
+    assert rt._client.inbox.mark_all_calls == 0
+
+
+def test_mark_notifications_read_all_when_no_id(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.mark_notifications_read({}, runtime=rt))
+    assert out["ok"] is True and out["scope"] == "all"
+    assert rt._client.inbox.mark_all_calls == 1
+    assert rt._client.inbox.mark_read_calls == []

--- a/sdk/plugin-hermes/tests/test_notifications.py
+++ b/sdk/plugin-hermes/tests/test_notifications.py
@@ -56,12 +56,13 @@ def _make_runtime(tmp_path: Path, monkeypatch) -> "runtime_mod.TinyPlaceRuntime"
     return rt
 
 
-def test_notifications_default_passes_no_params(tmp_path, monkeypatch):
+def test_notifications_defaults_to_unread(tmp_path, monkeypatch):
     rt = _make_runtime(tmp_path, monkeypatch)
     out = json.loads(tools.notifications({}, runtime=rt))
     assert out["ok"] is True
     assert out["inbox"]["unreadCount"] == 1
-    assert rt._client.inbox.list_params is None
+    # Omitting status defaults to unread explicitly (the backend default is broader).
+    assert rt._client.inbox.list_params == {"status": "unread"}
 
 
 def test_notifications_builds_filter_params(tmp_path, monkeypatch):
@@ -84,3 +85,22 @@ def test_mark_notifications_read_all_when_no_id(tmp_path, monkeypatch):
     assert out["ok"] is True and out["scope"] == "all"
     assert rt._client.inbox.mark_all_calls == 1
     assert rt._client.inbox.mark_read_calls == []
+
+
+def test_mark_notifications_read_rejects_blank_item_id(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    # A provided-but-blank item_id is an error, NOT a silent "mark all".
+    out = json.loads(tools.mark_notifications_read({"item_id": "  "}, runtime=rt))
+    assert out["ok"] is False and "item_id" in out["error"]
+    assert rt._client.inbox.mark_all_calls == 0
+    assert rt._client.inbox.mark_read_calls == []
+
+
+def test_notifications_errors_clearly_without_inbox_support(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    # An SDK that predates the inbox namespace -> actionable error, not AttributeError.
+    delattr(rt._client, "inbox")
+    out = json.loads(tools.notifications({}, runtime=rt))
+    assert out["ok"] is False
+    assert "AttributeError" not in out["error"]
+    assert "inbox" in out["error"]

--- a/sdk/plugin-hermes/tests/test_register.py
+++ b/sdk/plugin-hermes/tests/test_register.py
@@ -50,6 +50,8 @@ def test_all_tools_register():
         "tinyplace_discover_agents",
         "tinyplace_get_agent",
         "tinyplace_search",
+        "tinyplace_notifications",
+        "tinyplace_mark_notifications_read",
     ]
     for tool in ctx.tools:
         assert tool["toolset"] == "tinyplace"
@@ -81,6 +83,8 @@ def test_schemas_are_well_formed():
         schemas.DISCOVER_AGENTS,
         schemas.GET_AGENT,
         schemas.SEARCH,
+        schemas.NOTIFICATIONS,
+        schemas.MARK_NOTIFICATIONS_READ,
     ):
         assert set(schema) >= {"name", "description", "parameters"}
         assert schema["parameters"]["type"] == "object"


### PR DESCRIPTION
## What
Part 2 of 2 for Phase 2 / #95 — the **plugin layer**. Two tools so a Hermes agent can see and triage platform events (escrow updates, follows, mentions, group activity) — distinct from the encrypted DMs that `tinyplace_poll_inbox` handles:

- **`tinyplace_notifications`** → `inbox.list(...)` with `status` / `limit` filters; returns the items plus the unread count.
- **`tinyplace_mark_notifications_read`** → marks one item read (by `item_id`) or all unread notifications read.

## Changes (`sdk/plugin-hermes`)
- `tools.py` + `schemas.py` — the two handlers and their LLM-facing schemas.
- Registered in `__init__.py` + `plugin.yaml`; README/DEMO updated.
- `test_notifications.py` (param building, single-vs-all marking) + `test_register.py` updated. **43 plugin tests pass.**

## Depends on
⚠️ **#105** (the SDK's `InboxApi`). Merge #105 first — at runtime this calls `client.inbox.*`. Plugin tests inject a fake client, so CI is green independently.

Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform notification inbox tools to list notifications (with status filtering and unread-by-default) and mark notifications as read individually or all unread at once.

* **Documentation**
  * Updated the Hermes plugin README and demo/runbook with new notification tool usage and a “Stay on top of platform activity” step (including example commands).

* **Tests**
  * Added/expanded tests to verify default filtering, parameter handling, mark-read behavior, and clear error responses when notification inbox support is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->