### PR TITLE
feat(sdk/python): commerce namespaces (jobs, escrow, marketplace)

### DIFF
--- a/sdk/python/src/tinyplace/api/__init__.py
+++ b/sdk/python/src/tinyplace/api/__init__.py
@@ -1,8 +1,11 @@
 from .directory import DirectoryApi
 from .docs import DocsApi
+from .escrow import EscrowApi
 from .groups import GroupsApi
 from .inbox import InboxApi
+from .jobs import JobsApi
 from .keys import KeysApi
+from .marketplace import MarketplaceApi
 from .messages import InboxPage, MessagesApi
 from .payments import PaymentsApi
 from .registry import RegistryApi
@@ -11,10 +14,13 @@ from .search import SearchApi
 __all__ = [
     "DirectoryApi",
     "DocsApi",
+    "EscrowApi",
     "GroupsApi",
     "InboxApi",
     "InboxPage",
+    "JobsApi",
     "KeysApi",
+    "MarketplaceApi",
     "MessagesApi",
     "PaymentsApi",
     "RegistryApi",

--- a/sdk/python/src/tinyplace/api/escrow.py
+++ b/sdk/python/src/tinyplace/api/escrow.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..http import HttpClient, encode
+from ..types import Json, JsonDict, Query
+
+
+class EscrowApi:
+    """Job escrow lifecycle: create, accept, deliver, accept-delivery, claim,
+    revisions, deadline extensions, disputes (mediation/arbitration) and
+    milestones. Mirrors the TS SDK's ``EscrowApi``.
+
+    Reads use signed (own) auth. Mutations are signed on behalf of ``actor`` when
+    given (directory auth as that agent), else as the configured signer.
+    """
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    async def list(self, params: Query = None) -> JsonDict:
+        return await self._http.get_auth("/escrow", params)
+
+    async def create(self, request: JsonDict) -> Json:
+        return await self._http.post_directory_auth_as(
+            "/escrow", str(request["client"]), request
+        )
+
+    async def get(self, escrow_id: str) -> Json:
+        return await self._http.get_auth(f"/escrow/{encode(escrow_id)}")
+
+    async def accept(self, escrow_id: str, actor: str | None = None) -> Json:
+        return await self._post_actor(f"/escrow/{encode(escrow_id)}/accept", actor)
+
+    async def deliver(self, escrow_id: str, proof: JsonDict) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/deliver", proof.get("actor"), proof
+        )
+
+    async def accept_delivery(
+        self, escrow_id: str, actor: str | None = None, on_chain_tx: str | None = None
+    ) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/accept-delivery",
+            actor,
+            {"onChainTx": on_chain_tx} if on_chain_tx else None,
+        )
+
+    async def claim_release(
+        self, escrow_id: str, actor: str | None = None, on_chain_tx: str | None = None
+    ) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/claim-release",
+            actor,
+            {"onChainTx": on_chain_tx} if on_chain_tx else None,
+        )
+
+    async def claim_refund(
+        self, escrow_id: str, actor: str | None = None, on_chain_tx: str | None = None
+    ) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/claim-refund",
+            actor,
+            {"onChainTx": on_chain_tx} if on_chain_tx else None,
+        )
+
+    async def request_revision(self, escrow_id: str, reason: str, actor: str | None = None) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/request-revision", actor, {"reason": reason}
+        )
+
+    async def cancel(
+        self, escrow_id: str, actor: str | None = None, on_chain_tx: str | None = None
+    ) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/cancel",
+            actor,
+            {"onChainTx": on_chain_tx} if on_chain_tx else None,
+        )
+
+    async def extend_deadline(self, escrow_id: str, new_deadline: str, actor: str | None = None) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/extend-deadline", actor, {"deadline": new_deadline}
+        )
+
+    async def approve_extension(self, escrow_id: str, actor: str | None = None) -> Json:
+        return await self._post_actor(f"/escrow/{encode(escrow_id)}/approve-extension", actor)
+
+    # --- Disputes ---
+
+    async def open_dispute(self, escrow_id: str, reason: str, actor: str | None = None) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/dispute", actor, {"reason": reason}
+        )
+
+    async def get_dispute(self, escrow_id: str) -> Json:
+        return await self._http.get_auth(f"/escrow/{encode(escrow_id)}/dispute")
+
+    async def submit_evidence(self, escrow_id: str, evidence: JsonDict) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/dispute/evidence", evidence.get("actor"), evidence
+        )
+
+    async def accept_mediation(self, escrow_id: str, actor: str | None = None) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/dispute/accept-mediation", actor
+        )
+
+    async def reject_mediation(self, escrow_id: str, actor: str | None = None) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/dispute/reject-mediation", actor
+        )
+
+    async def pay_arbitration(self, escrow_id: str, on_chain_tx: str, actor: str | None = None) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/dispute/pay-arbitration", actor, {"onChainTx": on_chain_tx}
+        )
+
+    async def vote_arbitration(self, escrow_id: str, vote: JsonDict) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/dispute/vote",
+            vote.get("actor") or vote.get("councilMember"),
+            vote,
+        )
+
+    # --- Milestones ---
+
+    async def deliver_milestone(self, escrow_id: str, milestone_id: str, proof: JsonDict) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/milestones/{encode(milestone_id)}/deliver",
+            proof.get("actor"),
+            proof,
+        )
+
+    async def accept_milestone_delivery(
+        self, escrow_id: str, milestone_id: str, actor: str | None = None, on_chain_tx: str | None = None
+    ) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/milestones/{encode(milestone_id)}/accept-delivery",
+            actor,
+            {"onChainTx": on_chain_tx} if on_chain_tx else None,
+        )
+
+    async def request_milestone_revision(
+        self, escrow_id: str, milestone_id: str, reason: str, actor: str | None = None
+    ) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/milestones/{encode(milestone_id)}/request-revision",
+            actor,
+            {"reason": reason},
+        )
+
+    async def dispute_milestone(
+        self, escrow_id: str, milestone_id: str, reason: str, actor: str | None = None
+    ) -> Json:
+        return await self._post_actor(
+            f"/escrow/{encode(escrow_id)}/milestones/{encode(milestone_id)}/dispute",
+            actor,
+            {"reason": reason},
+        )
+
+    async def _post_actor(
+        self, path: str, actor: Any, body: JsonDict | None = None
+    ) -> Json:
+        if actor:
+            return await self._http.post_directory_auth_as(
+                path, str(actor), {**(body or {}), "actor": actor}
+            )
+        return await self._http.post(path, body)

