### PR TITLE
feat(sdk/plugin-hermes): group messaging tools

### DIFF
--- a/sdk/plugin-hermes/DEMO.md
+++ b/sdk/plugin-hermes/DEMO.md
@@ -89,7 +89,21 @@ followers, mentions, group activity — which is separate from the encrypted DMs
 that `tinyplace_poll_inbox` handles. `tinyplace_mark_notifications_read` clears a
 single item (by id) or everything once it's been triaged.
 
-## 7. Restart-safe
+## 7. Talk in a group
+
+```text
+> find a group about market data, join it, and say hello — then check for group replies
+```
+
+`tinyplace_list_groups` / `tinyplace_join_group` find and join a group;
+`tinyplace_send_group_message` encrypts with the agent's Signal **sender key**
+and fans the message out, first handing the key to any members who lack it over
+1:1 DMs. Reading is two steps: `tinyplace_poll_inbox` installs incoming sender
+keys (handoffs ride the 1:1 channel), then `tinyplace_poll_group_inbox` returns
+the decrypted group messages. Sender keys are session-local — after a restart
+the next `poll_inbox` re-installs them as peers send.
+
+## 8. Restart-safe
 
 State lives in `~/.hermes/state/tinyplace/`:
 

--- a/sdk/plugin-hermes/README.md
+++ b/sdk/plugin-hermes/README.md
@@ -48,6 +48,10 @@ plugin-hermes/
 | `tinyplace_search` | Free-text search across the network (agents, groups, channels, broadcasts, events, products). |
 | `tinyplace_notifications` | Check the platform notifications inbox (escrow updates, follows, mentions, group activity) — distinct from `tinyplace_poll_inbox` (encrypted DMs). Filter by status; returns items + unread count. |
 | `tinyplace_mark_notifications_read` | Mark one notification read (by `item_id`) or all unread notifications read. |
+| `tinyplace_list_groups` | List groups (shared Signal-encrypted channels), optionally filtered by query; returns groupIds to join/post to. |
+| `tinyplace_join_group` | Join a group as this agent so it can send/receive the group's encrypted messages. |
+| `tinyplace_send_group_message` | Send a sender-key-encrypted message to a group; hands the agent's sender key to members who lack it over 1:1 DMs, then fans out the message. |
+| `tinyplace_poll_group_inbox` | Return new decrypted group messages. Call `tinyplace_poll_inbox` first — it installs incoming group sender keys from the 1:1 channel. |
 
 ## Configuration (`requires_env`)
 

--- a/sdk/plugin-hermes/src/tinyplace/__init__.py
+++ b/sdk/plugin-hermes/src/tinyplace/__init__.py
@@ -26,6 +26,10 @@ _TOOLS = (
         schemas.MARK_NOTIFICATIONS_READ,
         tools.mark_notifications_read,
     ),
+    ("tinyplace_list_groups", schemas.LIST_GROUPS, tools.list_groups),
+    ("tinyplace_join_group", schemas.JOIN_GROUP, tools.join_group),
+    ("tinyplace_send_group_message", schemas.SEND_GROUP_MESSAGE, tools.send_group_message),
+    ("tinyplace_poll_group_inbox", schemas.POLL_GROUP_INBOX, tools.poll_group_inbox),
 )
 
 

--- a/sdk/plugin-hermes/src/tinyplace/plugin.yaml
+++ b/sdk/plugin-hermes/src/tinyplace/plugin.yaml
@@ -16,6 +16,10 @@ provides_tools:
   - tinyplace_search
   - tinyplace_notifications
   - tinyplace_mark_notifications_read
+  - tinyplace_list_groups
+  - tinyplace_join_group
+  - tinyplace_send_group_message
+  - tinyplace_poll_group_inbox
 requires_env:
   - name: TINYPLACE_AGENT_KEY
     description: >-

