### PR TITLE
fix(sdk): include private flag in the signed user.profile payload

### DIFF
--- a/sdk/rust/src/api/users.rs
+++ b/sdk/rust/src/api/users.rs
@@ -129,6 +129,7 @@ fn user_profile_signature_payload(crypto_id: &str, update: &UserProfileUpdate) -
             "displayName": or_null(&update.display_name),
             "harnessKey": or_null(&update.harness_key),
             "link": or_null(&update.link),
+            "private": or_null(&update.private),
             "tags": arr_or_null(&update.tags),
         }),
     )
@@ -172,4 +173,32 @@ fn user_email_confirm_signature_payload(
             "harnessKey": or_null(request.harness_key.as_deref()),
         }),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression: the backend's canonical user.profile payload includes the
+    // wallet-level `private` flag. If the SDK omits it, the signature never
+    // verifies and profile saves fail with HTTP 401.
+    #[test]
+    fn profile_payload_includes_private_flag() {
+        let default_payload =
+            user_profile_signature_payload("cid123", &UserProfileUpdate::default());
+        assert!(
+            default_payload.contains("\"private\":null"),
+            "default payload must carry private as null: {default_payload}"
+        );
+
+        let update = UserProfileUpdate {
+            private: Some(true),
+            ..Default::default()
+        };
+        let set_payload = user_profile_signature_payload("cid123", &update);
+        assert!(
+            set_payload.contains("\"private\":true"),
+            "payload must carry the set private flag: {set_payload}"
+        );
+    }
 }

--- a/sdk/rust/src/types/user.rs
+++ b/sdk/rust/src/types/user.rs
@@ -57,6 +57,9 @@ pub struct UserProfileUpdate {
     pub link: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    /// Wallet-level privacy flag; omit to leave the current value unchanged.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub private: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signature: Option<String>,
 }

--- a/sdk/typescript/src/api/users.ts
+++ b/sdk/typescript/src/api/users.ts
@@ -114,6 +114,7 @@ function userProfileSignaturePayload(
     displayName: update.displayName ?? null,
     harnessKey: update.harnessKey ?? null,
     link: update.link ?? null,
+    private: update.private ?? null,
     tags: update.tags ?? null,
   });
 }

--- a/sdk/typescript/src/types/user.ts
+++ b/sdk/typescript/src/types/user.ts
@@ -42,6 +42,8 @@ export interface UserProfileUpdate {
   harnessKey?: string;
   link?: string;
   tags?: Array<string>;
+  /** Wallet-level privacy flag; omit to leave the current value unchanged. */
+  private?: boolean;
   signature?: string;
 }
 

--- a/sdk/typescript/tests/users.test.ts
+++ b/sdk/typescript/tests/users.test.ts
@@ -1,5 +1,6 @@
+import { ed25519 } from "@noble/curves/ed25519.js";
 import { describe, expect, it } from "vitest";
-import { LocalSigner, TinyPlaceClient } from "../src/index.js";
+import { canonicalPayload, LocalSigner, TinyPlaceClient } from "../src/index.js";
 
 describe("UsersApi", () => {
   it("fetches a wallet profile by cryptoId", async () => {
@@ -79,6 +80,57 @@ describe("UsersApi", () => {
     expect(body.harnessKey).toBe("hermes-v1");
     expect(typeof body.signature).toBe("string");
     expect(body.signature!.length).toBeGreaterThan(0);
+  });
+
+  it("includes the private flag in the signed user.profile payload", async () => {
+    // Regression: the backend's canonical user.profile payload includes the
+    // wallet-level `private` flag. If the SDK omits it from the signed payload,
+    // the signature never verifies and profile saves fail with HTTP 401.
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(9));
+    let captured: Request | undefined;
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      signer,
+      fetch: async (input, init) => {
+        captured = new Request(input, init);
+        return Response.json({
+          cryptoId: "WalletCrypto222",
+          actorType: "agent",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-02T00:00:00Z",
+        });
+      },
+    });
+
+    await client.users.updateProfile("WalletCrypto222", {
+      displayName: "Ada",
+      private: true,
+    });
+
+    const body = (await captured!.json()) as { signature: string };
+    // Freshness signature: v1:<b64url(ts)>:<b64url(nonce)>:<b64(sig)>.
+    const [version, tsPart, noncePart, sigPart] = body.signature.split(":");
+    expect(version).toBe("v1");
+    const timestamp = Buffer.from(tsPart!, "base64url").toString("utf8");
+    const nonce = Buffer.from(noncePart!, "base64url").toString("utf8");
+    const signature = new Uint8Array(Buffer.from(sigPart!, "base64"));
+
+    // Reconstruct the exact canonical payload the client must have signed,
+    // including `private`, and verify the signature against it.
+    const payload = canonicalPayload("user.profile", {
+      actorType: null,
+      avatarEmail: null,
+      bio: null,
+      cryptoId: "WalletCrypto222",
+      displayName: "Ada",
+      harnessKey: null,
+      link: null,
+      private: true,
+      tags: null,
+    });
+    const message = new TextEncoder().encode(`${payload}\n${timestamp}\n${nonce}`);
+    const publicKey = new Uint8Array(Buffer.from(signer.publicKeyBase64, "base64"));
+    expect(ed25519.verify(signature, message, publicKey)).toBe(true);
   });
 
   it("starts and confirms email verification with signed wallet-scoped payloads", async () => {


### PR DESCRIPTION
## Bug

Editing a profile and clicking **Save** fails with:

> `HTTP 401: /users/<cryptoId>/profile`

## Root cause

The backend's canonical `user.profile` payload — `internal/users/handler.go` `userProfilePayload` — signs over these fields:

```
actorType, avatarEmail, bio, cryptoId, displayName, harnessKey, link, private, tags
```

Both the TypeScript and Rust SDKs omitted **`private`** from the payload they sign. The client's canonical string therefore differed from the one the backend derives (which includes `private`, defaulting to `null`), so the freshness-bound signature never verified and the request was rejected as **401 Unauthorized**. This broke *all* profile saves from the web app.

## Fix

- **TS SDK** — add `private?: boolean` to `UserProfileUpdate`, and `private: update.private ?? null` to `userProfileSignaturePayload`.
- **Rust SDK** — add `private: Option<bool>` to `UserProfileUpdate`, and `"private"` to `user_profile_signature_payload`.

The signed field set now matches the backend exactly, so the signature verifies. Omitting `private` (as the web ProfileEditor does) signs it as `null`, which leaves the current value unchanged — matching the backend contract.

## Tests

- **TS**: a regression test that reconstructs the `v1:<ts>:<nonce>:<sig>` freshness signature from the request body and **cryptographically verifies** (ed25519) it covers a payload including `private` — so dropping the field again fails the test.
- **Rust**: a unit test asserting the canonical payload carries `"private":null` by default and `"private":true` when set.

## Scope

- Python SDK is unaffected (it does not sign profile updates).
- **No website code change needed** — `ProfileEditor` passes the update through unchanged; the web app picks up the fix when the SDK is rebuilt (Vercel builds the SDK first).

## Validation

- TS: `tsc --noEmit` ✅, full SDK suite ✅ (249 passed), website typecheck ✅ against the rebuilt SDK
- Rust: `cargo fmt --check` ✅, `cargo clippy --all-targets -- -D warnings` ✅, `cargo test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional wallet-level privacy flag to user profile updates, available in both Rust and TypeScript SDKs. Users can now modify privacy settings independently without affecting other profile data.

* **Tests**
  * Added test coverage to ensure the privacy flag is properly included in signed profile update requests and validated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->