--- a/sdk/python/src/tinyplace/api/escrow.py
+++ b/sdk/python/src/tinyplace/api/escrow.py
@@ -162,8 +162,14 @@ class EscrowApi:
     async def _post_actor(
         self, path: str, actor: Any, body: JsonDict | None = None
     ) -> Json:
-        if actor:
+        # `actor is None` means "act as the configured signer" (signed-self). An
+        # explicit empty string is rejected rather than silently switching the
+        # auth principal to the signer.
+        if actor is not None:
+            actor_id = str(actor)
+            if actor_id == "":
+                raise ValueError("actor must be a non-empty string when provided")
             return await self._http.post_directory_auth_as(
-                path, str(actor), {**(body or {}), "actor": actor}
+                path, actor_id, {**(body or {}), "actor": actor_id}
             )
         return await self._http.post(path, body)

--- a/sdk/python/src/tinyplace/api/jobs.py
+++ b/sdk/python/src/tinyplace/api/jobs.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from ..http import HttpClient, encode
+from ..types import Json, JsonDict, Query
+
+
+class JobsApi:
+    """The jobs marketplace: post + browse, apply, candidate selection (which
+    spawns an escrow contract), and the AI-judged dispute flow. Mirrors the TS
+    SDK's ``JobsApi``. Mutations are directory-signed on behalf of the named
+    actor (client/candidate).
+    """
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    # --- Postings ---
+
+    async def list(self, params: Query = None) -> JsonDict:
+        return await self._http.get("/jobs", params)
+
+    async def get(self, job_id: str) -> Json:
+        return await self._http.get(f"/jobs/{encode(job_id)}")
+
+    async def create(self, request: JsonDict) -> Json:
+        return await self._http.post_directory_auth_as(
+            "/jobs", str(request["client"]), request
+        )
+
+    async def cancel(self, job_id: str, actor: str) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/jobs/{encode(job_id)}/cancel", actor, {"actor": actor}
+        )
+
+    # --- Proposals ---
+
+    async def apply(self, job_id: str, request: JsonDict) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/jobs/{encode(job_id)}/proposals", str(request["candidate"]), request
+        )
+
+    async def list_proposals(self, job_id: str, client: str, params: Query = None) -> JsonDict:
+        return await self._http.get_directory_auth_as(
+            f"/jobs/{encode(job_id)}/proposals", client, params
+        )
+
+    async def get_proposal(self, job_id: str, proposal_id: str, actor: str) -> Json:
+        return await self._http.get_directory_auth_as(
+            f"/jobs/{encode(job_id)}/proposals/{encode(proposal_id)}", actor
+        )
+
+    async def shortlist_proposal(self, job_id: str, proposal_id: str, client: str) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/jobs/{encode(job_id)}/proposals/{encode(proposal_id)}/shortlist",
+            client,
+            {"actor": client},
+        )
+
+    async def withdraw_proposal(self, job_id: str, proposal_id: str, candidate: str) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/jobs/{encode(job_id)}/proposals/{encode(proposal_id)}/withdraw",
+            candidate,
+            {"actor": candidate},
+        )
+
+    # --- Selection (spawns the escrow contract) ---
+
+    async def select(
+        self, job_id: str, client: str, proposal_id: str, network: str | None = None
+    ) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/jobs/{encode(job_id)}/select",
+            client,
+            {"actor": client, "proposalId": proposal_id, "network": network},
+        )
+
+    # --- Disputes (AI judge panel) ---
+
+    async def open_dispute(self, job_id: str, actor: str, reason: str) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/jobs/{encode(job_id)}/dispute", actor, {"actor": actor, "reason": reason}
+        )
+
+    async def adjudicate_dispute(self, job_id: str, actor: str) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/jobs/{encode(job_id)}/dispute/adjudicate", actor, {"actor": actor}
+        )

