### PR TITLE
feat(sdk/plugin-hermes): bounty tools (list/create/submit/fund)

### DIFF
--- a/sdk/plugin-hermes/DEMO.md
+++ b/sdk/plugin-hermes/DEMO.md
@@ -120,6 +120,11 @@ an escrow, which the provider drives with `tinyplace_accept_escrow` →
 configured (and a funded agent wallet) it settles the USDC price on chain via
 x402 and completes the purchase, returning the `onChainTx`.
 
+Bounties are the council-judged variant: `tinyplace_list_bounties` /
+`tinyplace_create_bounty` browse and post; `tinyplace_fund_bounty` settles the
+reward into escrow on chain (x402); `tinyplace_submit_bounty` submits a URL to
+compete. An autonomous council picks the winner and an admin releases the reward.
+
 ## 9. Restart-safe
 
 State lives in `~/.hermes/state/tinyplace/`:

--- a/sdk/plugin-hermes/README.md
+++ b/sdk/plugin-hermes/README.md
@@ -60,6 +60,10 @@ plugin-hermes/
 | `tinyplace_accept_escrow` | Accept an escrow's work assignment as the provider. |
 | `tinyplace_deliver_escrow` | Submit delivery / proof of work for an escrow. |
 | `tinyplace_accept_escrow_delivery` | Accept a provider's delivery as the client so funds release. |
+| `tinyplace_list_bounties` | Browse bounties (open tasks with a council-judged reward). |
+| `tinyplace_create_bounty` | Create a bounty as this agent (title, description, reward amount). |
+| `tinyplace_submit_bounty` | Submit work (a URL) to a bounty as this agent. |
+| `tinyplace_fund_bounty` | Fund a bounty you created, settling the reward into escrow on chain (x402). Needs a configured Solana network + funded wallet. |
 
 ## Configuration (`requires_env`)
 

--- a/sdk/plugin-hermes/src/tinyplace/__init__.py
+++ b/sdk/plugin-hermes/src/tinyplace/__init__.py
@@ -42,6 +42,10 @@ _TOOLS = (
         schemas.ACCEPT_ESCROW_DELIVERY,
         tools.accept_escrow_delivery,
     ),
+    ("tinyplace_list_bounties", schemas.LIST_BOUNTIES, tools.list_bounties),
+    ("tinyplace_create_bounty", schemas.CREATE_BOUNTY, tools.create_bounty),
+    ("tinyplace_submit_bounty", schemas.SUBMIT_BOUNTY, tools.submit_bounty),
+    ("tinyplace_fund_bounty", schemas.FUND_BOUNTY, tools.fund_bounty),
 )
 
 

--- a/sdk/plugin-hermes/src/tinyplace/plugin.yaml
+++ b/sdk/plugin-hermes/src/tinyplace/plugin.yaml
@@ -28,6 +28,10 @@ provides_tools:
   - tinyplace_accept_escrow
   - tinyplace_deliver_escrow
   - tinyplace_accept_escrow_delivery
+  - tinyplace_list_bounties
+  - tinyplace_create_bounty
+  - tinyplace_submit_bounty
+  - tinyplace_fund_bounty
 requires_env:
   - name: TINYPLACE_AGENT_KEY
     description: >-

--- a/sdk/plugin-hermes/src/tinyplace/schemas.py
+++ b/sdk/plugin-hermes/src/tinyplace/schemas.py
@@ -479,3 +479,79 @@ BUY_PRODUCT = {
         "required": ["product_id"],
     },
 }
+
+LIST_BOUNTIES = {
+    "name": "tinyplace_list_bounties",
+    "description": (
+        "Browse bounties on tiny.place — open tasks with a posted reward that "
+        "an autonomous council judges. Optionally filter by free-text 'query' "
+        "and/or 'status'. Use to find work to submit to (tinyplace_submit_bounty)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Optional free-text filter."},
+            "status": {"type": "string", "description": "Optional status filter (e.g. 'open')."},
+            "limit": {"type": "integer", "description": "Optional max number of bounties."},
+        },
+        "required": [],
+    },
+}
+
+CREATE_BOUNTY = {
+    "name": "tinyplace_create_bounty",
+    "description": (
+        "Create a bounty as THIS agent (the creator): a task with a reward an "
+        "autonomous council awards to the best submission. Fund it afterwards "
+        "with tinyplace_fund_bounty to escrow the reward."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string", "description": "The bounty title."},
+            "description": {"type": "string", "description": "What the bounty asks for."},
+            "amount": {
+                "type": "string",
+                "description": "The reward amount (e.g. '10').",
+            },
+            "asset": {
+                "type": "string",
+                "description": "Reward asset symbol. Defaults to 'USDC' when omitted.",
+            },
+        },
+        "required": ["title", "description", "amount"],
+    },
+}
+
+SUBMIT_BOUNTY = {
+    "name": "tinyplace_submit_bounty",
+    "description": (
+        "Submit work to a bounty as THIS agent — a URL pointing to the deliverable, "
+        "with an optional note. Find bounties with tinyplace_list_bounties."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "bounty_id": {"type": "string", "description": "The id of the bounty to submit to."},
+            "url": {"type": "string", "description": "A link to the submitted work."},
+            "note": {"type": "string", "description": "Optional note about the submission."},
+        },
+        "required": ["bounty_id", "url"],
+    },
+}
+
+FUND_BOUNTY = {
+    "name": "tinyplace_fund_bounty",
+    "description": (
+        "Fund a bounty you created, settling its reward into escrow on chain "
+        "(x402). Requires a configured Solana network + a funded agent wallet "
+        "(TINYPLACE_SOLANA_NETWORK); without that it returns an actionable error."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "bounty_id": {"type": "string", "description": "The id of the bounty to fund."}
+        },
+        "required": ["bounty_id"],
+    },
+}

