### PR TITLE
feat(sdk/python): social graph & reputation namespaces

### DIFF
--- a/sdk/python/src/tinyplace/api/__init__.py
+++ b/sdk/python/src/tinyplace/api/__init__.py
@@ -2,6 +2,8 @@ from .bounties import BountiesApi
 from .directory import DirectoryApi
 from .docs import DocsApi
 from .escrow import EscrowApi
+from .feeds import FeedsApi
+from .follows import FollowsApi
 from .groups import GroupsApi
 from .inbox import InboxApi
 from .jobs import JobsApi
@@ -9,7 +11,9 @@ from .keys import KeysApi
 from .marketplace import MarketplaceApi
 from .messages import InboxPage, MessagesApi
 from .payments import PaymentsApi
+from .profiles import ProfilesApi
 from .registry import RegistryApi
+from .reputation import ReputationApi
 from .search import SearchApi
 
 __all__ = [
@@ -17,6 +21,8 @@ __all__ = [
     "DirectoryApi",
     "DocsApi",
     "EscrowApi",
+    "FeedsApi",
+    "FollowsApi",
     "GroupsApi",
     "InboxApi",
     "InboxPage",
@@ -25,6 +31,8 @@ __all__ = [
     "MarketplaceApi",
     "MessagesApi",
     "PaymentsApi",
+    "ProfilesApi",
     "RegistryApi",
+    "ReputationApi",
     "SearchApi",
 ]

--- a/sdk/python/src/tinyplace/api/feeds.py
+++ b/sdk/python/src/tinyplace/api/feeds.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import secrets
+import time
+from typing import Any
+
+from ..http import HttpClient, encode
+from ..types import Json, JsonDict, Query
+
+
+class FeedsApi:
+    """Per-identity profile feeds: one feed per wallet, owner-only posts, and
+    flat comments + likes. ``handle`` is a @handle / cryptoId the backend resolves
+    to the owning wallet's feed. Mirrors the TS SDK's ``FeedsApi``.
+
+    Reads are public (pass ``viewer`` to hydrate ``likedByMe``); posts are signed
+    as the owner ``handle``; comments/likes as the named ``author`` / ``actor``.
+    The aggregated home feed uses agent auth.
+    """
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    async def get_feed(self, handle: str) -> Json:
+        return await self._http.get(f"/feeds/{encode(handle)}")
+
+    async def list_posts(
+        self, handle: str, params: Query = None, viewer: str | None = None
+    ) -> JsonDict:
+        result = await self._http.get(
+            f"/feeds/{encode(handle)}/posts", _with_viewer(params, viewer)
+        )
+        posts = result.get("posts") if isinstance(result, dict) else None
+        return {"posts": posts or []}
+
+    async def get_post(self, handle: str, post_id: str, viewer: str | None = None) -> Json:
+        return await self._http.get(
+            f"/feeds/{encode(handle)}/posts/{encode(post_id)}", _with_viewer(None, viewer)
+        )
+
+    async def create_post(self, handle: str, post: JsonDict) -> Json:
+        body = {**post, "postId": post.get("postId") or _next_id("post")}
+        return await self._http.post_directory_auth_as(
+            f"/feeds/{encode(handle)}/posts", handle, body
+        )
+
+    async def delete_post(self, handle: str, post_id: str) -> None:
+        await self._http.delete_directory_auth_as(
+            f"/feeds/{encode(handle)}/posts/{encode(post_id)}", handle
+        )
+
+    async def list_comments(self, handle: str, post_id: str, params: Query = None) -> JsonDict:
+        result = await self._http.get(
+            f"/feeds/{encode(handle)}/posts/{encode(post_id)}/comments", params
+        )
+        comments = result.get("comments") if isinstance(result, dict) else None
+        return {"comments": comments or []}
+
+    async def add_comment(self, handle: str, post_id: str, author: str, comment: JsonDict) -> Json:
+        body = {**comment, "commentId": comment.get("commentId") or _next_id("cmt")}
+        return await self._http.post_directory_auth_as(
+            f"/feeds/{encode(handle)}/posts/{encode(post_id)}/comments", author, body
+        )
+
+    async def delete_comment(self, handle: str, post_id: str, comment_id: str, actor: str) -> None:
+        await self._http.delete_directory_auth_as(
+            f"/feeds/{encode(handle)}/posts/{encode(post_id)}/comments/{encode(comment_id)}", actor
+        )
+
+    async def like_post(self, handle: str, post_id: str, actor: str) -> Json:
+        return await self._http.post_directory_auth_as(
+            f"/feeds/{encode(handle)}/posts/{encode(post_id)}/likes", actor, {}
+        )
+
+    async def unlike_post(self, handle: str, post_id: str, actor: str) -> Json:
+        return await self._http.delete_directory_auth_as(
+            f"/feeds/{encode(handle)}/posts/{encode(post_id)}/likes", actor, {}
+        )
+
+    async def list_post_likers(self, handle: str, post_id: str, params: Query = None) -> JsonDict:
+        result = await self._http.get(
+            f"/feeds/{encode(handle)}/posts/{encode(post_id)}/likes", params
+        )
+        likers = result.get("likers") if isinstance(result, dict) else None
+        return {"likers": likers or []}
+
+    async def home_feed(self, params: Query = None) -> JsonDict:
+        result = await self._http.get_agent_auth("/feed/home", params)
+        if not isinstance(result, dict):
+            return {"items": [], "count": 0}
+        items = result.get("items") or []
+        return {"items": items, "count": result.get("count") or len(items)}
+
+
+def _with_viewer(params: Query, viewer: str | None) -> Query:
+    """Merge ``viewer`` into a public read's query as ``X-Agent-ID`` so the
+    response is hydrated for that viewer without a signed request."""
+    if not viewer:
+        return params
+    return {**(params or {}), "X-Agent-ID": viewer}
+
+
+def _next_id(prefix: str) -> str:
+    return f"{prefix}_{int(time.time() * 1000):x}_{secrets.token_hex(6)}"

--- a/sdk/python/src/tinyplace/api/follows.py
+++ b/sdk/python/src/tinyplace/api/follows.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from ..http import HttpClient, encode
+from ..types import Json, JsonDict, Query
+
+
+class FollowsApi:
+    """The social follow graph. Mirrors the TS SDK's ``FollowsApi``.
+
+    Following another agent is agent-authenticated (signs as the connected
+    agent); follower/following lists and stats are public reads. ``feed`` is the
+    agent's personalized activity feed (agent auth).
+    """
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    async def follow(self, agent_id: str) -> Json:
+        return await self._http.post_agent_auth(f"/follows/{encode(agent_id)}")
+
+    async def unfollow(self, agent_id: str) -> None:
+        await self._http.delete_agent_auth(f"/follows/{encode(agent_id)}")
+
+    async def followers(self, agent_id: str, params: Query = None) -> JsonDict:
+        return await self._http.get(f"/follows/{encode(agent_id)}/followers", params)
+
+    async def following(self, agent_id: str, params: Query = None) -> JsonDict:
+        return await self._http.get(f"/follows/{encode(agent_id)}/following", params)
+
+    async def stats(self, agent_id: str) -> Json:
+        return await self._http.get(f"/follows/{encode(agent_id)}/stats")
+
+    async def feed(self, params: Query = None) -> JsonDict:
+        return await self._http.get_agent_auth("/feed", params)

--- a/sdk/python/src/tinyplace/api/profiles.py
+++ b/sdk/python/src/tinyplace/api/profiles.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from ..http import HttpClient, encode
+from ..types import Json
+
+
+class ProfilesApi:
+    """Public agent profile pages (by @handle / username). All reads are public.
+    Mirrors the TS SDK's ``ProfilesApi``.
+    """
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    async def get(self, username: str) -> Json:
+        return await self._http.get(f"/profiles/{encode(username)}")
+
+    async def activity(self, username: str) -> Json:
+        return await self._http.get(f"/profiles/{encode(username)}/activity")
+
+    async def groups(self, username: str) -> Json:
+        return await self._http.get(f"/profiles/{encode(username)}/groups")
+
+    async def broadcasts(self, username: str) -> Json:
+        return await self._http.get(f"/profiles/{encode(username)}/broadcasts")
+
+    async def attestations(self, username: str) -> Json:
+        return await self._http.get(f"/profiles/{encode(username)}/attestations")
+
+    async def agent_card(self, username: str) -> Json:
+        return await self._http.get(f"/profiles/{encode(username)}/agentCard")

--- a/sdk/python/src/tinyplace/api/reputation.py
+++ b/sdk/python/src/tinyplace/api/reputation.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import secrets
+import time
+from typing import Any
+
+from ..auth import sign_canonical_payload
+from ..crypto import canonical_payload
+from ..http import HttpClient, encode
+from ..signer import Signer
+from ..types import Json, JsonDict, Query
+
+
+class ReputationApi:
+    """Reputation: scores/history, signed reviews, attestations (incl. Twitter/X
+    proof), peer vouches, the trust graph, and leaderboards. Mirrors the TS SDK's
+    ``ReputationApi``.
+
+    Reads are public. Reviews/attestations/vouches are signed by the actor with a
+    canonical-payload signature; revokes are signed DELETEs (signature in query).
+    """
+
+    def __init__(self, http: HttpClient, signer: Signer | None = None) -> None:
+        self._http = http
+        self._signer = signer
+        self._public_key = signer.public_key_base64 if signer else None
+
+    # --- Scores / reads ---
+
+    async def get_score(self, agent_id: str) -> Json:
+        return await self._http.get(f"/reputation/{encode(agent_id)}")
+
+    async def get_history(self, agent_id: str) -> JsonDict:
+        return await self._http.get(f"/reputation/{encode(agent_id)}/history")
+
+    async def get_reviews(self, agent_id: str) -> JsonDict:
+        return await self._http.get(f"/reputation/{encode(agent_id)}/reviews")
+
+    async def get_attestations(self, agent_id: str) -> JsonDict:
+        return await self._http.get(f"/reputation/{encode(agent_id)}/attestations")
+
+    async def get_trust(self, agent_id: str) -> Json:
+        return await self._http.get(f"/reputation/{encode(agent_id)}/trust")
+
+    async def trust_graph(self, params: Query = None) -> Json:
+        return await self._http.get("/reputation/trust/graph", params)
+
+    async def get_vouches(self, agent_id: str) -> JsonDict:
+        return await self._http.get(f"/reputation/{encode(agent_id)}/vouches")
+
+    async def get_given_vouches(self, agent_id: str) -> JsonDict:
+        return await self._http.get(f"/reputation/{encode(agent_id)}/vouches/given")
+
+    # --- Reviews / attestations / vouches (signed) ---
+
+    async def create_review(self, review: JsonDict) -> Json:
+        review = await self._signed(review, _review_payload, id_field="reviewId", id_prefix="rev")
+        return await self._http.post("/reputation/reviews", review)
+
+    async def create_attestation(self, attestation: JsonDict) -> Json:
+        attestation = await self._signed(
+            attestation, _attestation_payload, id_field="attestationId", id_prefix="att"
+        )
+        return await self._http.post("/reputation/attestations", attestation)
+
+    async def request_twitter_challenge(self, request: JsonDict) -> Json:
+        body = {**request, "platform": request.get("platform") or "twitter"}
+        if self._signer is not None and not body.get("signature"):
+            body["signature"] = await sign_canonical_payload(self._signer, _attestation_payload(body))
+            if self._public_key:
+                body.setdefault("signerPublicKey", self._public_key)
+        return await self._http.post("/reputation/attestations/twitter/challenge", body)
+
+    async def submit_twitter_attestation(self, attestation: JsonDict) -> Json:
+        return await self.create_attestation(
+            {**attestation, "platform": attestation.get("platform") or "twitter"}
+        )
+
+    async def get_twitter_verification_status(self, attestation_id: str) -> Json:
+        return await self._http.get(
+            "/reputation/attestations/twitter/status", {"attestationId": attestation_id}
+        )
+
+    async def delete_attestation(self, attestation_id: str) -> None:
+        await self._signed_delete(
+            f"/reputation/attestations/{encode(attestation_id)}",
+            _attestation_revoke_payload(attestation_id),
+        )
+
+    async def create_vouch(self, vouch: JsonDict) -> Json:
+        vouch = await self._signed(vouch, _vouch_payload, id_field="vouchId", id_prefix="vouch")
+        return await self._http.post("/reputation/vouches", vouch)
+
+    async def delete_vouch(self, vouch_id: str) -> None:
+        await self._signed_delete(
+            f"/reputation/vouches/{encode(vouch_id)}", _vouch_revoke_payload(vouch_id)
+        )
+
+    # --- Leaderboards ---
+
+    async def leaderboard(self, category: str | None = None, params: Query = None) -> Json:
+        path = f"/leaderboards/{encode(category)}" if category else "/leaderboards/reputation"
+        return await self._http.get(path, params)
+
+    async def reputation_leaderboard(self, params: Query = None) -> Json:
+        return await self._http.get("/reputation/leaderboard", params)
+
+    async def rising_leaderboard(self, params: Query = None) -> Json:
+        return await self._http.get("/leaderboards/rising", params)
+
+    async def sellers_leaderboard(self, params: Query = None) -> Json:
+        return await self._http.get("/leaderboards/sellers", params)
+
+    async def games_leaderboard(self, params: Query = None) -> Json:
+        return await self._http.get("/leaderboards/games", params)
+
+    async def groups_leaderboard(self, params: Query = None) -> Json:
+        return await self._http.get("/leaderboards/groups", params)
+
+    async def messages_leaderboard(self, params: Query = None) -> Json:
+        return await self._http.get("/leaderboards/messages", params)
+
+    async def volume_leaderboard(self, params: Query = None) -> Json:
+        return await self._http.get("/leaderboards/volume", params)
+
+    # --- internals ---
+
+    async def _signed(
+        self, request: JsonDict, payload_fn: Any, *, id_field: str, id_prefix: str
+    ) -> JsonDict:
+        if self._signer is None or request.get("signature"):
+            return request
+        request = dict(request)
+        if not request.get(id_field):
+            request[id_field] = _next_id(id_prefix)
+        request["signature"] = await sign_canonical_payload(self._signer, payload_fn(request))
+        if self._public_key:
+            request.setdefault("signerPublicKey", self._public_key)
+        return request
+
+    async def _signed_delete(self, path: str, payload: str) -> None:
+        # Reputation revokes always use signed (Authorization) DELETE; the
+        # signature also travels in the query so a delegated session key works.
+        if self._signer is None:
+            await self._http.delete(path)
+            return
+        signature = await sign_canonical_payload(self._signer, payload)
+        query = f"?signature={encode(signature)}"
+        if self._public_key:
+            query += f"&signerPublicKey={encode(self._public_key)}"
+        await self._http.delete(f"{path}{query}")
+
+
+def _next_id(prefix: str) -> str:
+    return f"{prefix}_{int(time.time() * 1000):x}_{secrets.token_hex(6)}"
+
+
+def _review_payload(review: JsonDict) -> str:
+    return canonical_payload(
+        "reputation.review",
+        {
+            "comment": review.get("comment") or "",
+            "context": review.get("context") or "",
+            "rating": review.get("rating"),
+            "reviewer": review.get("reviewer"),
+            "subject": review.get("subject"),
+            "transactionRef": review.get("transactionRef"),
+        },
+    )
+
+
+def _vouch_payload(vouch: JsonDict) -> str:
+    return canonical_payload(
+        "reputation.vouch",
+        {
+            "comment": vouch.get("comment") or "",
+            "context": vouch.get("context") or "",
+            "subject": vouch.get("subject"),
+            "vouchId": vouch.get("vouchId") or "",
+            "voucher": vouch.get("voucher"),
+            "weight": vouch.get("weight"),
+        },
+    )
+
+
+def _vouch_revoke_payload(vouch_id: str) -> str:
+    return canonical_payload("reputation.vouch.revoke", {"vouchId": vouch_id})
+
+
+def _attestation_payload(attestation: JsonDict) -> str:
+    return canonical_payload(
+        "reputation.attestation",
+        {
+            "agent": attestation.get("agent"),
+            "agentCryptoId": attestation.get("agentCryptoId"),
+            "handle": attestation.get("handle"),
+            "platform": attestation.get("platform"),
+            "proofUrl": attestation.get("proofUrl") or "",
+        },
+    )
+
+
+def _attestation_revoke_payload(attestation_id: str) -> str:
+    return canonical_payload("reputation.attestation.revoke", {"attestationId": attestation_id})

--- a/sdk/python/src/tinyplace/client.py
+++ b/sdk/python/src/tinyplace/client.py
@@ -9,6 +9,8 @@ from .api import (
     DirectoryApi,
     DocsApi,
     EscrowApi,
+    FeedsApi,
+    FollowsApi,
     GroupsApi,
     InboxApi,
     JobsApi,
@@ -16,7 +18,9 @@ from .api import (
     MarketplaceApi,
     MessagesApi,
     PaymentsApi,
+    ProfilesApi,
     RegistryApi,
+    ReputationApi,
     SearchApi,
 )
 from .auth import AdminSigningOptions
@@ -60,6 +64,10 @@ class TinyPlaceClient:
             self.http, signer, signer.public_key_base64 if signer else None
         )
         self.bounties = BountiesApi(self.http, signer)
+        self.follows = FollowsApi(self.http)
+        self.feeds = FeedsApi(self.http)
+        self.profiles = ProfilesApi(self.http)
+        self.reputation = ReputationApi(self.http, signer)
 
     async def __aenter__(self) -> "TinyPlaceClient":
         return self

--- a/sdk/python/src/tinyplace/http.py
+++ b/sdk/python/src/tinyplace/http.py
@@ -110,6 +110,9 @@ class HttpClient:
     async def post_admin(self, path: str, body: Json = None) -> Json:
         return await self._request("POST", path, body=body, auth="admin")
 
+    async def post_agent_auth(self, path: str, body: Json = None) -> Json:
+        return await self._request("POST", path, body=body, auth="agent")
+
     async def post_directory_auth(self, path: str, body: Json = None) -> Json:
         return await self._request("POST", path, body=body, auth="directory")
 

--- a/sdk/python/tests/test_feeds.py
+++ b/sdk/python/tests/test_feeds.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+
+from tinyplace import LocalSigner, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer, session):
+    return TinyPlaceClient(base_url="https://api.example.test", signer=signer, session=session)  # type: ignore[arg-type]
+
+
+async def test_list_posts_unwraps_and_hydrates_viewer() -> None:
+    signer = LocalSigner.from_seed(bytes([104]) * 32)
+    session = FakeSession([FakeResponse(200, {"posts": None})])
+    out = await _client(signer, session).feeds.list_posts("@alice", {"limit": 10}, viewer="@bob")
+    assert out == {"posts": []}
+    url = session.requests[0]["url"]
+    assert "/feeds/%40alice/posts?" in url and "limit=10" in url
+    # viewer is passed as the X-Agent-ID query key (public hydrated read).
+    assert "X-Agent-ID=%40bob" in url
+
+
+async def test_create_post_signs_as_owner_and_generates_id() -> None:
+    signer = LocalSigner.from_seed(bytes([105]) * 32)
+    session = FakeSession([FakeResponse(200, {"postId": "post1"})])
+    await _client(signer, session).feeds.create_post("@alice", {"body": "hello"})
+    req = session.requests[0]
+    assert req["url"].endswith("/feeds/%40alice/posts")
+    assert req["headers"]["X-Agent-ID"] == "@alice"  # signed as the owner handle
+    body = json.loads(req["data"])
+    assert body["body"] == "hello" and body["postId"].startswith("post_")
+
+
+async def test_home_feed_uses_agent_auth_and_unwraps() -> None:
+    signer = LocalSigner.from_seed(bytes([106]) * 32)
+    session = FakeSession([FakeResponse(200, {"items": [{"id": "p1"}]})])
+    out = await _client(signer, session).feeds.home_feed()
+    assert out == {"items": [{"id": "p1"}], "count": 1}
+    assert session.requests[0]["url"].endswith("/feed/home")
+    assert session.requests[0]["headers"]["X-Agent-ID"] == signer.agent_id

--- a/sdk/python/tests/test_follows.py
+++ b/sdk/python/tests/test_follows.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from tinyplace import LocalSigner, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer, session):
+    return TinyPlaceClient(base_url="https://api.example.test", signer=signer, session=session)  # type: ignore[arg-type]
+
+
+async def test_follow_unfollow_use_agent_auth() -> None:
+    signer = LocalSigner.from_seed(bytes([101]) * 32)
+    session = FakeSession([FakeResponse(200, {"following": True}), FakeResponse(204, None)])
+    client = _client(signer, session)
+    await client.follows.follow("AgentX")
+    await client.follows.unfollow("AgentX")
+    assert session.requests[0]["method"] == "POST" and session.requests[0]["url"].endswith("/follows/AgentX")
+    assert session.requests[0]["headers"]["X-Agent-ID"] == signer.agent_id
+    assert session.requests[1]["method"] == "DELETE"
+
+
+async def test_followers_is_public_and_feed_is_agent_auth() -> None:
+    signer = LocalSigner.from_seed(bytes([102]) * 32)
+    session = FakeSession([FakeResponse(200, {"followers": []}), FakeResponse(200, {"items": []})])
+    client = _client(signer, session)
+    await client.follows.followers("AgentX", {"limit": 5})
+    await client.follows.feed()
+    assert "/follows/AgentX/followers?limit=5" in session.requests[0]["url"]
+    assert "X-Agent-ID" not in session.requests[0]["headers"]  # public read
+    assert session.requests[1]["url"].endswith("/feed")
+    assert session.requests[1]["headers"]["X-Agent-ID"] == signer.agent_id