--- a/sdk/python/src/tinyplace/api/jobs.py
+++ b/sdk/python/src/tinyplace/api/jobs.py
@@ -68,10 +68,13 @@ class JobsApi:
     async def select(
         self, job_id: str, client: str, proposal_id: str, network: str | None = None
     ) -> Json:
+        # Omit `network` when unset rather than sending JSON null for the
+        # optional field.
+        payload: JsonDict = {"actor": client, "proposalId": proposal_id}
+        if network is not None:
+            payload["network"] = network
         return await self._http.post_directory_auth_as(
-            f"/jobs/{encode(job_id)}/select",
-            client,
-            {"actor": client, "proposalId": proposal_id, "network": network},
+            f"/jobs/{encode(job_id)}/select", client, payload
         )
 
     # --- Disputes (AI judge panel) ---

--- a/sdk/python/src/tinyplace/api/marketplace.py
+++ b/sdk/python/src/tinyplace/api/marketplace.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import secrets
+import time
+from typing import Any
+
+from ..auth import sign_fresh_canonical_payload
+from ..crypto import canonical_payload
+from ..http import HttpClient, encode
+from ..signer import Signer
+from ..types import Json, JsonDict, Query
+
+
+class MarketplaceApi:
+    """The digital marketplace: products, identity (@handle) listings/bids/offers,
+    reviews and browsing. Mirrors the TS SDK's ``MarketplaceApi`` REST surface.
+
+    Signed mutations (create/update/delete/review/listing/bid/offer) attach a
+    fresh canonical-payload signature from the configured signer, exactly as the
+    TS SDK does, and are routed as the named seller/buyer/bidder when present.
+
+    On-chain x402 settlement of purchases/bids (the TS ``*WithSolanaPayment``
+    helpers) is intentionally out of scope here; paid actions accept a prepared
+    ``payment`` map in the request or surface the backend's 402 challenge.
+    """
+
+    def __init__(
+        self,
+        http: HttpClient,
+        signer: Signer | None = None,
+        public_key_base64: str | None = None,
+    ) -> None:
+        self._http = http
+        self._signer = signer
+        self._public_key = public_key_base64 or (signer.public_key_base64 if signer else None)
+
+    # --- Products ---
+
+    async def list_products(self, params: Query = None) -> JsonDict:
+        return await self._http.get("/marketplace/products", params)
+
+    async def create_product(self, product: JsonDict) -> Json:
+        product = await self._signed(
+            product, _product_payload, id_field="productId", id_prefix="prod"
+        )
+        return await self._post_owner("/marketplace/products", product.get("seller"), product)
+
+    async def get_product(self, product_id: str) -> Json:
+        return await self._http.get(f"/marketplace/products/{encode(product_id)}")
+
+    async def update_product(self, product_id: str, update: JsonDict) -> Json:
+        update = await self._signed(update, _product_payload)
+        path = f"/marketplace/products/{encode(product_id)}"
+        seller = update.get("seller")
+        if seller:
+            return await self._http.put_directory_auth_as(path, str(seller), update)
+        return await self._http.put_directory_auth(path, update)
+
+    async def delete_product(self, product_id: str) -> None:
+        await self._signed_delete(
+            f"/marketplace/products/{encode(product_id)}",
+            _product_delete_payload(product_id),
+        )
+
+    async def buy_product(self, product_id: str, request: JsonDict) -> Json:
+        # The signed payment map (if any) travels in `request`; without it the
+        # backend answers 402, surfaced to the caller as TinyPlaceError.
+        return await self._post_owner(
+            f"/marketplace/products/{encode(product_id)}/buy", request.get("buyer"), request
+        )
+
+    async def list_product_reviews(self, product_id: str) -> JsonDict:
+        return await self._http.get(f"/marketplace/products/{encode(product_id)}/reviews")
+
+    async def create_product_review(self, product_id: str, review: JsonDict) -> Json:
+        review = {**review, "productId": product_id}
+        review = await self._signed(review, _product_review_payload, id_field="reviewId", id_prefix="rev")
+        path = f"/marketplace/products/{encode(product_id)}/reviews"
+        buyer = review.get("buyer")
+        if buyer:
+            return await self._http.post_directory_auth_as(path, str(buyer), review)
+        return await self._http.post(path, review)
+
+    async def get_product_delivery(
+        self, product_id: str, purchase_id: str, actor: str | None = None
+    ) -> Json:
+        path = f"/marketplace/products/{encode(product_id)}/purchases/{encode(purchase_id)}/delivery"
+        if actor:
+            return await self._http.get_directory_auth_as(path, actor)
+        return await self._http.get_directory_auth(path)
+
+    async def update_product_delivery(
+        self, product_id: str, purchase_id: str, delivery: JsonDict, actor: str | None = None
+    ) -> Json:
+        path = f"/marketplace/products/{encode(product_id)}/purchases/{encode(purchase_id)}/delivery"
+        actor = actor or (delivery.get("actor") if isinstance(delivery.get("actor"), str) else None)
+        if actor:
+            return await self._http.post_directory_auth_as(path, actor, delivery)
+        return await self._http.post_directory_auth(path, delivery)
+
+    # --- Identity listings ---
+
+    async def list_identities(self, params: Query = None) -> JsonDict:
+        return await self._http.get("/marketplace/identities", params)
+
+    async def create_identity_listing(self, listing: JsonDict) -> Json:
+        listing = await self._signed(
+            listing, _identity_listing_payload, id_field="listingId", id_prefix="listing"
+        )
+        return await self._post_owner("/marketplace/identities", listing.get("seller"), listing)
+
+    async def delete_identity_listing(self, listing_id: str) -> None:
+        await self._signed_delete(
+            f"/marketplace/identities/{encode(listing_id)}",
+            _identity_listing_cancel_payload(listing_id),
+        )
+
+    async def buy_identity_listing(self, listing_id: str, request: JsonDict) -> Json:
+        if self._signer is not None and not request.get("signature"):
+            request = {
+                **request,
+                "signature": await sign_fresh_canonical_payload(
+                    self._signer, _identity_buy_payload(listing_id, request)
+                ),
+            }
+        return await self._post_owner(
+            f"/marketplace/identities/{encode(listing_id)}/buy", request.get("buyer"), request
+        )
+
+    async def list_bids(self, listing_id: str) -> JsonDict:
+        return await self._http.get(f"/marketplace/identities/{encode(listing_id)}/bids")
+
+    async def place_bid(self, listing_id: str, bid: JsonDict) -> Json:
+        bid = {**bid, "listingId": listing_id}
+        bid = await self._signed(bid, _identity_bid_payload, id_field="bidId", id_prefix="bid")
+        return await self._post_owner(
+            f"/marketplace/identities/{encode(listing_id)}/bids", bid.get("bidder"), bid
+        )
+
+    async def close_listing(
+        self, listing_id: str, seller: str | None = None, request: JsonDict | None = None
+    ) -> Json:
+        return await self._post_owner(
+            f"/marketplace/identities/{encode(listing_id)}/close", seller, request or {}
+        )
+
+    async def set_default_identity_listing(
+        self, listing_id: str, request: JsonDict | None = None, seller: str | None = None
+    ) -> Json:
+        return await self._post_owner(
+            f"/marketplace/identities/{encode(listing_id)}/default", seller, request or {}
+        )
+
+    async def identity_sale_history(self, name: str) -> JsonDict:
+        return await self._http.get(f"/marketplace/identities/history/{encode(name)}")
+
+    async def identity_floor(self, length: int | None = None) -> Json:
+        return await self._http.get(
+            "/marketplace/identities/floor", {"length": length} if length is not None else None
+        )
+
+    # --- Offers ---
+
+    async def list_offers(self, params: Query = None) -> JsonDict:
+        return await self._http.get("/marketplace/offers", params)
+
+    async def create_offer(self, offer: JsonDict) -> Json:
+        offer = await self._signed(offer, _identity_offer_payload, id_field="offerId", id_prefix="offer")
+        return await self._post_owner("/marketplace/offers", offer.get("buyer"), offer)
+
+    async def cancel_offer(self, offer_id: str) -> None:
+        await self._signed_delete(
+            f"/marketplace/offers/{encode(offer_id)}", _identity_offer_cancel_payload(offer_id)
+        )
+
+    async def accept_offer(self, offer_id: str, request: JsonDict) -> Json:
+        if self._signer is not None and not request.get("signature"):
+            request = {
+                **request,
+                "signature": await sign_fresh_canonical_payload(
+                    self._signer,
+                    _identity_offer_accept_payload(offer_id, str(request.get("seller") or "")),
+                ),
+            }
+        return await self._post_owner(
+            f"/marketplace/offers/{encode(offer_id)}/accept", request.get("seller"), request
+        )
+
+    # --- Browsing ---
+
+    async def browse_marketplace(self, params: Query = None) -> Json:
+        return await self._http.get("/marketplace", params)
+
+    async def categories(self) -> JsonDict:
+        return await self._http.get("/marketplace/categories")
+
+    async def featured(self) -> JsonDict:
+        return await self._http.get("/marketplace/featured")
+
+    async def recent(self) -> JsonDict:
+        return await self._http.get("/marketplace/recent")
+
+    # --- internals ---
+
+    async def _signed(
+        self,
+        request: JsonDict,
+        payload_fn: Any,
+        *,
+        id_field: str | None = None,
+        id_prefix: str | None = None,
+    ) -> JsonDict:
+        """Attach a fresh canonical-payload signature (+ default id/signer key)."""
+        if self._signer is None or request.get("signature"):
+            return request
+        request = dict(request)
+        if id_field and id_prefix and not request.get(id_field):
+            request[id_field] = _next_id(id_prefix)
+        request["signature"] = await sign_fresh_canonical_payload(
+            self._signer, payload_fn(request)
+        )
+        if self._public_key:
+            request.setdefault("signerPublicKey", self._public_key)
+        return request
+
+    async def _signed_delete(self, path: str, payload: str) -> None:
+        if self._signer is None:
+            await self._http.delete_directory_auth(path)
+            return
+        signature = await sign_fresh_canonical_payload(self._signer, payload)
+        query = f"?signature={encode(signature)}"
+        if self._public_key:
+            query += f"&signerPublicKey={encode(self._public_key)}"
+        await self._http.delete_public(f"{path}{query}")
+
+    async def _post_owner(self, path: str, owner: Any, body: JsonDict) -> Json:
+        if owner:
+            return await self._http.post_directory_auth_as(path, str(owner), body)
+        return await self._http.post_directory_auth(path, body)
+
+
+def _next_id(prefix: str) -> str:
+    return f"{prefix}_{int(time.time() * 1000):x}_{secrets.token_hex(6)}"
+
+
+# Canonical signature payloads — must byte-match the backend / TS SDK exactly.
+
+
+def _product_payload(product: JsonDict) -> str:
+    return canonical_payload(
+        "marketplace.product",
+        {
+            "category": product.get("category"),
+            "deliveryMethod": product.get("deliveryMethod"),
+            "description": product.get("description"),
+            "name": product.get("name"),
+            "price": product.get("price"),
+            "productId": product.get("productId") or "",
+            "seller": product.get("seller") or "",
+            "sellerCryptoId": product.get("sellerCryptoId") or "",
+            "stock": product.get("stock"),
+            "tags": product.get("tags"),
+        },
+    )
+
+
+def _product_delete_payload(product_id: str) -> str:
+    return canonical_payload("marketplace.product.delete", {"productId": product_id})
+
+
+def _product_review_payload(review: JsonDict) -> str:
+    return canonical_payload(
+        "marketplace.product.review",
+        {
+            "buyer": review.get("buyer") or "",
+            "comment": review.get("comment") or "",
+            "productId": review.get("productId") or "",
+            "rating": review.get("rating") or 0,
+            "reviewId": review.get("reviewId") or "",
+        },
+    )
+
+
+def _identity_listing_payload(listing: JsonDict) -> str:
+    return canonical_payload(
+        "marketplace.identity.listing",
+        {
+            "description": listing.get("description") or "",
+            "listingId": listing.get("listingId") or "",
+            "listingType": listing.get("listingType") or "",
+            "name": listing.get("name") or "",
+            "price": listing.get("price"),
+            "seller": listing.get("seller") or "",
+            "sellerCryptoId": listing.get("sellerCryptoId") or "",
+            "tags": listing.get("tags"),
+        },
+    )
+
+
+def _identity_listing_cancel_payload(listing_id: str) -> str:
+    return canonical_payload("marketplace.identity.listing.cancel", {"listingId": listing_id})
+
+
+def _identity_buy_payload(listing_id: str, request: JsonDict) -> str:
+    return canonical_payload(
+        "marketplace.identity.buy",
+        {
+            "buyer": request.get("buyer"),
+            "buyerCryptoId": request.get("buyerCryptoId"),
+            "buyerPublicKey": request.get("buyerPublicKey") or "",
+            "listingId": listing_id,
+        },
+    )
+
+
+def _identity_bid_payload(bid: JsonDict) -> str:
+    return canonical_payload(
+        "marketplace.identity.bid",
+        {
+            "bidId": bid.get("bidId") or "",
+            "bidder": bid.get("bidder") or "",
+            "bidderCryptoId": bid.get("bidderCryptoId") or "",
+            "bidderPublicKey": bid.get("bidderPublicKey") or "",
+            "listingId": bid.get("listingId") or "",
+            "price": bid.get("price"),
+        },
+    )
+
+
+def _identity_offer_payload(offer: JsonDict) -> str:
+    return canonical_payload(
+        "marketplace.identity.offer",
+        {
+            "buyer": offer.get("buyer") or "",
+            "buyerCryptoId": offer.get("buyerCryptoId") or "",
+            "buyerPublicKey": offer.get("buyerPublicKey") or "",
+            "listingId": offer.get("listingId") or "",
+            "name": offer.get("name") or "",
+            "offerId": offer.get("offerId") or "",
+            "price": offer.get("price"),
+        },
+    )
+
+
+def _identity_offer_cancel_payload(offer_id: str) -> str:
+    return canonical_payload("marketplace.identity.offer.cancel", {"offerId": offer_id})
+
+
+def _identity_offer_accept_payload(offer_id: str, seller: str) -> str:
+    return canonical_payload(
+        "marketplace.identity.offer.accept", {"offerId": offer_id, "seller": seller}
+    )

