### PR TITLE
feat(sdk/python): bounties platform (BountiesApi)

### DIFF
--- a/sdk/python/src/tinyplace/api/__init__.py
+++ b/sdk/python/src/tinyplace/api/__init__.py
@@ -1,3 +1,4 @@
+from .bounties import BountiesApi
 from .directory import DirectoryApi
 from .docs import DocsApi
 from .escrow import EscrowApi
@@ -12,6 +13,7 @@ from .registry import RegistryApi
 from .search import SearchApi
 
 __all__ = [
+    "BountiesApi",
     "DirectoryApi",
     "DocsApi",
     "EscrowApi",

--- a/sdk/python/src/tinyplace/api/bounties.py
+++ b/sdk/python/src/tinyplace/api/bounties.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from ..http import HttpClient, TinyPlaceError, encode
 from ..signer import Signer
 from ..solana import SOLANA_MAINNET_NETWORK, SOLANA_USDC_MINT, execute_solana_x402_payment
 from ..types import Json, JsonDict, Query
+
+DEFAULT_FUND_ATTEMPTS = 30
+DEFAULT_FUND_INTERVAL_MS = 3000
+_FUND_RETRY_ERRORS = ["transaction not found", "insufficient confirmations"]
+
+
+def _should_retry_fund(exc: TinyPlaceError) -> bool:
+    """True when a fund failed only because the on-chain payment isn't confirmed yet."""
+    haystack = f"{exc} {exc.body}".lower()
+    return any(error in haystack for error in _FUND_RETRY_ERRORS)
 
 
 class BountiesApi:
@@ -54,11 +65,16 @@ class BountiesApi:
         mint: str | None = None,
         decimals: int = 6,
         network: str | None = None,
+        attempts: int = DEFAULT_FUND_ATTEMPTS,
+        interval_ms: int = DEFAULT_FUND_INTERVAL_MS,
     ) -> dict[str, Any]:
         """Fund a bounty, settling the reward into escrow on chain (exact x402).
 
         Probes ``fund`` for the 402 challenge, pays it on chain, then re-funds
-        with the signed payment map. Mirrors ``registry.register_with_solana_payment``.
+        with the signed payment map — polling through the unconfirmed window and
+        recovering if a post-payment 5xx already funded it, so a transient error
+        never causes a second on-chain transfer. Mirrors
+        ``registry.register_with_solana_payment``.
         """
         if self._signer is None:
             raise ValueError("fund_with_solana_payment requires a signer")
@@ -89,8 +105,42 @@ class BountiesApi:
                 },
             },
         )
-        bounty = await self.fund(bounty_id, creator, execution["payment"])
+        bounty = await self._fund_retrying(
+            bounty_id, creator, execution["payment"], attempts, interval_ms
+        )
         return {"bounty": bounty, "payment": execution}
