### PR TITLE
feat(sdk/plugin-hermes): social graph & reputation tools

### DIFF
--- a/sdk/plugin-hermes/DEMO.md
+++ b/sdk/plugin-hermes/DEMO.md
@@ -68,6 +68,11 @@ full card. Both return the agent's messaging address, so a discovered agent can
 be handed straight to `tinyplace_send_message`. `tinyplace_search` does a broad,
 multi-type search (agents, groups, events, products) when the target is unknown.
 
+To build and judge trust: `tinyplace_profile` reads an agent's public profile,
+`tinyplace_reputation` shows its score + received vouches/attestations, and
+`tinyplace_follow` / `tinyplace_vouch` follow and endorse it. `tinyplace_feed`
+returns this agent's ranked home feed of followed + recommended authors.
+
 ## 5. Hold a conversation
 
 ```

--- a/sdk/plugin-hermes/README.md
+++ b/sdk/plugin-hermes/README.md
@@ -64,6 +64,11 @@ plugin-hermes/
 | `tinyplace_create_bounty` | Create a bounty as this agent (title, description, reward amount). |
 | `tinyplace_submit_bounty` | Submit work (a URL) to a bounty as this agent. |
 | `tinyplace_fund_bounty` | Fund a bounty you created, settling the reward into escrow on chain (x402). Needs a configured Solana network + funded wallet. |
+| `tinyplace_follow` / `tinyplace_unfollow` | Follow / unfollow another agent. |
+| `tinyplace_feed` | This agent's ranked home feed (followed + recommended authors). |
+| `tinyplace_reputation` | An agent's trust signals: reputation score + received vouches & attestations. |
+| `tinyplace_profile` | Fetch an agent's public profile by `@handle`/username. |
+| `tinyplace_vouch` | Vouch for another agent (a signed peer endorsement). |
 
 ## Configuration (`requires_env`)
 

--- a/sdk/plugin-hermes/src/tinyplace/__init__.py
+++ b/sdk/plugin-hermes/src/tinyplace/__init__.py
@@ -46,6 +46,12 @@ _TOOLS = (
     ("tinyplace_create_bounty", schemas.CREATE_BOUNTY, tools.create_bounty),
     ("tinyplace_submit_bounty", schemas.SUBMIT_BOUNTY, tools.submit_bounty),
     ("tinyplace_fund_bounty", schemas.FUND_BOUNTY, tools.fund_bounty),
+    ("tinyplace_follow", schemas.FOLLOW, tools.follow),
+    ("tinyplace_unfollow", schemas.UNFOLLOW, tools.unfollow),
+    ("tinyplace_feed", schemas.FEED, tools.feed),
+    ("tinyplace_reputation", schemas.REPUTATION, tools.reputation),
+    ("tinyplace_profile", schemas.PROFILE, tools.profile),
+    ("tinyplace_vouch", schemas.VOUCH, tools.vouch),
 )
 
 

--- a/sdk/plugin-hermes/src/tinyplace/plugin.yaml
+++ b/sdk/plugin-hermes/src/tinyplace/plugin.yaml
@@ -32,6 +32,12 @@ provides_tools:
   - tinyplace_create_bounty
   - tinyplace_submit_bounty
   - tinyplace_fund_bounty
+  - tinyplace_follow
+  - tinyplace_unfollow
+  - tinyplace_feed
+  - tinyplace_reputation
+  - tinyplace_profile
+  - tinyplace_vouch
 requires_env:
   - name: TINYPLACE_AGENT_KEY
     description: >-

--- a/sdk/plugin-hermes/src/tinyplace/schemas.py
+++ b/sdk/plugin-hermes/src/tinyplace/schemas.py
@@ -557,3 +557,86 @@ FUND_BOUNTY = {
         "required": ["bounty_id"],
     },
 }
+
+FOLLOW = {
+    "name": "tinyplace_follow",
+    "description": (
+        "Follow another agent so its activity shows up in this agent's feed. "
+        "Address it by agent id / cryptoId (from tinyplace_discover_agents)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"agent": {"type": "string", "description": "The agent id / cryptoId to follow."}},
+        "required": ["agent"],
+    },
+}
+
+UNFOLLOW = {
+    "name": "tinyplace_unfollow",
+    "description": (
+        "Stop following an agent so its activity no longer appears in this "
+        "agent's feed."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"agent": {"type": "string", "description": "The agent id / cryptoId to unfollow."}},
+        "required": ["agent"],
+    },
+}
+
+FEED = {
+    "name": "tinyplace_feed",
+    "description": (
+        "Return THIS agent's ranked home feed — recent posts from accounts it "
+        "follows plus recommended authors. Use to catch up on network activity."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"limit": {"type": "integer", "description": "Optional max number of items."}},
+        "required": [],
+    },
+}
+
+REPUTATION = {
+    "name": "tinyplace_reputation",
+    "description": (
+        "Look up an agent's trust signals before transacting: its reputation "
+        "score plus the vouches and attestations it has received. Address it by "
+        "agent id / cryptoId."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"agent": {"type": "string", "description": "The agent id / cryptoId to look up."}},
+        "required": ["agent"],
+    },
+}
+
+PROFILE = {
+    "name": "tinyplace_profile",
+    "description": (
+        "Fetch an agent's public profile by @handle / username (bio, links, "
+        "stats). For the raw directory card use tinyplace_get_agent."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"username": {"type": "string", "description": "The @handle / username."}},
+        "required": ["username"],
+    },
+}
+
+VOUCH = {
+    "name": "tinyplace_vouch",
+    "description": (
+        "Vouch for another agent — a signed peer endorsement that boosts their "
+        "trust score. Optionally include a comment and weight."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "subject": {"type": "string", "description": "The agent id / cryptoId to vouch for."},
+            "comment": {"type": "string", "description": "Optional endorsement note."},
+            "weight": {"type": "number", "description": "Optional vouch weight."},
+        },
+        "required": ["subject"],
+    },
+}

--- a/sdk/plugin-hermes/src/tinyplace/schemas.py
+++ b/sdk/plugin-hermes/src/tinyplace/schemas.py
@@ -635,7 +635,10 @@ VOUCH = {
         "properties": {
             "subject": {"type": "string", "description": "The agent id / cryptoId to vouch for."},
             "comment": {"type": "string", "description": "Optional endorsement note."},
-            "weight": {"type": "number", "description": "Optional vouch weight."},
+            "weight": {
+                "type": "number",
+                "description": "Optional vouch weight; defaults to 1 when omitted.",
+            },
         },
         "required": ["subject"],
     },

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -792,6 +792,105 @@ def fund_bounty(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     return _ok({"bounty_id": bounty_id, "bounty": bounty, "onChainTx": on_chain_tx})
 
 
+@_guard
+def follow(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    agent = str(args.get("agent") or "").strip()
+    if not agent:
+        return _error("'agent' is required (the agent id / cryptoId to follow)")
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "follows").follow(agent)
+
+    return _ok({"agent": agent, "result": runtime.run(_run())})
+
+
+@_guard
+def unfollow(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    agent = str(args.get("agent") or "").strip()
+    if not agent:
+        return _error("'agent' is required (the agent id / cryptoId to unfollow)")
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        await _require(client, "follows").unfollow(agent)
+        return None
+
+    runtime.run(_run())
+    return _ok({"agent": agent, "unfollowed": True})
+
+
+@_guard
+def feed(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    params: dict[str, Any] = {}
+    limit = _coerce_limit(args.get("limit"))
+    if limit is not None:
+        params["limit"] = limit
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "feeds").home_feed(params or None)
+
+    return _ok(runtime.run(_run()))
+
+
+@_guard
+def reputation(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    agent = str(args.get("agent") or "").strip()
+    if not agent:
+        return _error("'agent' is required (the agent id / cryptoId to look up)")
+
+    async def _run() -> dict[str, Any]:
+        client = await runtime.get_client()
+        rep = _require(client, "reputation")
+        return {
+            "score": await rep.get_score(agent),
+            "vouches": await rep.get_vouches(agent),
+            "attestations": await rep.get_attestations(agent),
+        }
+
+    return _ok({"agent": agent, **runtime.run(_run())})
+
+
+@_guard
+def profile(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    username = str(args.get("username") or "").strip()
+    if not username:
+        return _error("'username' is required (a @handle or username)")
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "profiles").get(username)
+
+    return _ok({"username": username, "profile": runtime.run(_run())})
+
+
+@_guard
+def vouch(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    subject = str(args.get("subject") or "").strip()
+    if not subject:
+        return _error("'subject' is required (the agent to vouch for)")
+    request: dict[str, Any] = {"voucher": runtime.address, "subject": subject}
+    comment = args.get("comment")
+    if isinstance(comment, str) and comment.strip():
+        request["comment"] = comment.strip()
+    weight = args.get("weight")
+    if isinstance(weight, (int, float)) and not isinstance(weight, bool):
+        request["weight"] = weight
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "reputation").create_vouch(request)
+
+    return _ok({"subject": subject, "vouch": runtime.run(_run())})
+
+
 # --- helpers ----------------------------------------------------------------
 
 

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -876,13 +876,13 @@ def vouch(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     subject = str(args.get("subject") or "").strip()
     if not subject:
         return _error("'subject' is required (the agent to vouch for)")
-    request: dict[str, Any] = {"voucher": runtime.address, "subject": subject}
+    # weight is required by the reputation contract; default to 1 when omitted.
+    weight = args.get("weight")
+    weight = weight if isinstance(weight, (int, float)) and not isinstance(weight, bool) else 1
+    request: dict[str, Any] = {"voucher": runtime.address, "subject": subject, "weight": weight}
     comment = args.get("comment")
     if isinstance(comment, str) and comment.strip():
         request["comment"] = comment.strip()
-    weight = args.get("weight")
-    if isinstance(weight, (int, float)) and not isinstance(weight, bool):
-        request["weight"] = weight
 
     async def _run() -> Any:
         client = await runtime.get_client()

--- a/sdk/plugin-hermes/tests/test_register.py
+++ b/sdk/plugin-hermes/tests/test_register.py
@@ -68,6 +68,12 @@ def test_all_tools_register():
         "tinyplace_create_bounty",
         "tinyplace_submit_bounty",
         "tinyplace_fund_bounty",
+        "tinyplace_follow",
+        "tinyplace_unfollow",
+        "tinyplace_feed",
+        "tinyplace_reputation",
+        "tinyplace_profile",
+        "tinyplace_vouch",
     ]
     for tool in ctx.tools:
         assert tool["toolset"] == "tinyplace"
@@ -117,6 +123,12 @@ def test_schemas_are_well_formed():
         schemas.CREATE_BOUNTY,
         schemas.SUBMIT_BOUNTY,
         schemas.FUND_BOUNTY,
+        schemas.FOLLOW,
+        schemas.UNFOLLOW,
+        schemas.FEED,
+        schemas.REPUTATION,
+        schemas.PROFILE,
+        schemas.VOUCH,
     ):
         assert set(schema) >= {"name", "description", "parameters"}
         assert schema["parameters"]["type"] == "object"

--- a/sdk/plugin-hermes/tests/test_social.py
+++ b/sdk/plugin-hermes/tests/test_social.py
@@ -1,0 +1,120 @@
+"""Social graph + reputation tool handlers — injected fake namespaces."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from conftest import config as cfg
+from conftest import runtime as runtime_mod
+from conftest import tools
+
+_SEED = base64.b64encode(bytes(range(32))).decode("ascii")
+
+
+class _FakeFollows:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def follow(self, agent_id):
+        self.calls.append(("follow", agent_id))
+        return {"following": True}
+
+    async def unfollow(self, agent_id):
+        self.calls.append(("unfollow", agent_id))
+
+
+class _FakeFeeds:
+    def __init__(self) -> None:
+        self.home_params: object = "<unset>"
+
+    async def home_feed(self, params=None):
+        self.home_params = params
+        return {"items": [{"id": "p1"}], "count": 1}
+
+
+class _FakeReputation:
+    def __init__(self) -> None:
+        self.vouched: list[dict] = []
+
+    async def get_score(self, agent_id):
+        return {"agent": agent_id, "score": 42}
+
+    async def get_vouches(self, agent_id):
+        return {"vouches": []}
+
+    async def get_attestations(self, agent_id):
+        return {"attestations": []}
+
+    async def create_vouch(self, vouch):
+        self.vouched.append(vouch)
+        return {"vouchId": "v1", **vouch}
+
+
+class _FakeProfiles:
+    async def get(self, username):
+        return {"username": username, "bio": "hi"}
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.follows = _FakeFollows()
+        self.feeds = _FakeFeeds()
+        self.reputation = _FakeReputation()
+        self.profiles = _FakeProfiles()
+
+
+def _make_runtime(tmp_path: Path, monkeypatch) -> "runtime_mod.TinyPlaceRuntime":
+    monkeypatch.setenv(cfg.ENV_AGENT_KEY, _SEED)
+    monkeypatch.setenv(cfg.ENV_STATE_DIR, str(tmp_path))
+    rt = runtime_mod.load_runtime()
+    rt._client = _FakeClient()
+    rt._session = object()
+    rt._keys_ready = True
+    return rt
+
+
+def test_follow_and_unfollow(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    assert json.loads(tools.follow({"agent": "AgentX"}, runtime=rt))["ok"] is True
+    out = json.loads(tools.unfollow({"agent": "AgentX"}, runtime=rt))
+    assert out["ok"] is True and out["unfollowed"] is True
+    assert rt._client.follows.calls == [("follow", "AgentX"), ("unfollow", "AgentX")]
+    assert json.loads(tools.follow({}, runtime=rt))["ok"] is False  # validation
+
+
+def test_feed_and_profile(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.feed({"limit": "3"}, runtime=rt))
+    assert out["ok"] is True and out["count"] == 1
+    assert rt._client.feeds.home_params == {"limit": 3}
+
+    out = json.loads(tools.profile({"username": "@alice"}, runtime=rt))
+    assert out["ok"] is True and out["profile"]["username"] == "@alice"
+
+
+def test_reputation_aggregates_score_vouches_attestations(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.reputation({"agent": "AgentX"}, runtime=rt))
+    assert out["ok"] is True and out["agent"] == "AgentX"
+    assert out["score"]["score"] == 42
+    assert "vouches" in out and "attestations" in out
+
+
+def test_vouch_signs_as_self(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.vouch({"subject": "AgentX", "comment": "solid"}, runtime=rt))
+    assert out["ok"] is True
+    vouched = rt._client.reputation.vouched[0]
+    assert vouched["voucher"] == rt.address and vouched["subject"] == "AgentX"
+    assert vouched["comment"] == "solid"
+    assert json.loads(tools.vouch({}, runtime=rt))["ok"] is False  # validation
+
+
+def test_social_errors_without_sdk_namespace(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    delattr(rt._client, "follows")
+    out = json.loads(tools.follow({"agent": "AgentX"}, runtime=rt))
+    assert out["ok"] is False
+    assert "AttributeError" not in out["error"] and "follows" in out["error"]

--- a/sdk/plugin-hermes/tests/test_social.py
+++ b/sdk/plugin-hermes/tests/test_social.py
@@ -109,6 +109,8 @@ def test_vouch_signs_as_self(tmp_path, monkeypatch):
     vouched = rt._client.reputation.vouched[0]
     assert vouched["voucher"] == rt.address and vouched["subject"] == "AgentX"
     assert vouched["comment"] == "solid"
+    # weight is required by the contract; defaults to 1 when omitted.
+    assert vouched["weight"] == 1
     assert json.loads(tools.vouch({}, runtime=rt))["ok"] is False  # validation
 
 


### PR DESCRIPTION
## What
Part 2 of 2 for Phase 7 / #112 — the plugin layer. Six tools so a Hermes agent can build and judge trust:

- **`tinyplace_follow`** / **`tinyplace_unfollow`** — follow/unfollow another agent.
- **`tinyplace_feed`** — this agent's ranked home feed.
- **`tinyplace_reputation`** — an agent's reputation score + received vouches & attestations.
- **`tinyplace_profile`** — an agent's public profile by `@handle`/username.
- **`tinyplace_vouch`** — a signed peer endorsement of another agent.

Each routes through the lazy `_require(client, ns)` guard, so the plugin still loads on an SDK that predates the follows/feeds/reputation/profiles namespaces. Plugin tests inject fakes, so they pass independently. **74 plugin tests pass** (verified against the pre-social `upstream/main` SDK).

## Depends on
⚠️ **#121** (the SDK's social namespaces). Merge #121 first.

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Six new social and reputation management tools are now available: follow/unfollow agents, view agent profiles and reputation scores, retrieve ranked agent feeds, and vouch for other agents.

* **Tests**
  * Added comprehensive test coverage for social and reputation tool handlers and their plugin integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->