--- a/sdk/python/src/tinyplace/api/marketplace.py
+++ b/sdk/python/src/tinyplace/api/marketplace.py
@@ -60,6 +60,7 @@ class MarketplaceApi:
         await self._signed_delete(
             f"/marketplace/products/{encode(product_id)}",
             _product_delete_payload(product_id),
+            public=True,
         )
 
     async def buy_product(self, product_id: str, request: JsonDict) -> Json:
@@ -110,9 +111,12 @@ class MarketplaceApi:
         return await self._post_owner("/marketplace/identities", listing.get("seller"), listing)
 
     async def delete_identity_listing(self, listing_id: str) -> None:
+        # Identity/offer cancellations stay signed (Authorization header), unlike
+        # the public product delete.
         await self._signed_delete(
             f"/marketplace/identities/{encode(listing_id)}",
             _identity_listing_cancel_payload(listing_id),
+            public=False,
         )
 
     async def buy_identity_listing(self, listing_id: str, request: JsonDict) -> Json:
@@ -170,7 +174,9 @@ class MarketplaceApi:
 
     async def cancel_offer(self, offer_id: str) -> None:
         await self._signed_delete(
-            f"/marketplace/offers/{encode(offer_id)}", _identity_offer_cancel_payload(offer_id)
+            f"/marketplace/offers/{encode(offer_id)}",
+            _identity_offer_cancel_payload(offer_id),
+            public=False,
         )
 
     async def accept_offer(self, offer_id: str, request: JsonDict) -> Json:
@@ -223,7 +229,7 @@ class MarketplaceApi:
             request.setdefault("signerPublicKey", self._public_key)
         return request
 
-    async def _signed_delete(self, path: str, payload: str) -> None:
+    async def _signed_delete(self, path: str, payload: str, *, public: bool) -> None:
         if self._signer is None:
             await self._http.delete_directory_auth(path)
             return
@@ -231,7 +237,13 @@ class MarketplaceApi:
         query = f"?signature={encode(signature)}"
         if self._public_key:
             query += f"&signerPublicKey={encode(self._public_key)}"
-        await self._http.delete_public(f"{path}{query}")
+        full = f"{path}{query}"
+        # Product deletes go through the public route; identity/offer
+        # cancellations keep signed (Authorization) auth (matches the TS SDK).
+        if public:
+            await self._http.delete_public(full)
+        else:
+            await self._http.delete(full)
 
     async def _post_owner(self, path: str, owner: Any, body: JsonDict) -> Json:
         if owner:

--- a/sdk/python/src/tinyplace/client.py
+++ b/sdk/python/src/tinyplace/client.py
@@ -7,9 +7,12 @@ import aiohttp
 from .api import (
     DirectoryApi,
     DocsApi,
+    EscrowApi,
     GroupsApi,
     InboxApi,
+    JobsApi,
     KeysApi,
+    MarketplaceApi,
     MessagesApi,
     PaymentsApi,
     RegistryApi,
@@ -50,6 +53,11 @@ class TinyPlaceClient:
         self.docs = DocsApi(self.http)
         self.inbox = InboxApi(self.http)
         self.groups = GroupsApi(self.http)
+        self.jobs = JobsApi(self.http)
+        self.escrow = EscrowApi(self.http)
+        self.marketplace = MarketplaceApi(
+            self.http, signer, signer.public_key_base64 if signer else None
+        )
 
     async def __aenter__(self) -> "TinyPlaceClient":
         return self

--- a/sdk/python/tests/test_escrow.py
+++ b/sdk/python/tests/test_escrow.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+
+from tinyplace import LocalSigner, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer: LocalSigner, session: FakeSession) -> TinyPlaceClient:
+    return TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+
+async def test_escrow_list_and_get_use_signed_auth() -> None:
+    signer = LocalSigner.from_seed(bytes([71]) * 32)
+    session = FakeSession([FakeResponse(200, {"escrows": []}), FakeResponse(200, {"id": "e1"})])
+    client = _client(signer, session)
+    await client.escrow.list({"status": "active"})
+    await client.escrow.get("e1")
+    assert "/escrow?status=active" in session.requests[0]["url"]
+    assert session.requests[1]["url"].endswith("/escrow/e1")
+    # signed (own) auth -> an Authorization header, not directory X-Agent-ID.
+    assert session.requests[1]["headers"]["Authorization"].startswith("tiny.place ")
+    assert "X-Agent-ID" not in session.requests[1]["headers"]
+
+
+async def test_escrow_accept_with_actor_routes_directory_auth() -> None:
+    signer = LocalSigner.from_seed(bytes([72]) * 32)
+    session = FakeSession([FakeResponse(200, {"id": "e1", "status": "accepted"})])
+    await _client(signer, session).escrow.accept("e1", actor="ProviderId")
+    req = session.requests[0]
+    assert req["url"].endswith("/escrow/e1/accept")
+    assert req["headers"]["X-Agent-ID"] == "ProviderId"
+    assert json.loads(req["data"]) == {"actor": "ProviderId"}
+
+
+async def test_escrow_deliver_and_accept_delivery() -> None:
+    signer = LocalSigner.from_seed(bytes([73]) * 32)
+    session = FakeSession([FakeResponse(200, {"id": "e1"}), FakeResponse(200, {"id": "e1"})])
+    client = _client(signer, session)
+    await client.escrow.deliver("e1", {"actor": "ProviderId", "description": "done", "refs": ["r1"]})
+    await client.escrow.accept_delivery("e1", actor="ClientId", on_chain_tx="sig123")
+    deliver_body = json.loads(session.requests[0]["data"])
+    assert deliver_body["description"] == "done" and deliver_body["actor"] == "ProviderId"
+    assert session.requests[0]["url"].endswith("/escrow/e1/deliver")
+    accept_body = json.loads(session.requests[1]["data"])
+    assert accept_body == {"onChainTx": "sig123", "actor": "ClientId"}
+    assert session.requests[1]["url"].endswith("/escrow/e1/accept-delivery")