+
+    async def _fund_retrying(
+        self, bounty_id: str, creator: str, payment: JsonDict, attempts: int, interval_ms: int
+    ) -> Json:
+        # The payment is already on chain; retry the SAME fund call (same payment
+        # map — no new transfer) through confirmation lag, and recover if a 5xx
+        # actually funded the bounty, so the creator never pays twice.
+        attempts = max(1, attempts)
+        for attempt in range(attempts):
+            try:
+                return await self.fund(bounty_id, creator, payment)
+            except TinyPlaceError as exc:
+                if attempt == attempts - 1 or not _should_retry_fund(exc):
+                    recovered = await self._recover_funded_bounty(bounty_id, exc)
+                    if recovered is not None:
+                        return recovered
+                    raise
+            if interval_ms > 0:
+                await asyncio.sleep(interval_ms / 1000)
+        raise RuntimeError("unreachable: bounty fund retry loop exhausted")
+
+    async def _recover_funded_bounty(self, bounty_id: str, exc: TinyPlaceError) -> Json | None:
+        """Return the bounty if a post-payment 5xx still funded it (has fundingTxSig)."""
+        if exc.status < 500:
+            return None
+        try:
+            bounty = await self.get(bounty_id)
+        except TinyPlaceError:
+            return None
+        if isinstance(bounty, dict) and bounty.get("fundingTxSig"):
+            return bounty
+        return None
 
     async def cancel(self, bounty_id: str, creator: str) -> Json:
         return await self._http.post_directory_auth_as(

--- a/sdk/python/src/tinyplace/api/bounties.py
+++ b/sdk/python/src/tinyplace/api/bounties.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..http import HttpClient, TinyPlaceError, encode
+from ..signer import Signer
+from ..solana import SOLANA_MAINNET_NETWORK, SOLANA_USDC_MINT, execute_solana_x402_payment
+from ..types import Json, JsonDict, Query
+
+
+class BountiesApi:
+    """The bounty platform: create + fund (x402 → escrow), browse, submit a URL,
+    comment for free, run the autonomous council, and the admin-approved payout.
+    Mirrors the TS SDK's ``BountiesApi``.
+
+    ``fund`` accepts a prepared x402 payment map (or surfaces the 402 challenge);
+    ``fund_with_solana_payment`` settles it on chain automatically, reusing the
+    same Solana primitives as registration/marketplace settlement.
+    """
+
+    def __init__(self, http: HttpClient, signer: Signer | None = None) -> None:
+        self._http = http
+        self._signer = signer
+
+    # --- Bounties ---
+
+    async def list(self, params: Query = None) -> JsonDict:
+        return await self._http.get("/bounties", params)
+
+    async def get(self, bounty_id: str) -> Json:
+        return await self._http.get(f"/bounties/{encode(bounty_id)}")
+
+    async def create(self, request: JsonDict) -> Json:
+        return await self._http.post_directory_auth_as(
+            "/bounties", str(request.get("creator") or ""), request
+        )
+
+    async def fund(self, bounty_id: str, creator: str, payment: JsonDict | None = None) -> Json:
+        # Call without a payment to receive the 402 challenge; re-call with the
+        # signed payment map to fund the escrow.
+        return await self._http.post_directory_auth_as(
+            f"/bounties/{encode(bounty_id)}/fund",
+            creator,
+            {"payment": payment} if payment else {},
+        )
+
+    async def fund_with_solana_payment(
+        self,
+        bounty_id: str,
+        creator: str,
+        *,
+        rpc_url: str,
+        secret_key: str | bytes,
+        mint: str | None = None,
+        decimals: int = 6,
+        network: str | None = None,
+    ) -> dict[str, Any]:
+        """Fund a bounty, settling the reward into escrow on chain (exact x402).
+
+        Probes ``fund`` for the 402 challenge, pays it on chain, then re-funds
+        with the signed payment map. Mirrors ``registry.register_with_solana_payment``.
+        """
+        if self._signer is None:
+            raise ValueError("fund_with_solana_payment requires a signer")
+        challenge = await self._fund_challenge(bounty_id, creator)
+        amount = challenge.get("amount")
+        recipient = challenge.get("to")
+        if not amount or not recipient:
+            raise ValueError("bounty fund challenge is missing amount or recipient")
+        execution = await execute_solana_x402_payment(
+            signer=self._signer,
+            rpc_url=rpc_url,
+            secret_key=secret_key,
+            mint=mint or SOLANA_USDC_MINT,
+            decimals=decimals,
+            payment={
+                "scheme": challenge.get("scheme", "exact"),
+                "network": challenge.get("network") or network or SOLANA_MAINNET_NETWORK,
+                "asset": challenge.get("asset") or "USDC",
+                "amount": amount,
+                "from": creator,
+                "to": recipient,
+                "nonce": challenge.get("nonce"),
+                "expiresAt": challenge.get("expiresAt"),
+                "metadata": {
+                    **(challenge.get("metadata") or {}),
+                    "bountyId": bounty_id,
+                    "kind": "bounty-fund",
+                },
+            },
+        )
+        bounty = await self.fund(bounty_id, creator, execution["payment"])
+        return {"bounty": bounty, "payment": execution}
+
+    async def cancel(self, bounty_id: str, creator: str) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/bounties/{encode(bounty_id)}/cancel", creator, {}
+        )
+
+    # --- Submissions ---
+
+    async def submit(self, bounty_id: str, request: JsonDict) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/bounties/{encode(bounty_id)}/submissions",
+            str(request.get("submitter") or ""),
+            request,
+        )
+
+    async def list_submissions(self, bounty_id: str, params: Query = None) -> JsonDict:
+        return await self._http.get(f"/bounties/{encode(bounty_id)}/submissions", params)
+
+    # --- Comments (free) ---
+
+    async def comment(self, bounty_id: str, request: JsonDict) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/bounties/{encode(bounty_id)}/comments",
+            str(request.get("author") or ""),
+            request,
+        )
+
+    async def list_comments(self, bounty_id: str, params: Query = None) -> JsonDict:
+        return await self._http.get(f"/bounties/{encode(bounty_id)}/comments", params)
+
+    # --- Council + approval ---
+
+    async def run_council(self, bounty_id: str, actor: str) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/bounties/{encode(bounty_id)}/council", actor, {}
+        )
+
+    async def approve(self, bounty_id: str, submission_id: str | None = None) -> Json:
+        return await self._http.post_admin(
+            f"/bounties/{encode(bounty_id)}/approve",
+            {"submissionId": submission_id} if submission_id else {},
+        )
+
+    async def _fund_challenge(self, bounty_id: str, creator: str) -> dict[str, Any]:
+        try:
+            await self.fund(bounty_id, creator)
+        except TinyPlaceError as exc:
+            if exc.status == 402 and exc.payment_required is not None:
+                return exc.payment_required.payment
+            raise
+        raise ValueError("bounty fund did not return a payment challenge")

