### PR TITLE
fix: staging bug sweep — first 4 (feedback button, feed sort, header banner, handle check)

### DIFF
--- a/website/src/components/ActivityMarquee.tsx
+++ b/website/src/components/ActivityMarquee.tsx
@@ -88,14 +88,11 @@ export const ActivityMarquee = ({
 	const itemColor = isDark ? "text-neutral-400" : "text-neutral-500";
 	const dotColor = isDark ? "text-neutral-700" : "text-neutral-300";
 
-	// The parent supplies the flex-1 fill (see ExploreShell), so this just spans
-	// the available width. Shows a placeholder until activity streams in.
+	// The parent supplies the flex-1 fill (see ExploreShell). Render nothing
+	// until activity streams in, so the header doesn't show a blank placeholder
+	// strip on every tab when the ticker is empty.
 	if (items.length === 0) {
-		return (
-			<div className="w-full overflow-hidden">
-				<span className={`text-xs ${dotColor}`}>Live activity…</span>
-			</div>
-		);
+		return null;
 	}
 
 	const track = [...items, ...items];

--- a/website/src/components/explore/DomainRegistration.test.tsx
+++ b/website/src/components/explore/DomainRegistration.test.tsx
@@ -51,10 +51,15 @@ vi.mock("@src/hooks/use-registry", () => ({
 	): {
 		data: { available: boolean; name: string } | undefined;
 		isLoading: boolean;
-	} => ({
-		data: name ? { available: true, name } : undefined,
-		isLoading: false,
-	}),
+	} => {
+		// Mirror the real hook: it only queries (and so only yields data) once the
+		// normalized handle reaches MIN_HANDLE_LENGTH.
+		const label = name.trim().replace(/^@+/, "");
+		return {
+			data: label.length >= 2 ? { available: true, name } : undefined,
+			isLoading: false,
+		};
+	},
 }));
 
 vi.mock("@src/hooks/use-marketplace", () => ({

--- a/website/src/components/explore/DomainRegistration.test.tsx
+++ b/website/src/components/explore/DomainRegistration.test.tsx
@@ -45,6 +45,7 @@ vi.mock("@src/common/api-client", () => ({
 }));
 
 vi.mock("@src/hooks/use-registry", () => ({
+	MIN_HANDLE_LENGTH: 2,
 	useHandleAvailability: (
 		name: string
 	): {

--- a/website/src/components/explore/DomainRegistration.tsx
+++ b/website/src/components/explore/DomainRegistration.tsx
@@ -87,6 +87,9 @@ export const DomainRegistration = ({
 		useState<RegistryPaymentChallenge | null>(null);
 
 	const searchName = normalizedHandle(searchInput);
+	// Gate the verdict UI on the same normalized (de-`@`-ed) length the
+	// availability query enables on, so `@a` can't desync the hint from the query.
+	const normalizedNameLength = searchName.replace(/^@/, "").length;
 	const availabilityQuery = useHandleAvailability(searchName);
 
 	// A wallet's first name is auto-assigned as primary; offer the toggle
@@ -368,19 +371,20 @@ export const DomainRegistration = ({
 					</button>
 				</div>
 
-				{searchInput.length > 0 && searchInput.length < MIN_HANDLE_LENGTH && (
-					<p className={`mt-2 text-xs ${secondaryClass}`}>
-						Handles must be at least {MIN_HANDLE_LENGTH} characters.
-					</p>
-				)}
+				{normalizedNameLength > 0 &&
+					normalizedNameLength < MIN_HANDLE_LENGTH && (
+						<p className={`mt-2 text-xs ${secondaryClass}`}>
+							Handles must be at least {MIN_HANDLE_LENGTH} characters.
+						</p>
+					)}
 
 				{availabilityQuery.isLoading &&
-					searchInput.length >= MIN_HANDLE_LENGTH && (
+					normalizedNameLength >= MIN_HANDLE_LENGTH && (
 						<p className={`mt-2 text-xs ${secondaryClass}`}>Checking...</p>
 					)}
 
 				{availabilityQuery.isError &&
-					searchInput.length >= MIN_HANDLE_LENGTH && (
+					normalizedNameLength >= MIN_HANDLE_LENGTH && (
 						<p className="mt-2 text-xs font-medium text-red-500">
 							Couldn&apos;t check availability. Please try again.
 						</p>

--- a/website/src/components/explore/DomainRegistration.tsx
+++ b/website/src/components/explore/DomainRegistration.tsx
@@ -20,7 +20,10 @@ import { createClient } from "@src/common/api-client";
 import { queryKeys } from "@src/common/query-keys";
 import { assertValidX402Challenge } from "@src/common/x402-challenge";
 import { signX402ChallengePaymentMap } from "@src/common/auth-payment";
-import { useHandleAvailability } from "@src/hooks/use-registry";
+import {
+	MIN_HANDLE_LENGTH,
+	useHandleAvailability,
+} from "@src/hooks/use-registry";
 import { useOwnedIdentities } from "@src/hooks/use-marketplace";
 import { useAuthStore } from "@src/store/auth";
 
@@ -365,9 +368,23 @@ export const DomainRegistration = ({
 					</button>
 				</div>
 
-				{availabilityQuery.isLoading && searchInput.length > 0 && (
-					<p className={`mt-2 text-xs ${secondaryClass}`}>Checking...</p>
+				{searchInput.length > 0 && searchInput.length < MIN_HANDLE_LENGTH && (
+					<p className={`mt-2 text-xs ${secondaryClass}`}>
+						Handles must be at least {MIN_HANDLE_LENGTH} characters.
+					</p>
 				)}
+
+				{availabilityQuery.isLoading &&
+					searchInput.length >= MIN_HANDLE_LENGTH && (
+						<p className={`mt-2 text-xs ${secondaryClass}`}>Checking...</p>
+					)}
+
+				{availabilityQuery.isError &&
+					searchInput.length >= MIN_HANDLE_LENGTH && (
+						<p className="mt-2 text-xs font-medium text-red-500">
+							Couldn&apos;t check availability. Please try again.
+						</p>
+					)}
 
 				{availabilityQuery.data && (
 					<div className="mt-3">

--- a/website/src/components/explore/Feedback.tsx
+++ b/website/src/components/explore/Feedback.tsx
@@ -121,7 +121,7 @@ function FeedbackCard({
 			) : null}
 			<div className="mt-4 grid grid-cols-2 gap-2 sm:flex">
 				<button
-					className="inline-flex items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+					className="inline-flex items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-front disabled:cursor-not-allowed disabled:opacity-50"
 					disabled={voting || !canVote}
 					type="button"
 					onClick={(): void => {
@@ -249,7 +249,7 @@ export const Feedback = ({ isDark }: FeedbackProperties): FunctionComponent => {
 				/>
 				<div className="mt-3 flex items-center gap-3">
 					<button
-						className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+						className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-front disabled:cursor-not-allowed disabled:opacity-50"
 						type="submit"
 						disabled={
 							!agentId ||
@@ -362,7 +362,7 @@ export const Feedback = ({ isDark }: FeedbackProperties): FunctionComponent => {
 									</p>
 								</div>
 								<button
-									className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+									className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-front disabled:cursor-not-allowed disabled:opacity-50"
 									disabled={updateStatus.isPending}
 									type="button"
 									onClick={(): void => {

--- a/website/src/hooks/use-registry.ts
+++ b/website/src/hooks/use-registry.ts
@@ -84,10 +84,14 @@ function settleRegistryPaymentChallenge<T>(
 	});
 }
 
+/** Minimum handle length the registry accepts (backend rule `{2,64}`). */
+export const MIN_HANDLE_LENGTH = 2;
+
 /**
  * Checks whether an identity handle is available to register. Disabled until a
- * non-empty name is provided. A leading `@` is normalized away so `atlas` and
- * `@atlas` resolve to the same query and backend lookup.
+ * name of at least {@link MIN_HANDLE_LENGTH} characters is provided. A leading
+ * `@` is normalized away so `atlas` and `@atlas` resolve to the same query and
+ * backend lookup.
  *
  * @param name - The handle to check (with or without a leading `@`).
  */
@@ -100,7 +104,9 @@ export function useHandleAvailability(
 		queryKey: queryKeys.registry.availability(normalized),
 		queryFn: (): Promise<AvailabilityResponse> =>
 			client.registry.get(normalized),
-		enabled: normalized.length > 0,
+		// Handles are 2-64 chars; a 1-char lookup is rejected by the backend, so
+		// don't fire a request that can only fail (the UI shows a length hint).
+		enabled: normalized.length >= MIN_HANDLE_LENGTH,
 	});
 }
 

--- a/website/src/views/HomeFeed.tsx
+++ b/website/src/views/HomeFeed.tsx
@@ -59,6 +59,14 @@ export function HomeFeed(): FunctionComponent {
 		}
 	}
 
+	// Render newest-first by post time. The backend returns items in ranked
+	// order, but the feed is expected to read chronologically, so sort by
+	// createdAt descending (numeric compare on the parsed timestamp).
+	posts.sort(
+		(first: Post, second: Post): number =>
+			new Date(second.createdAt).getTime() - new Date(first.createdAt).getTime()
+	);
+
 	const isLoading = graphqlFeedEnabled ? gqlHome.isLoading : restHome.isLoading;
 	const isError = graphqlFeedEnabled ? gqlHome.isError : restHome.isError;
 


### PR DESCRIPTION
## Summary

First batch of fixes from the staging.tiny.place bug sweep — the **4 quickest, highest-confidence, frontend-only** items. Each is a focused micro-commit. The remaining reported bugs are tracked below for follow-up PRs.

## Fixes in this PR

### UI / theming
- **Feedback submit button invisible in light mode** — `text-primary-foreground` is not a defined color token (the real token is `text-primary-front`), so the label inherited the dark front color and vanished against the near-black primary button in light mode. Swapped all 3 usages in `Feedback.tsx`.
- **Empty placeholder banner in the header of every tab** — the activity ticker rendered a faint, low-contrast `"Live activity…"` placeholder when no events had streamed in, reading as a blank banner. `ActivityMarquee` now renders nothing until events arrive.

### Feed
- **Feed not sorted by time posted** — the home timeline rendered posts in raw backend (ranked) order, so it didn't read chronologically. Assembled posts are now sorted newest-first by `createdAt`.

### Domain registration
- **Single-character handle check showed no verdict** — a 1-char query fired a backend lookup that always fails the `{2,64}` handle rule; the SDK threw and the UI rendered nothing (no available/taken). The availability query is now gated to names `>= MIN_HANDLE_LENGTH`, with a length hint below the input and an error branch so a failed check is no longer silent.

## Testing
- `pnpm --filter @tinyplace/website lint` — green
- `prettier --check` on changed files — green
- `pnpm --filter @tinyplace/website build` — green
- `DomainRegistration.test.tsx` — green (added `MIN_HANDLE_LENGTH` to the existing mock)
- Pre-existing local failures in `auth-payment` / `session-wallet` / `OnboardWizard` are a local-Node `SubtleCrypto` Ed25519 signing-env issue, unrelated to this diff (zero file overlap; CI on Node 22 signs fine).

## Follow-up (remaining reported bugs, not in this PR)
- **Messaging:** DM search by handle/key; inbox "failed to load" (cryptoId-as-actor auth)
- **Wallet:** buy-domain "transaction reverted" (devnet app vs hardcoded mainnet USDC mint/network)
- **Payments:** MoonPay slow load (no preconnect / no skeleton)
- **i18n:** Spanish has no effect (UI strings hardcoded English — coverage gap)
- **Social links:** point at parent `tinyhumans` / fragile X intent-link (need canonical tiny.place URLs)
- **Activity:** shows actor only, not the action (`ledger.*` kinds hit the `default` branch)
- **Marketplace:** submit-bounty amount validation / empty `client` auth identity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home feed posts are now sorted newest-first by creation date.

* **Bug Fixes**
  * Empty activity feed no longer shows placeholder header/ticker content.
  * Domain registration now enforces a minimum handle length before running or displaying availability checks.

* **Style**
  * Updated button styling to use the correct text color token for upvote and admin “Update” actions.

* **Tests**
  * Updated domain registration test mocks to reflect the minimum handle length rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->