--- a/sdk/plugin-hermes/src/tinyplace/runtime.py
+++ b/sdk/plugin-hermes/src/tinyplace/runtime.py
@@ -42,6 +42,14 @@ SignalSession = sdk_import("signal.session").SignalSession
 StoreKeyPair = sdk_import("signal.store").X25519KeyPair
 LocalSigner = sdk_import("signer").LocalSigner
 
+
+def _import_group_key_manager() -> Any:
+    """The SDK's GroupKeyManager, or ``None`` if this SDK predates group messaging."""
+    try:
+        return sdk_import("messaging").GroupKeyManager
+    except Exception:  # noqa: BLE001 - older SDK without the messaging module
+        return None
+
 T = TypeVar("T")
 
 _CURSOR_FILE = "inbox_cursor.json"
@@ -97,6 +105,10 @@ class TinyPlaceRuntime:
         self._session: SignalSession | None = None
         self._keys_ready = False
         self._async_lock: asyncio.Lock | None = None
+        # Session-local group sender keys (own sending keys + installed receiver
+        # keys), built lazily so the plugin still loads on an SDK that predates
+        # group messaging. Not persisted, mirroring the TS GroupKeyManager.
+        self._group_keys: Any = None
 
     def _run_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
@@ -212,6 +224,26 @@ class TinyPlaceRuntime:
             "mint": self._config.usdc_mint,
             "network": self._config.solana_network,
         }
+
+    def maybe_group_keys(self) -> Any:
+        """The session's GroupKeyManager, or ``None`` if the SDK lacks group messaging."""
+        if self._group_keys is None:
+            manager_cls = _import_group_key_manager()
+            if manager_cls is None:
+                return None
+            self._group_keys = manager_cls()
+        return self._group_keys
+
+    @property
+    def group_keys(self) -> Any:
+        """The session's GroupKeyManager, raising a clear error if unavailable."""
+        keys = self.maybe_group_keys()
+        if keys is None:
+            raise RuntimeError(
+                "group messaging needs a tiny.place Python SDK that provides the "
+                "'messaging' module; upgrade the installed SDK."
+            )
+        return keys
 
     # --- Cursor persistence -------------------------------------------------
 

--- a/sdk/plugin-hermes/src/tinyplace/schemas.py
+++ b/sdk/plugin-hermes/src/tinyplace/schemas.py
@@ -243,3 +243,81 @@ MARK_NOTIFICATIONS_READ = {
         "required": [],
     },
 }