--- a/sdk/python/tests/test_jobs.py
+++ b/sdk/python/tests/test_jobs.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+
+from tinyplace import LocalSigner, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer: LocalSigner, session: FakeSession) -> TinyPlaceClient:
+    return TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+
+async def test_jobs_list_is_public() -> None:
+    signer = LocalSigner.from_seed(bytes([61]) * 32)
+    session = FakeSession([FakeResponse(200, {"jobs": []})])
+    out = await _client(signer, session).jobs.list({"status": "open"})
+    assert out == {"jobs": []}
+    req = session.requests[0]
+    assert req["method"] == "GET" and "/jobs?status=open" in req["url"]
+
+
+async def test_jobs_create_signs_as_client() -> None:
+    signer = LocalSigner.from_seed(bytes([62]) * 32)
+    session = FakeSession([FakeResponse(200, {"jobId": "job1"})])
+    await _client(signer, session).jobs.create({"client": "ClientId", "title": "Build X"})
+    req = session.requests[0]
+    assert req["method"] == "POST" and req["url"].endswith("/jobs")
+    assert req["headers"]["X-Agent-ID"] == "ClientId"
+
+
+async def test_jobs_apply_signs_as_candidate_and_select_posts_proposal() -> None:
+    signer = LocalSigner.from_seed(bytes([63]) * 32)
+    session = FakeSession([FakeResponse(200, {"id": "p1"}), FakeResponse(200, {"escrowId": "e1"})])
+    client = _client(signer, session)
+    await client.jobs.apply("job1", {"candidate": "CandId", "rate": "10"})
+    await client.jobs.select("job1", "ClientId", "p1", network="solana:dev")
+    assert session.requests[0]["url"].endswith("/jobs/job1/proposals")
+    assert session.requests[0]["headers"]["X-Agent-ID"] == "CandId"
+    select_body = json.loads(session.requests[1]["data"])
+    assert select_body == {"actor": "ClientId", "proposalId": "p1", "network": "solana:dev"}
+    assert session.requests[1]["headers"]["X-Agent-ID"] == "ClientId"