--- a/sdk/python/src/tinyplace/client.py
+++ b/sdk/python/src/tinyplace/client.py
@@ -5,6 +5,7 @@ from typing import Any
 import aiohttp
 
 from .api import (
+    BountiesApi,
     DirectoryApi,
     DocsApi,
     EscrowApi,
@@ -58,6 +59,7 @@ class TinyPlaceClient:
         self.marketplace = MarketplaceApi(
             self.http, signer, signer.public_key_base64 if signer else None
         )
+        self.bounties = BountiesApi(self.http, signer)
 
     async def __aenter__(self) -> "TinyPlaceClient":
         return self

--- a/sdk/python/tests/test_bounties.py
+++ b/sdk/python/tests/test_bounties.py
@@ -70,3 +70,52 @@ async def test_bounties_fund_with_solana_payment_settles_then_funds(monkeypatch)
     fund_body = json.loads(session.requests[1]["data"])
     assert fund_body["payment"]["signature"] == "s"
     assert result["bounty"]["status"] == "funded"
+
+
+async def test_bounties_fund_retries_through_confirmation_lag(monkeypatch) -> None:
+    signer = LocalSigner.from_seed(bytes([94]) * 32)
+    challenge = {"amount": "1", "to": "Escrow1", "network": SOLANA_MAINNET_NETWORK, "asset": "USDC"}
+    session = FakeSession(
+        [
+            FakeResponse(402, {"payment": challenge}),  # probe
+            FakeResponse(409, {"error": "transaction not found"}),  # re-fund: not confirmed yet
+            FakeResponse(200, {"bountyId": "b1", "status": "open"}),  # re-fund: confirmed
+        ]
+    )
+    client = _client(signer, session)
+
+    async def fake_exec(**kwargs):
+        return {"signature": "sig", "payment": {"signature": "s"}}
+
+    monkeypatch.setattr("tinyplace.api.bounties.execute_solana_x402_payment", fake_exec)
+
+    result = await client.bounties.fund_with_solana_payment(
+        "b1", "CreatorId", rpc_url="https://rpc.example", secret_key=bytes([94]) * 32, interval_ms=0
+    )
+    # Retried the SAME fund (no second on-chain transfer) until it confirmed.
+    assert result["bounty"]["status"] == "open"
+    assert len(session.requests) == 3
+
+
+async def test_bounties_fund_recovers_after_post_payment_5xx(monkeypatch) -> None:
+    signer = LocalSigner.from_seed(bytes([95]) * 32)
+    challenge = {"amount": "1", "to": "Escrow1", "network": SOLANA_MAINNET_NETWORK, "asset": "USDC"}
+    session = FakeSession(
+        [
+            FakeResponse(402, {"payment": challenge}),  # probe
+            FakeResponse(500, {"error": "boom"}),  # re-fund: 5xx after persisting
+            FakeResponse(200, {"bountyId": "b1", "status": "open", "fundingTxSig": "sig"}),  # get()
+        ]
+    )
+    client = _client(signer, session)
+
+    async def fake_exec(**kwargs):
+        return {"signature": "sig", "payment": {"signature": "s"}}
+
+    monkeypatch.setattr("tinyplace.api.bounties.execute_solana_x402_payment", fake_exec)
+
+    result = await client.bounties.fund_with_solana_payment(
+        "b1", "CreatorId", rpc_url="https://rpc.example", secret_key=bytes([95]) * 32, interval_ms=0
+    )
+    # The bounty was funded (has fundingTxSig) despite the 5xx -> recovered, no re-pay.
+    assert result["bounty"]["fundingTxSig"] == "sig"

--- a/sdk/python/tests/test_bounties.py
+++ b/sdk/python/tests/test_bounties.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+
+from tinyplace import LocalSigner, SOLANA_MAINNET_NETWORK, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer: LocalSigner, session: FakeSession) -> TinyPlaceClient:
+    return TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+
+async def test_bounties_list_is_public() -> None:
+    signer = LocalSigner.from_seed(bytes([91]) * 32)
+    session = FakeSession([FakeResponse(200, {"bounties": []})])
+    out = await _client(signer, session).bounties.list({"status": "open"})
+    assert out == {"bounties": []}
+    assert "/bounties?status=open" in session.requests[0]["url"]
+
+
+async def test_bounties_create_and_submit_sign_as_actor() -> None:
+    signer = LocalSigner.from_seed(bytes([92]) * 32)
+    session = FakeSession([FakeResponse(200, {"bountyId": "b1"}), FakeResponse(200, {"id": "s1"})])
+    client = _client(signer, session)
+    await client.bounties.create({"creator": "CreatorId", "title": "Summarize X"})
+    await client.bounties.submit("b1", {"submitter": "SubmitterId", "url": "https://x"})
+    assert session.requests[0]["url"].endswith("/bounties")
+    assert session.requests[0]["headers"]["X-Agent-ID"] == "CreatorId"
+    assert session.requests[1]["url"].endswith("/bounties/b1/submissions")
+    assert session.requests[1]["headers"]["X-Agent-ID"] == "SubmitterId"
+
+
+async def test_bounties_fund_with_solana_payment_settles_then_funds(monkeypatch) -> None:
+    signer = LocalSigner.from_seed(bytes([93]) * 32)
+    challenge = {
+        "amount": "100",
+        "to": "EscrowWallet111",
+        "network": SOLANA_MAINNET_NETWORK,
+        "asset": "USDC",
+        "nonce": "n1",
+    }
+    session = FakeSession(
+        [
+            FakeResponse(402, {"error": "payment required", "payment": challenge}),  # probe
+            FakeResponse(200, {"bountyId": "b1", "status": "funded"}),  # re-fund
+        ]
+    )
+    client = _client(signer, session)
+    captured: dict = {}
+
+    async def fake_exec(**kwargs):
+        captured.update(kwargs)
+        return {"signature": "sig", "payment": {"signature": "s"}}
+
+    monkeypatch.setattr("tinyplace.api.bounties.execute_solana_x402_payment", fake_exec)
+
+    result = await client.bounties.fund_with_solana_payment(
+        "b1", "CreatorId", rpc_url="https://rpc.example", secret_key=bytes([93]) * 32
+    )
+    # Paid the challenge amount into the escrow wallet, from the creator.
+    assert captured["payment"]["amount"] == "100"
+    assert captured["payment"]["to"] == "EscrowWallet111" and captured["payment"]["from"] == "CreatorId"
+    assert captured["payment"]["metadata"]["kind"] == "bounty-fund"
+    # The re-fund carried the signed payment map.
+    fund_body = json.loads(session.requests[1]["data"])
+    assert fund_body["payment"]["signature"] == "s"
+    assert result["bounty"]["status"] == "funded"