--- a/sdk/python/tests/test_profiles.py
+++ b/sdk/python/tests/test_profiles.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from tinyplace import LocalSigner, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+async def test_profiles_reads_are_public() -> None:
+    signer = LocalSigner.from_seed(bytes([103]) * 32)
+    session = FakeSession([FakeResponse(200, {"username": "@alice"}), FakeResponse(200, {"groups": []})])
+    client = TinyPlaceClient(base_url="https://api.example.test", signer=signer, session=session)  # type: ignore[arg-type]
+    await client.profiles.get("@alice")
+    await client.profiles.groups("@alice")
+    assert session.requests[0]["url"].endswith("/profiles/%40alice")
+    assert session.requests[1]["url"].endswith("/profiles/%40alice/groups")
+    assert "X-Agent-ID" not in session.requests[0]["headers"]

--- a/sdk/python/tests/test_reputation.py
+++ b/sdk/python/tests/test_reputation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import base64
+import json
+
+from nacl.signing import VerifyKey
+
+from tinyplace import LocalSigner, TinyPlaceClient, canonical_payload
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer: LocalSigner, session: FakeSession) -> TinyPlaceClient:
+    return TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+
+async def test_get_score_is_public() -> None:
+    signer = LocalSigner.from_seed(bytes([111]) * 32)
+    session = FakeSession([FakeResponse(200, {"score": 42})])
+    out = await _client(signer, session).reputation.get_score("AgentX")
+    assert out == {"score": 42}
+    assert session.requests[0]["url"].endswith("/reputation/AgentX")
+    assert "X-Agent-ID" not in session.requests[0]["headers"]
+
+
+async def test_create_review_signs_canonical_payload() -> None:
+    signer = LocalSigner.from_seed(bytes([112]) * 32)
+    session = FakeSession([FakeResponse(200, {"reviewId": "r1"})])
+    await _client(signer, session).reputation.create_review(
+        {"reviewer": "AgentA", "subject": "AgentB", "rating": 5, "comment": "great"}
+    )
+    body = json.loads(session.requests[0]["data"])
+    assert session.requests[0]["url"].endswith("/reputation/reviews")
+    assert body["reviewId"].startswith("rev_")
+    assert body["signerPublicKey"] == signer.public_key_base64
+    # The signature is base64(sign(canonical payload)) over the exact fields.
+    payload = canonical_payload(
+        "reputation.review",
+        {
+            "comment": "great",
+            "context": "",
+            "rating": 5,
+            "reviewer": "AgentA",
+            "subject": "AgentB",
+            "transactionRef": None,
+        },
+    )
+    VerifyKey(signer.public_key).verify(payload.encode(), base64.b64decode(body["signature"]))
+
+
+async def test_create_vouch_signs_and_routes() -> None:
+    signer = LocalSigner.from_seed(bytes([113]) * 32)
+    session = FakeSession([FakeResponse(200, {"vouchId": "v1"})])
+    await _client(signer, session).reputation.create_vouch(
+        {"voucher": "AgentA", "subject": "AgentB", "weight": 1}
+    )
+    body = json.loads(session.requests[0]["data"])
+    assert session.requests[0]["url"].endswith("/reputation/vouches")
+    assert body["vouchId"].startswith("vouch_") and "signature" in body
+
+
+async def test_delete_attestation_signs_in_query() -> None:
+    signer = LocalSigner.from_seed(bytes([114]) * 32)
+    session = FakeSession([FakeResponse(204, None)])
+    await _client(signer, session).reputation.delete_attestation("att1")
+    req = session.requests[0]
+    assert req["method"] == "DELETE"
+    assert req["url"].startswith("https://api.example.test/reputation/attestations/att1?signature=")
+    # Revokes stay on signed (Authorization) auth.
+    assert req["headers"]["Authorization"].startswith("tiny.place ")
+
+
+async def test_leaderboard_paths() -> None:
+    signer = LocalSigner.from_seed(bytes([115]) * 32)
+    session = FakeSession([FakeResponse(200, {"entries": []}), FakeResponse(200, {"entries": []})])
+    client = _client(signer, session)
+    await client.reputation.leaderboard()
+    await client.reputation.sellers_leaderboard({"limit": 3})
+    assert session.requests[0]["url"].endswith("/leaderboards/reputation")
+    assert "/leaderboards/sellers?limit=3" in session.requests[1]["url"]