--- a/sdk/plugin-hermes/src/tinyplace/schemas.py
+++ b/sdk/plugin-hermes/src/tinyplace/schemas.py
@@ -484,14 +484,16 @@ LIST_BOUNTIES = {
     "name": "tinyplace_list_bounties",
     "description": (
         "Browse bounties on tiny.place — open tasks with a posted reward that "
-        "an autonomous council judges. Optionally filter by free-text 'query' "
-        "and/or 'status'. Use to find work to submit to (tinyplace_submit_bounty)."
+        "an autonomous council judges. Optionally filter by 'status'. Use to "
+        "find work to submit to (tinyplace_submit_bounty)."
     ),
     "parameters": {
         "type": "object",
         "properties": {
-            "query": {"type": "string", "description": "Optional free-text filter."},
-            "status": {"type": "string", "description": "Optional status filter (e.g. 'open')."},
+            "status": {
+                "type": "string",
+                "description": "Optional status filter: open, judging, awarded, etc.",
+            },
             "limit": {"type": "integer", "description": "Optional max number of bounties."},
         },
         "required": [],

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -690,10 +690,8 @@ def accept_escrow_delivery(args: dict[str, Any], ctx: dict[str, Any]) -> str:
 @_guard
 def list_bounties(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     runtime: TinyPlaceRuntime = ctx["runtime"]
+    # The bounty list API supports creator/status/limit/offset — no text search.
     params: dict[str, Any] = {}
-    query = args.get("query")
-    if isinstance(query, str) and query.strip():
-        params["q"] = query.strip()
     status = args.get("status")
     if isinstance(status, str) and status.strip():
         params["status"] = status.strip()

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -687,6 +687,113 @@ def accept_escrow_delivery(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     return _ok({"escrow_id": escrow_id, "escrow": runtime.run(_run())})
 
 
+@_guard
+def list_bounties(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    params: dict[str, Any] = {}
+    query = args.get("query")
+    if isinstance(query, str) and query.strip():
+        params["q"] = query.strip()
+    status = args.get("status")
+    if isinstance(status, str) and status.strip():
+        params["status"] = status.strip()
+    limit = _coerce_limit(args.get("limit"))
+    if limit is not None:
+        params["limit"] = limit
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "bounties").list(params or None)
+
+    return _ok(runtime.run(_run()))
+
+
+@_guard
+def create_bounty(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    title = str(args.get("title") or "").strip()
+    description = args.get("description")
+    amount = args.get("amount")
+    if not title:
+        return _error("'title' is required")
+    if not isinstance(description, str) or not description.strip():
+        return _error("'description' is required")
+    if not isinstance(amount, str) or not amount.strip():
+        return _error("'amount' is required (the reward amount, e.g. '10')")
+    asset = args.get("asset")
+    asset = asset.strip() if isinstance(asset, str) and asset.strip() else "USDC"
+    request: dict[str, Any] = {
+        "creator": runtime.address,
+        "title": title,
+        "description": description.strip(),
+        "amount": amount.strip(),
+        "asset": asset,
+    }
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "bounties").create(request)
+
+    return _ok({"bounty": runtime.run(_run())})
+
+
+@_guard
+def submit_bounty(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    bounty_id = str(args.get("bounty_id") or "").strip()
+    url = args.get("url")
+    if not bounty_id:
+        return _error("'bounty_id' is required")
+    if not isinstance(url, str) or not url.strip():
+        return _error("'url' is required (a link to the submitted work)")
+    request: dict[str, Any] = {"submitter": runtime.address, "url": url.strip()}
+    note = args.get("note")
+    if isinstance(note, str) and note.strip():
+        request["note"] = note.strip()
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "bounties").submit(bounty_id, request)
+
+    return _ok({"bounty_id": bounty_id, "submission": runtime.run(_run())})
+
+
+@_guard
+def fund_bounty(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    bounty_id = str(args.get("bounty_id") or "").strip()
+    if not bounty_id:
+        return _error("'bounty_id' is required")
+    settlement = runtime.payment_settlement()
+    if settlement is None:
+        return _error(
+            "funding a bounty settles the reward into escrow on chain — set "
+            "TINYPLACE_SOLANA_NETWORK (and fund the agent wallet) to enable it."
+        )
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        bounties = _require(client, "bounties")
+        if not hasattr(bounties, "fund_with_solana_payment"):
+            raise RuntimeError(
+                "on-chain bounty funding needs a tiny.place Python SDK that "
+                "provides bounties.fund_with_solana_payment; upgrade the SDK."
+            )
+        return await bounties.fund_with_solana_payment(
+            bounty_id,
+            runtime.address,
+            rpc_url=settlement["rpc_url"],
+            secret_key=settlement["secret_key"],
+            mint=settlement["mint"],
+        )
+
+    result = runtime.run(_run())
+    payment = result.get("payment") if isinstance(result, dict) else None
+    on_chain_tx = payment.get("signature") if isinstance(payment, dict) else None
+    bounty = result.get("bounty") if isinstance(result, dict) else result
+    return _ok({"bounty_id": bounty_id, "bounty": bounty, "onChainTx": on_chain_tx})
+
+
 # --- helpers ----------------------------------------------------------------
 
 

--- a/sdk/plugin-hermes/tests/test_bounties.py
+++ b/sdk/plugin-hermes/tests/test_bounties.py
@@ -1,0 +1,109 @@
+"""Bounty tool handlers — injected fake ``bounties`` namespace + settlement gating."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from conftest import config as cfg
+from conftest import runtime as runtime_mod
+from conftest import tools
+
+_SEED = base64.b64encode(bytes(range(32))).decode("ascii")
+
+
+class _FakeBounties:
+    def __init__(self) -> None:
+        self.list_params: object = "<unset>"
+        self.created: list[dict] = []
+        self.submitted: list[tuple[str, dict]] = []
+        self.fund_calls: list[tuple] = []
+
+    async def list(self, params=None):
+        self.list_params = params
+        return {"bounties": [{"bountyId": "b1"}]}
+
+    async def create(self, request):
+        self.created.append(request)
+        return {"bountyId": "b1", **request}
+
+    async def submit(self, bounty_id, request):
+        self.submitted.append((bounty_id, request))
+        return {"submissionId": "s1", **request}
+
+    async def fund_with_solana_payment(self, bounty_id, creator, **kwargs):
+        self.fund_calls.append((bounty_id, creator, kwargs))
+        return {"bounty": {"bountyId": bounty_id, "status": "funded"}, "payment": {"signature": "sig"}}
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.bounties = _FakeBounties()
+
+
+def _make_runtime(tmp_path: Path, monkeypatch) -> "runtime_mod.TinyPlaceRuntime":
+    monkeypatch.setenv(cfg.ENV_AGENT_KEY, _SEED)
+    monkeypatch.setenv(cfg.ENV_STATE_DIR, str(tmp_path))
+    rt = runtime_mod.load_runtime()
+    rt._client = _FakeClient()
+    rt._session = object()
+    rt._keys_ready = True
+    return rt
+
+
+def test_list_bounties_builds_params(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.list_bounties({"query": "summarize", "status": "open"}, runtime=rt))
+    assert out["ok"] is True and out["bounties"][0]["bountyId"] == "b1"
+    assert rt._client.bounties.list_params == {"q": "summarize", "status": "open"}
+
+
+def test_create_bounty_addresses_as_self(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(
+        tools.create_bounty(
+            {"title": "Summarize X", "description": "do it", "amount": "10"}, runtime=rt
+        )
+    )
+    assert out["ok"] is True
+    created = rt._client.bounties.created[0]
+    assert created["creator"] == rt.address and created["title"] == "Summarize X"
+    assert created["amount"] == "10" and created["asset"] == "USDC"
+
+
+def test_submit_bounty_addresses_as_self(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(
+        tools.submit_bounty({"bounty_id": "b1", "url": "https://x", "note": "here"}, runtime=rt)
+    )
+    assert out["ok"] is True and out["bounty_id"] == "b1"
+    bounty_id, request = rt._client.bounties.submitted[0]
+    assert bounty_id == "b1" and request["submitter"] == rt.address
+    assert request["url"] == "https://x" and request["note"] == "here"
+
+
+def test_create_and_submit_validation(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    assert json.loads(tools.create_bounty({"title": "X"}, runtime=rt))["ok"] is False  # no desc/amount
+    assert json.loads(tools.submit_bounty({"bounty_id": "b1"}, runtime=rt))["ok"] is False  # no url
+
+
+def test_fund_bounty_settles_when_configured(tmp_path, monkeypatch):
+    monkeypatch.setenv("TINYPLACE_SOLANA_NETWORK", "devnet")
+    monkeypatch.setenv("TINYPLACE_SOLANA_RPC_URL", "https://rpc.example.test")
+    rt = _make_runtime(tmp_path, monkeypatch)
+
+    out = json.loads(tools.fund_bounty({"bounty_id": "b1"}, runtime=rt))
+    assert out["ok"] is True and out["onChainTx"] == "sig"
+    bounty_id, creator, kwargs = rt._client.bounties.fund_calls[0]
+    assert bounty_id == "b1" and creator == rt.address
+    assert kwargs["rpc_url"] == "https://rpc.example.test"
+    assert isinstance(kwargs["secret_key"], (bytes, bytearray))
+
+
+def test_fund_bounty_requires_solana_config(tmp_path, monkeypatch):
+    monkeypatch.delenv("TINYPLACE_SOLANA_NETWORK", raising=False)
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.fund_bounty({"bounty_id": "b1"}, runtime=rt))
+    assert out["ok"] is False and "TINYPLACE_SOLANA_NETWORK" in out["error"]

--- a/sdk/plugin-hermes/tests/test_bounties.py
+++ b/sdk/plugin-hermes/tests/test_bounties.py
@@ -54,9 +54,10 @@ def _make_runtime(tmp_path: Path, monkeypatch) -> "runtime_mod.TinyPlaceRuntime"
 
 def test_list_bounties_builds_params(tmp_path, monkeypatch):
     rt = _make_runtime(tmp_path, monkeypatch)
+    # query is ignored (the bounty list API has no text search); status passes through.
     out = json.loads(tools.list_bounties({"query": "summarize", "status": "open"}, runtime=rt))
     assert out["ok"] is True and out["bounties"][0]["bountyId"] == "b1"
-    assert rt._client.bounties.list_params == {"q": "summarize", "status": "open"}
+    assert rt._client.bounties.list_params == {"status": "open"}
 
 
 def test_create_bounty_addresses_as_self(tmp_path, monkeypatch):

--- a/sdk/plugin-hermes/tests/test_register.py
+++ b/sdk/plugin-hermes/tests/test_register.py
@@ -64,6 +64,10 @@ def test_all_tools_register():
         "tinyplace_accept_escrow",
         "tinyplace_deliver_escrow",
         "tinyplace_accept_escrow_delivery",
+        "tinyplace_list_bounties",
+        "tinyplace_create_bounty",
+        "tinyplace_submit_bounty",
+        "tinyplace_fund_bounty",
     ]
     for tool in ctx.tools:
         assert tool["toolset"] == "tinyplace"
@@ -109,6 +113,10 @@ def test_schemas_are_well_formed():
         schemas.ACCEPT_ESCROW,
         schemas.DELIVER_ESCROW,
         schemas.ACCEPT_ESCROW_DELIVERY,
+        schemas.LIST_BOUNTIES,
+        schemas.CREATE_BOUNTY,
+        schemas.SUBMIT_BOUNTY,
+        schemas.FUND_BOUNTY,
     ):
         assert set(schema) >= {"name", "description", "parameters"}
         assert schema["parameters"]["type"] == "object"


### PR DESCRIPTION
## What
Part 2 of 2 for Phase 6 / #114 — the plugin layer. Four tools for the bounty platform:

- **`tinyplace_list_bounties`** / **`tinyplace_create_bounty`** / **`tinyplace_submit_bounty`** — browse, post (as creator), and submit work (a URL) as this agent.
- **`tinyplace_fund_bounty`** — settle the reward into escrow on chain (x402) via the SDK's `bounties.fund_with_solana_payment` + the runtime's `payment_settlement()` config. Gated on `TINYPLACE_SOLANA_NETWORK` with a clear error otherwise; `hasattr` guard for older SDKs.

Each routes through the lazy `_require(client, "bounties")` guard, so the plugin still loads on an SDK that predates the bounties namespace. Plugin tests inject a fake bounties namespace, so they pass independently. **69 plugin tests pass** (verified against the pre-bounties `upstream/main` SDK).

## Depends on
⚠️ **#118** (the SDK's `BountiesApi`). Merge #118 first.

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four new tinyplace bounty tools: list, create, submit work, and fund bounties (including optional on-chain settlement details when configured).

* **Tests**
  * Added test coverage for bounty listing/creation/submission validation and funding behavior, including conditional on-chain payment settlement.

* **Documentation**
  * Updated the tinyplace tools documentation and the demo/runbook with bounties workflow details and the autonomous council winner selection flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->