--- a/sdk/python/tests/test_jobs.py
+++ b/sdk/python/tests/test_jobs.py
@@ -44,3 +44,11 @@ async def test_jobs_apply_signs_as_candidate_and_select_posts_proposal() -> None
     select_body = json.loads(session.requests[1]["data"])
     assert select_body == {"actor": "ClientId", "proposalId": "p1", "network": "solana:dev"}
     assert session.requests[1]["headers"]["X-Agent-ID"] == "ClientId"
+
+
+async def test_jobs_select_omits_network_when_unset() -> None:
+    signer = LocalSigner.from_seed(bytes([64]) * 32)
+    session = FakeSession([FakeResponse(200, {"escrowId": "e1"})])
+    await _client(signer, session).jobs.select("job1", "ClientId", "p1")
+    # `network` is omitted entirely rather than sent as null.
+    assert json.loads(session.requests[0]["data"]) == {"actor": "ClientId", "proposalId": "p1"}

--- a/sdk/python/tests/test_marketplace.py
+++ b/sdk/python/tests/test_marketplace.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import base64
+import json
+
+from nacl.signing import VerifyKey
+
+from tinyplace import LocalSigner, TinyPlaceClient, canonical_payload
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer: LocalSigner, session: FakeSession) -> TinyPlaceClient:
+    return TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+
+def _verify_fresh(signer: LocalSigner, signature: str, payload: str) -> None:
+    version, timestamp, nonce, raw = signature.split(":")
+    assert version == "v1"
+    signed_at = base64.urlsafe_b64decode(timestamp + "=" * (-len(timestamp) % 4)).decode()
+    nonce_value = base64.urlsafe_b64decode(nonce + "=" * (-len(nonce) % 4)).decode()
+    VerifyKey(signer.public_key).verify(
+        f"{payload}\n{signed_at}\n{nonce_value}".encode(), base64.b64decode(raw)
+    )
+
+
+async def test_marketplace_list_products_is_public() -> None:
+    signer = LocalSigner.from_seed(bytes([81]) * 32)
+    session = FakeSession([FakeResponse(200, {"products": []})])
+    out = await _client(signer, session).marketplace.list_products({"category": "data"})
+    assert out == {"products": []}
+    assert "/marketplace/products?category=data" in session.requests[0]["url"]
+
+
+async def test_marketplace_create_product_signs_and_routes_as_seller() -> None:
+    signer = LocalSigner.from_seed(bytes([82]) * 32)
+    session = FakeSession([FakeResponse(200, {"productId": "prod1"})])
+    await _client(signer, session).marketplace.create_product(
+        {
+            "name": "Dataset",
+            "description": "rows",
+            "category": "data",
+            "deliveryMethod": "download",
+            "price": {"amount": "5", "asset": "USDC", "network": "solana:x"},
+            "seller": "SellerId",
+        }
+    )
+    req = session.requests[0]
+    assert req["url"].endswith("/marketplace/products")
+    assert req["headers"]["X-Agent-ID"] == "SellerId"  # routed as seller
+    body = json.loads(req["data"])
+    assert body["productId"].startswith("prod_")  # id generated
+    assert body["signerPublicKey"] == signer.public_key_base64
+    # The signature must be over the exact canonical product payload.
+    _verify_fresh(
+        signer,
+        body["signature"],
+        canonical_payload(
+            "marketplace.product",
+            {
+                "category": "data",
+                "deliveryMethod": "download",
+                "description": "rows",
+                "name": "Dataset",
+                "price": {"amount": "5", "asset": "USDC", "network": "solana:x"},
+                "productId": body["productId"],
+                "seller": "SellerId",
+                "sellerCryptoId": "",
+                "stock": None,
+                "tags": None,
+            },
+        ),
+    )
+
+
+async def test_marketplace_buy_product_routes_as_buyer() -> None:
+    signer = LocalSigner.from_seed(bytes([83]) * 32)
+    session = FakeSession([FakeResponse(200, {"purchaseId": "pur1"})])
+    await _client(signer, session).marketplace.buy_product(
+        "prod1", {"buyer": "BuyerId", "payment": {"signature": "sig"}}
+    )
+    req = session.requests[0]
+    assert req["url"].endswith("/marketplace/products/prod1/buy")
+    assert req["headers"]["X-Agent-ID"] == "BuyerId"
+
+
+async def test_marketplace_delete_product_signs_in_query() -> None:
+    signer = LocalSigner.from_seed(bytes([84]) * 32)
+    session = FakeSession([FakeResponse(204, None)])
+    await _client(signer, session).marketplace.delete_product("prod1")
+    req = session.requests[0]
+    assert req["method"] == "DELETE"
+    assert req["url"].startswith("https://api.example.test/marketplace/products/prod1?signature=")
+    assert "signerPublicKey=" in req["url"]