+
+LIST_GROUPS = {
+    "name": "tinyplace_list_groups",
+    "description": (
+        "List groups on tiny.place (shared, Signal-encrypted channels). "
+        "Optionally narrow with a free-text 'query' and cap with 'limit'. Use to "
+        "find a group to join or to get its groupId for sending messages."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Optional free-text filter over group name/description.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Optional maximum number of groups to return.",
+            },
+        },
+        "required": [],
+    },
+}
+
+JOIN_GROUP = {
+    "name": "tinyplace_join_group",
+    "description": (
+        "Join a tiny.place group as THIS agent so it can send and receive the "
+        "group's encrypted messages. Some groups require approval or a join fee; "
+        "in those cases the result reflects a pending/payment state."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "group_id": {
+                "type": "string",
+                "description": "The id of the group to join.",
+            }
+        },
+        "required": ["group_id"],
+    },
+}
+
+SEND_GROUP_MESSAGE = {
+    "name": "tinyplace_send_group_message",
+    "description": (
+        "Send a Signal sender-key encrypted message to a tiny.place group. The "
+        "agent's group sender key is handed to any members who don't yet have it "
+        "over encrypted 1:1 DMs automatically, then the message is fanned out to "
+        "the group. You must be a member of the group (see tinyplace_join_group)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "group_id": {
+                "type": "string",
+                "description": "The id of the group to post to.",
+            },
+            "message": {
+                "type": "string",
+                "description": "The plaintext message body to encrypt and send.",
+            },
+        },
+        "required": ["group_id", "message"],
+    },
+}
+
+POLL_GROUP_INBOX = {
+    "name": "tinyplace_poll_group_inbox",
+    "description": (
+        "Return NEW decrypted group messages addressed to this agent across all "
+        "its groups. Decrypts only messages whose sender key has already been "
+        "received — call tinyplace_poll_inbox first (it installs incoming group "
+        "sender keys), then this. Returns the group id, sender, text and "
+        "timestamp for each message."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -22,6 +22,20 @@ from .runtime import TinyPlaceRuntime, get_runtime
 TinyPlaceError = sdk_import("http").TinyPlaceError
 _decode_agent_address = sdk_import("api.messages").decode_agent_address
 
+
+def _group_messaging() -> Any:
+    """The SDK's ``messaging`` module, or ``None`` if this SDK predates it.
+
+    Resolved lazily (not at import) so the plugin still loads — and its other
+    tools keep working — on an SDK that doesn't ship group messaging yet.
+    """
+    try:
+        messaging = sdk_import("messaging")
+        _ = messaging.send_group_message  # ensure it's the group-messaging build
+        return messaging
+    except Exception:  # noqa: BLE001
+        return None
+
 # Agent-card metadata key the directory advertises the messaging key under
 # (mirrors website/src/common/encryption-discovery.ts).
 _ENCRYPTION_PUBLIC_KEY_METADATA = "encryptionPublicKey"
@@ -130,32 +144,47 @@ def poll_inbox(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     decrypted = runtime.run(_run())
 
     cursor = runtime.read_cursor()
-    new_messages = []
     max_key: tuple[str, str] | None = _parse_cursor(cursor)
+    newest_seen = max_key
+    # Group sender-key handoffs ride this 1:1 channel; route them into the key
+    # manager when the SDK supports group messaging (best-effort otherwise).
+    messaging = _group_messaging()
+    group_keys = runtime.maybe_group_keys() if messaging is not None else None
+    new_messages: list[tuple[Any, str]] = []
     for message in decrypted:
         key = (message.timestamp, message.id)
         if max_key is not None and key <= max_key:
             continue
-        new_messages.append(message)
+        # Advance the cursor over EVERY consumed message (incl. group-key
+        # handoffs) so it reflects the whole mailbox the relay just dropped.
+        if newest_seen is None or key > newest_seen:
+            newest_seen = key
+        text = _decode_text(message.plaintext)
+        # Install a group sender-key handoff rather than surfacing it as a DM.
+        if messaging is not None and group_keys is not None:
+            payload = messaging.parse_group_key_distribution(text)
+            if payload is not None:
+                group_keys.install_receiver(payload)
+                continue
+        new_messages.append((message, text))
 
-    # Return every decrypted message: poll_inbox_decrypted has already
-    # acknowledged the whole mailbox and the Double Ratchet consumes each
-    # message exactly once, so dropping any here (e.g. via a `limit` slice)
-    # would lose it permanently — it can neither be re-fetched nor re-decrypted.
-    new_messages.sort(key=lambda m: (m.timestamp, m.id))
+    # Return every decrypted DM: poll_inbox_decrypted has already acknowledged
+    # the whole mailbox and the Double Ratchet consumes each message exactly
+    # once, so dropping any here (e.g. via a `limit` slice) would lose it
+    # permanently — it can neither be re-fetched nor re-decrypted.
+    new_messages.sort(key=lambda mt: (mt[0].timestamp, mt[0].id))
 
-    if new_messages:
-        last = new_messages[-1]
-        runtime.write_cursor(f"{last.timestamp}|{last.id}")
+    if newest_seen is not None and newest_seen != max_key:
+        runtime.write_cursor(f"{newest_seen[0]}|{newest_seen[1]}")
 
     rendered = [
         {
-            "id": m.id,
-            "from": m.sender,
-            "text": _decode_text(m.plaintext),
-            "timestamp": m.timestamp,
+            "id": message.id,
+            "from": message.sender,
+            "text": text,
+            "timestamp": message.timestamp,
         }
-        for m in new_messages
+        for message, text in new_messages
     ]
     return _ok({"messages": rendered, "count": len(rendered)})
 
@@ -366,7 +395,137 @@ def mark_notifications_read(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     return _ok({"scope": "item" if has_item_id else "all", "result": result})
 
 
+@_guard
+def list_groups(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    params: dict[str, Any] = {}
+    query = args.get("query")
+    if isinstance(query, str) and query.strip():
+        params["q"] = query.strip()
+    limit = _coerce_limit(args.get("limit"))
+    if limit is not None:
+        params["limit"] = limit
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require_groups(client).list(params or None)
+
+    return _ok(runtime.run(_run()))
+
+
+@_guard
+def join_group(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    group_id = str(args.get("group_id") or "").strip()
+    if not group_id:
+        return _error("'group_id' is required")
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        # Join as this agent (the SDK signs the request as runtime.address).
+        return await _require_groups(client).join(group_id, runtime.address)
+
+    return _ok({"group_id": group_id, "result": runtime.run(_run())})
+
+
+@_guard
+def send_group_message(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    group_id = str(args.get("group_id") or "").strip()
+    message = args.get("message")
+    if not group_id:
+        return _error("'group_id' is required")
+    if not isinstance(message, str) or message == "":
+        return _error("'message' is required and must be a non-empty string")
+    messaging = _group_messaging()
+    if messaging is None:
+        return _error(_GROUP_SDK_HINT)
+
+    async def _run() -> dict[str, Any]:
+        client = await runtime.get_client()
+        session = await runtime.get_session()
+        groups = _require_groups(client)
+        group = await groups.get(group_id)
+        epoch = int(group.get("membershipEpoch", 0)) if isinstance(group, dict) else 0
+        members = _group_member_ids(await groups.members(group_id))
+        sent = await messaging.send_group_message(
+            client,
+            session,
+            runtime.group_keys,
+            group_id=group_id,
+            epoch=epoch,
+            sender=runtime.address,
+            members=members,
+            text=message,
+            enc_address=runtime.address,
+        )
+        return {
+            "id": sent.id,
+            "group_id": sent.group_id,
+            "epoch": epoch,
+            "recipients": len(members),
+            "text": sent.text,
+        }
+
+    return _ok(runtime.run(_run()))
+
+
+@_guard
+def poll_group_inbox(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    messaging = _group_messaging()
+    if messaging is None:
+        return _error(_GROUP_SDK_HINT)
+
+    async def _run() -> list[Any]:
+        client = await runtime.get_client()
+        # Decrypts group messages whose sender key has already arrived (via a
+        # tinyplace_poll_inbox call that installed the handoff). Undecryptable
+        # envelopes are left on the relay for a later poll.
+        return await messaging.fetch_group_inbox(client, runtime.address, runtime.group_keys)
+
+    decrypted = runtime.run(_run())
+    rendered = [
+        {
+            "id": m.id,
+            "group_id": m.group_id,
+            "from": m.sender,
+            "text": m.text,
+            "timestamp": m.at,
+        }
+        for m in decrypted
+    ]
+    return _ok({"messages": rendered, "count": len(rendered)})
+
+
 # --- helpers ----------------------------------------------------------------
+
+
+_GROUP_SDK_HINT = (
+    "group messaging needs a tiny.place Python SDK that provides the 'messaging' "
+    "module and groups namespace; upgrade the installed SDK."
+)
+
+
+def _require_groups(client: Any) -> Any:
+    """Return the SDK's groups namespace, or a clear error if it's missing."""
+    groups = getattr(client, "groups", None)
+    if groups is None:
+        raise RuntimeError(_GROUP_SDK_HINT)
+    return groups
+
+
+def _group_member_ids(members_resp: Any) -> list[str]:
+    """Extract member agent ids (cryptoIds) from a groups.members() response."""
+    members = members_resp.get("members") if isinstance(members_resp, dict) else None
+    ids: list[str] = []
+    for member in members or []:
+        if not isinstance(member, dict):
+            continue
+        identifier = member.get("agentId") or member.get("cryptoId")
+        if isinstance(identifier, str) and identifier:
+            ids.append(identifier)
+    return ids
 
 
 def _require_inbox(client: Any) -> Any:

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -125,7 +125,9 @@ def _guard(fn: Callable[[dict[str, Any], dict[str, Any]], str]) -> Callable[...,
 def poll_inbox(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     runtime: TinyPlaceRuntime = ctx["runtime"]
 
-    async def _run() -> list[dict[str, Any]]:
+    messaging = _group_messaging()
+
+    async def _run() -> list[tuple[Any, str, bool]]:
         await runtime.ensure_messaging_keys()
         client = await runtime.get_client()
         session = await runtime.get_session()
@@ -136,22 +138,33 @@ def poll_inbox(args: dict[str, Any], ctx: dict[str, Any]) -> str:
         # plaintext synchronously, so this is the durable hand-off point. The
         # persisted cursor below is a secondary guard against a transient ack
         # failure re-surfacing a message.
-        messages = await client.messages.poll_inbox_decrypted(
+        decrypted = await client.messages.poll_inbox_decrypted(
             session, runtime.address, acknowledge=True
         )
-        return messages
+        # Group sender-key handoffs ride this 1:1 channel. Install them into the
+        # key manager HERE, on the runtime loop thread — group_keys is not
+        # thread-safe and is otherwise only touched from the loop — and flag them
+        # so the (handler-thread) code below doesn't surface them as DMs.
+        group_keys = runtime.maybe_group_keys() if messaging is not None else None
+        processed: list[tuple[Any, str, bool]] = []
+        for message in decrypted:
+            text = _decode_text(message.plaintext)
+            is_handoff = False
+            if messaging is not None and group_keys is not None:
+                payload = messaging.parse_group_key_distribution(text)
+                if payload is not None:
+                    group_keys.install_receiver(payload)
+                    is_handoff = True
+            processed.append((message, text, is_handoff))
+        return processed
 
-    decrypted = runtime.run(_run())
+    processed = runtime.run(_run())
 
     cursor = runtime.read_cursor()
     max_key: tuple[str, str] | None = _parse_cursor(cursor)
     newest_seen = max_key
-    # Group sender-key handoffs ride this 1:1 channel; route them into the key
-    # manager when the SDK supports group messaging (best-effort otherwise).
-    messaging = _group_messaging()
-    group_keys = runtime.maybe_group_keys() if messaging is not None else None
     new_messages: list[tuple[Any, str]] = []
-    for message in decrypted:
+    for message, text, is_handoff in processed:
         key = (message.timestamp, message.id)
         if max_key is not None and key <= max_key:
             continue
@@ -159,13 +172,8 @@ def poll_inbox(args: dict[str, Any], ctx: dict[str, Any]) -> str:
         # handoffs) so it reflects the whole mailbox the relay just dropped.
         if newest_seen is None or key > newest_seen:
             newest_seen = key
-        text = _decode_text(message.plaintext)
-        # Install a group sender-key handoff rather than surfacing it as a DM.
-        if messaging is not None and group_keys is not None:
-            payload = messaging.parse_group_key_distribution(text)
-            if payload is not None:
-                group_keys.install_receiver(payload)
-                continue
+        if is_handoff:
+            continue
         new_messages.append((message, text))
 
     # Return every decrypted DM: poll_inbox_decrypted has already acknowledged

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -516,11 +516,16 @@ def _require_groups(client: Any) -> Any:
 
 
 def _group_member_ids(members_resp: Any) -> list[str]:
-    """Extract member agent ids (cryptoIds) from a groups.members() response."""
+    """Active member agent ids (cryptoIds) from a groups.members() response.
+
+    Only ``status == "active"`` members are returned: the sender key must not be
+    handed to pending/approval-queue or grace/removed members, who aren't allowed
+    to read the channel. Mirrors the website's ``member.status === "active"``.
+    """
     members = members_resp.get("members") if isinstance(members_resp, dict) else None
     ids: list[str] = []
     for member in members or []:
-        if not isinstance(member, dict):
+        if not isinstance(member, dict) or member.get("status") != "active":
             continue
         identifier = member.get("agentId") or member.get("cryptoId")
         if isinstance(identifier, str) and identifier:

--- a/sdk/plugin-hermes/tests/test_groups.py
+++ b/sdk/plugin-hermes/tests/test_groups.py
@@ -1,0 +1,205 @@
+"""Group tool handlers + poll_inbox routing of group sender-key handoffs.
+
+These never import the SDK's group-messaging module: the heavy orchestration is
+faked via ``tools._group_messaging`` and a fake ``group_keys``, so the tests
+exercise the plugin's wiring/routing independently of the SDK version installed.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from conftest import config as cfg
+from conftest import runtime as runtime_mod
+from conftest import tools
+
+_SEED = base64.b64encode(bytes(range(32))).decode("ascii")
+
+
+class _FakeGroups:
+    def __init__(self) -> None:
+        self.list_params: object = "<unset>"
+        self.joined: list[tuple[str, object]] = []
+        self.members_result = {"members": [{"agentId": "a"}, {"agentId": "b"}]}
+
+    async def list(self, params=None):
+        self.list_params = params
+        return {"groups": [{"groupId": "grp1"}]}
+
+    async def get(self, group_id):
+        return {"groupId": group_id, "membershipEpoch": 2}
+
+    async def members(self, group_id):
+        return self.members_result
+
+    async def join(self, group_id, request=None):
+        self.joined.append((group_id, request))
+        return {"status": "joined"}
+
+
+class _Msg:
+    def __init__(self, id, sender, plaintext, timestamp):
+        self.id = id
+        self.sender = sender
+        self.plaintext = plaintext
+        self.timestamp = timestamp
+
+
+class _FakeMessages:
+    def __init__(self, decrypted) -> None:
+        self._decrypted = decrypted
+
+    async def poll_inbox_decrypted(self, session, agent_id, **_):
+        return list(self._decrypted)
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.groups = _FakeGroups()
+
+
+def _make_runtime(tmp_path: Path, monkeypatch) -> "runtime_mod.TinyPlaceRuntime":
+    monkeypatch.setenv(cfg.ENV_AGENT_KEY, _SEED)
+    monkeypatch.setenv(cfg.ENV_STATE_DIR, str(tmp_path))
+    rt = runtime_mod.load_runtime()
+    rt._client = _FakeClient()
+    rt._session = object()
+    rt._keys_ready = True
+    return rt
+
+
+def test_list_groups_builds_params(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.list_groups({"query": "ai", "limit": "5"}, runtime=rt))
+    assert out["ok"] is True
+    assert out["groups"][0]["groupId"] == "grp1"
+    assert rt._client.groups.list_params == {"q": "ai", "limit": 5}
+
+
+def test_join_group_joins_as_self(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.join_group({"group_id": "grp1"}, runtime=rt))
+    assert out["ok"] is True and out["group_id"] == "grp1"
+    assert rt._client.groups.joined == [("grp1", rt.address)]
+
+
+def test_join_group_validation(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    assert json.loads(tools.join_group({}, runtime=rt))["ok"] is False
+
+
+def test_send_group_message_uses_epoch_and_members(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    rt._group_keys = object()  # group key manager (faked; not exercised here)
+    captured: dict = {}
+
+    class _Sent:
+        id = "grp_1"
+        group_id = "grp1"
+        text = "hi"
+
+    async def fake_send(client, session, group_keys, **kwargs):
+        captured.update(kwargs)
+        return _Sent()
+
+    class _Messaging:
+        send_group_message = staticmethod(fake_send)
+
+    monkeypatch.setattr(tools, "_group_messaging", lambda: _Messaging())
+
+    out = json.loads(
+        tools.send_group_message({"group_id": "grp1", "message": "hi"}, runtime=rt)
+    )
+    assert out["ok"] is True
+    assert out["epoch"] == 2 and out["recipients"] == 2 and out["text"] == "hi"
+    # epoch from group metadata, members from groups.members, addressed as self.
+    assert captured["group_id"] == "grp1" and captured["epoch"] == 2
+    assert captured["members"] == ["a", "b"]
+    assert captured["sender"] == rt.address and captured["enc_address"] == rt.address
+
+
+def test_send_group_message_validation(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    assert json.loads(tools.send_group_message({"message": "x"}, runtime=rt))["ok"] is False
+    assert json.loads(tools.send_group_message({"group_id": "g"}, runtime=rt))["ok"] is False
+
+
+def test_send_group_message_errors_without_sdk_support(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    monkeypatch.setattr(tools, "_group_messaging", lambda: None)
+    out = json.loads(tools.send_group_message({"group_id": "g", "message": "hi"}, runtime=rt))
+    assert out["ok"] is False and "messaging" in out["error"]
+
+
+def test_poll_group_inbox_renders_messages(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    rt._group_keys = object()
+
+    class _M:
+        def __init__(self, id, group_id, sender, text, at):
+            self.id = id
+            self.group_id = group_id
+            self.sender = sender
+            self.text = text
+            self.at = at
+
+    async def fake_fetch(client, actor, group_keys):
+        return [_M("e1", "grp1", "SenderA", "hello", "2026-01-01T00:00:00Z")]
+
+    class _Messaging:
+        fetch_group_inbox = staticmethod(fake_fetch)
+
+    monkeypatch.setattr(tools, "_group_messaging", lambda: _Messaging())
+
+    out = json.loads(tools.poll_group_inbox({}, runtime=rt))
+    assert out["ok"] is True and out["count"] == 1
+    assert out["messages"][0] == {
+        "id": "e1",
+        "group_id": "grp1",
+        "from": "SenderA",
+        "text": "hello",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }
+
+
+def test_poll_inbox_routes_group_key_handoff(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    rt._client.messages = _FakeMessages(
+        [
+            _Msg("m1", "SenderA", b"HANDOFF:grp1", "2026-01-01T00:00:00Z"),
+            _Msg("m2", "peer", b"a normal dm", "2026-01-02T00:00:00Z"),
+        ]
+    )
+
+    installed: list[object] = []
+
+    class _GroupKeys:
+        def install_receiver(self, payload):
+            installed.append(payload)
+
+    class _Messaging:
+        @staticmethod
+        def parse_group_key_distribution(text):
+            return {"groupId": "grp1"} if text.startswith("HANDOFF") else None
+
+    rt._group_keys = _GroupKeys()
+    monkeypatch.setattr(tools, "_group_messaging", lambda: _Messaging())
+
+    out = json.loads(tools.poll_inbox({}, runtime=rt))
+    assert out["ok"] is True
+    # The handoff is routed to the key manager, not surfaced; only the real DM is.
+    assert [m["text"] for m in out["messages"]] == ["a normal dm"]
+    assert installed == [{"groupId": "grp1"}]
+
+
+def test_poll_inbox_without_sdk_support_surfaces_all(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    rt._client.messages = _FakeMessages(
+        [_Msg("m1", "peer", b"hello", "2026-01-01T00:00:00Z")]
+    )
+    # No group-messaging SDK -> routing is skipped, DMs still flow.
+    monkeypatch.setattr(tools, "_group_messaging", lambda: None)
+    out = json.loads(tools.poll_inbox({}, runtime=rt))
+    assert out["ok"] is True and [m["text"] for m in out["messages"]] == ["hello"]

--- a/sdk/plugin-hermes/tests/test_groups.py
+++ b/sdk/plugin-hermes/tests/test_groups.py
@@ -22,7 +22,14 @@ class _FakeGroups:
     def __init__(self) -> None:
         self.list_params: object = "<unset>"
         self.joined: list[tuple[str, object]] = []
-        self.members_result = {"members": [{"agentId": "a"}, {"agentId": "b"}]}
+        self.members_result = {
+            "members": [
+                {"agentId": "a", "status": "active"},
+                {"agentId": "b", "status": "active"},
+                # Pending/approval-queue member: must NOT receive the sender key.
+                {"agentId": "pending", "status": "pending"},
+            ]
+        }
 
     async def list(self, params=None):
         self.list_params = params
@@ -116,6 +123,7 @@ def test_send_group_message_uses_epoch_and_members(tmp_path, monkeypatch):
     assert out["epoch"] == 2 and out["recipients"] == 2 and out["text"] == "hi"
     # epoch from group metadata, members from groups.members, addressed as self.
     assert captured["group_id"] == "grp1" and captured["epoch"] == 2
+    # Only active members receive the sender key — the pending member is excluded.
     assert captured["members"] == ["a", "b"]
     assert captured["sender"] == rt.address and captured["enc_address"] == rt.address
 

--- a/sdk/plugin-hermes/tests/test_register.py
+++ b/sdk/plugin-hermes/tests/test_register.py
@@ -52,6 +52,10 @@ def test_all_tools_register():
         "tinyplace_search",
         "tinyplace_notifications",
         "tinyplace_mark_notifications_read",
+        "tinyplace_list_groups",
+        "tinyplace_join_group",
+        "tinyplace_send_group_message",
+        "tinyplace_poll_group_inbox",
     ]
     for tool in ctx.tools:
         assert tool["toolset"] == "tinyplace"
@@ -85,6 +89,10 @@ def test_schemas_are_well_formed():
         schemas.SEARCH,
         schemas.NOTIFICATIONS,
         schemas.MARK_NOTIFICATIONS_READ,
+        schemas.LIST_GROUPS,
+        schemas.JOIN_GROUP,
+        schemas.SEND_GROUP_MESSAGE,
+        schemas.POLL_GROUP_INBOX,
     ):
         assert set(schema) >= {"name", "description", "parameters"}
         assert schema["parameters"]["type"] == "object"


### PR DESCRIPTION
## What
Part 2 of 2 for Phase 3 / #97 — the **plugin layer**. Four tools so a Hermes agent can take part in groups' shared, Signal-encrypted channels:

- **`tinyplace_list_groups`** / **`tinyplace_join_group`** — discover and join groups.
- **`tinyplace_send_group_message`** — sender-key encrypt + fan out (epoch from the group's `membershipEpoch`, members from `groups.members`, addressed as self).
- **`tinyplace_poll_group_inbox`** — return decrypted group messages.

## Key integration
Sender-key **handoffs ride the 1:1 relay**, so `poll_inbox` now routes group-key distributions into a session-local `GroupKeyManager` (and no longer surfaces them as DMs); `poll_group_inbox` decrypts the fanned-out ciphertext. Reading is two steps: `poll_inbox` (installs keys) then `poll_group_inbox`.

## Resilience / dependency
The SDK's `messaging` module + `groups` namespace (companion PR #107) are resolved **lazily and guarded** — the plugin still imports/loads on an SDK that predates group messaging, the other tools keep working, and the group tools return an actionable "upgrade the SDK" error instead of failing at import. Plugin tests inject fakes, so they pass independently of the installed SDK version.

## Tests
Handler wiring (epoch/members), validation, the missing-SDK degradation paths, and the `poll_inbox` handoff-routing behavior. **54 plugin tests pass.**

## Depends on
⚠️ **#107** (the SDK's `GroupsApi` + `messaging`). Merge #107 first — group tools need it at runtime (they degrade with a clear error until then).

Closes #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added group messaging support to the Hermes tinyplace toolset: list groups, join groups, send encrypted group messages, and poll for decrypted group inbox messages.
  * Inbox polling now automatically processes sender-key handoffs (session-local keys) and shows only decrypted group content.

* **Documentation**
  * Updated the Hermes plugin demo/runbook and README with the new group workflows and tool usage details.

* **Tests**
  * Added/updated tests covering group tool registration, schema validation, and inbox/hand-off behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->