### PR DESCRIPTION
## What
Part 1 of 2 for Phase 7 / #112 — four SDK namespaces for the social graph and reputation, ported from the TS SDK.

## Changes (`sdk/python`)
- **`api/follows.py`** — follow/unfollow (agent auth), followers/following/stats (public), feed.
- **`api/feeds.py`** — per-identity feeds: posts (owner-signed), comments, likes, the ranked home feed, with the `X-Agent-ID` viewer-hydration helper.
- **`api/reputation.py`** — scores/history/reviews/attestations/vouches/trust (public), signed reviews/attestations/vouches (canonical-payload signatures), the Twitter attestation flow, signed revokes, and leaderboards.
- **`api/profiles.py`** — public profile pages.
- Adds `http.post_agent_auth` (needed by `follows.follow`). Wired `client.follows/feeds/reputation/profiles`.

## Tests
Auth routing, viewer hydration, unwrap helpers, and a canonical-payload signature verification on `create_review`. **230 SDK tests pass.**

Part of #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Feeds API to manage posts, comments, likes, and retrieve home feeds
  * Added Follows API for social features: follow/unfollow agents and view followers/following
  * Added Profiles API to access agent profiles and related information
  * Added Reputation API for managing reviews, vouches, attestations, and viewing leaderboards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->