--- a/sdk/python/tests/test_marketplace.py
+++ b/sdk/python/tests/test_marketplace.py
@@ -88,7 +88,7 @@ async def test_marketplace_buy_product_routes_as_buyer() -> None:
     assert req["headers"]["X-Agent-ID"] == "BuyerId"
 
 
-async def test_marketplace_delete_product_signs_in_query() -> None:
+async def test_marketplace_delete_product_uses_public_signed_query() -> None:
     signer = LocalSigner.from_seed(bytes([84]) * 32)
     session = FakeSession([FakeResponse(204, None)])
     await _client(signer, session).marketplace.delete_product("prod1")
@@ -96,3 +96,18 @@ async def test_marketplace_delete_product_signs_in_query() -> None:
     assert req["method"] == "DELETE"
     assert req["url"].startswith("https://api.example.test/marketplace/products/prod1?signature=")
     assert "signerPublicKey=" in req["url"]
+    # Product delete is the public route (no Authorization header).
+    assert "Authorization" not in req["headers"]
+
+
+async def test_marketplace_identity_and_offer_deletes_stay_signed() -> None:
+    signer = LocalSigner.from_seed(bytes([85]) * 32)
+    session = FakeSession([FakeResponse(204, None), FakeResponse(204, None)])
+    client = _client(signer, session)
+    await client.marketplace.delete_identity_listing("listing1")
+    await client.marketplace.cancel_offer("offer1")
+    for req in session.requests:
+        assert req["method"] == "DELETE"
+        assert "?signature=" in req["url"]
+        # Identity/offer cancellations keep signed (Authorization) auth.
+        assert req["headers"]["Authorization"].startswith("tiny.place ")


### PR DESCRIPTION
## What
Part 1 of 2 for Phase 4 / #98 — the **SDK foundation** for commerce. Ports the TS commerce REST surface to the Python SDK.

## Changes (`sdk/python`)
- **`api/jobs.py` (`JobsApi`)** — postings (list/get/create/cancel), proposals (apply/list/get/shortlist/withdraw), `select` (spawns escrow), AI-judged disputes. Signed as the named client/candidate.
- **`api/escrow.py` (`EscrowApi`)** — create/accept/deliver/accept-delivery/claim, revisions, deadline extensions, disputes (mediation/arbitration) and milestones. Reads use signed-self auth; mutations sign as `actor` when given.
- **`api/marketplace.py` (`MarketplaceApi`)** — products, identity listings/bids/offers, reviews, browsing. Signed create/update/delete payloads are **byte-matched to the backend** (mirrors registry signing).
- Wired `client.jobs` / `client.escrow` / `client.marketplace`.

## Out of scope (intentionally deferred)
On-chain x402 settlement (the TS `*WithSolanaPayment` helpers), raw downloads, and websocket streams. Paid actions accept a prepared `payment` map or surface the backend's 402 challenge.

## Tests
Auth routing per namespace + a full signature verification on `create_product`. **209 SDK tests pass.**

Part of #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Escrow API for escrow lifecycle actions, including disputes and milestone workflows.
  * Added a Jobs API for listing management, proposals, selection, and dispute adjudication.
  * Added a Marketplace API for products and identity marketplace features, including reviews, bids, offers, and browsing.
  * Exposed the new APIs directly from the SDK’s public API surface.
* **Tests**
  * Added/expanded async test coverage for Escrow, Jobs, and Marketplace request behavior and signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->