### PR DESCRIPTION
## What
Part 1 of 2 for Phase 6 / #114 — the SDK **bounties** platform, ported from the TS `BountiesApi`.

## Changes (`sdk/python`)
- **`api/bounties.py` (`BountiesApi`)** — list/get/create/fund/cancel, submit/listSubmissions, comment/listComments, runCouncil, approve (admin). `fund` accepts a prepared x402 payment map or surfaces the 402.
- **`fund_with_solana_payment`** — probes the 402 challenge, settles the reward into escrow on chain (reusing `execute_solana_x402_payment` + `SOLANA_USDC_MINT`), then re-funds with the signed payment map. Mirrors `registry.register_with_solana_payment`.
- Wired `client.bounties`.

## Tests
REST routing (create/submit signed as the named actor) + the fund settle flow (mocked RPC). **217 SDK tests pass.**

Part of #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Bounties API to the Python SDK for listing, creating, retrieving, funding, and canceling bounties.
  * Implemented Solana x402-based funding with support for payment-required challenge handling.
  * Added bounty submission, commenting, and council review/admin approval payout workflows.
* **Bug Fixes**
  * Improved funding reliability with automatic retry and recovery for confirmation lag and post-payment errors.
* **Tests**
  * Expanded bounties test coverage, including x402 funding, retry behavior, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->