### PR TITLE
feat(python-sdk): port conversations, broadcasts & events namespaces (Phase 8 SDK)

### DIFF
--- a/sdk/python/src/tinyplace/api/__init__.py
+++ b/sdk/python/src/tinyplace/api/__init__.py
@@ -1,7 +1,10 @@
 from .bounties import BountiesApi
+from .broadcasts import BroadcastsApi
+from .conversations import ConversationsApi
 from .directory import DirectoryApi
 from .docs import DocsApi
 from .escrow import EscrowApi
+from .events import EventsApi
 from .feeds import FeedsApi
 from .follows import FollowsApi
 from .groups import GroupsApi
@@ -18,9 +21,12 @@ from .search import SearchApi
 
 __all__ = [
     "BountiesApi",
+    "BroadcastsApi",
+    "ConversationsApi",
     "DirectoryApi",
     "DocsApi",
     "EscrowApi",
+    "EventsApi",
     "FeedsApi",
     "FollowsApi",
     "GroupsApi",

--- a/sdk/python/src/tinyplace/api/broadcasts.py
+++ b/sdk/python/src/tinyplace/api/broadcasts.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import secrets
+import time
+
+from ..http import HttpClient, encode
+from ..types import Json, JsonDict, Query
+
+
+class BroadcastsApi:
+    """One-to-many broadcast channels: publishers, subscribers and messages.
+
+    Broadcasts live under ``/broadcasts``. Public reads need no auth; mutations
+    are directory-signed, either as the configured signer
+    (``post_directory_auth``) or, when an owner/actor is supplied, on behalf of
+    that managed agent (``post_directory_auth_as``). Reading messages is
+    directory-authenticated and may carry an ``X-Payment-Authorization`` header
+    for paid channels. Mirrors the TS SDK's ``BroadcastsApi`` (the websocket
+    ``stream`` helper is omitted — the Python SDK is REST-only).
+    """
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    async def list(self, params: Query = None) -> JsonDict:
+        result = await self._http.get("/broadcasts", params)
+        items = result.get("broadcasts") if isinstance(result, dict) else None
+        return {"broadcasts": items or []}
+
+    async def create(self, request: JsonDict) -> Json:
+        body = {
+            **request,
+            "broadcastId": request.get("broadcastId") or _next_client_id("bcast"),
+        }
+        owner = request.get("owner")
+        if owner:
+            return await self._http.post_directory_auth_as("/broadcasts", str(owner), body)
+        return await self._http.post_directory_auth("/broadcasts", body)
+
+    async def get(self, broadcast_id: str) -> Json:
+        return await self._http.get(f"/broadcasts/{encode(broadcast_id)}")
+
+    async def update(self, broadcast_id: str, update: JsonDict, actor: str | None = None) -> Json:
+        path = f"/broadcasts/{encode(broadcast_id)}"
+        if actor:
+            return await self._http.put_directory_auth_as(path, actor, update)
+        return await self._http.put_directory_auth(path, update)
+
+    async def remove(self, broadcast_id: str, actor: str | None = None) -> None:
+        path = f"/broadcasts/{encode(broadcast_id)}"
+        if actor:
+            await self._http.delete_directory_auth_as(path, actor)
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def add_publisher(
+        self, broadcast_id: str, agent_id: str, actor: str | None = None
+    ) -> None:
+        path = f"/broadcasts/{encode(broadcast_id)}/publishers"
+        if actor:
+            await self._http.post_directory_auth_as(path, actor, {"agentId": agent_id})
+            return
+        await self._http.post_directory_auth(path, {"agentId": agent_id})
+
+    async def remove_publisher(
+        self, broadcast_id: str, agent_id: str, actor: str | None = None
+    ) -> None:
+        path = f"/broadcasts/{encode(broadcast_id)}/publishers/{encode(agent_id)}"
+        if actor:
+            await self._http.delete_directory_auth_as(path, actor)
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def subscribe(self, broadcast_id: str, request: JsonDict | str | None = None) -> Json:
+        body: JsonDict = {"agentId": request} if isinstance(request, str) else (request or {})
+        path = f"/broadcasts/{encode(broadcast_id)}/subscribe"
+        agent_id = body.get("agentId")
+        if agent_id:
+            return await self._http.post_directory_auth_as(path, str(agent_id), body)
+        return await self._http.post_directory_auth(path, body)
+
+    async def unsubscribe(self, broadcast_id: str, agent_id: str | None = None) -> None:
+        path = f"/broadcasts/{encode(broadcast_id)}/subscribe"
+        if agent_id:
+            await self._http.delete_directory_auth_as(path, agent_id)
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def subscribers(self, broadcast_id: str, actor: str | None = None) -> JsonDict:
+        path = f"/broadcasts/{encode(broadcast_id)}/subscribers"
+        if actor:
+            result = await self._http.get_directory_auth_as(path, actor)
+        else:
+            result = await self._http.get_directory_auth(path)
+        items = result.get("subscribers") if isinstance(result, dict) else None
+        return {"subscribers": items or []}
+
+    async def remove_subscriber(
+        self, broadcast_id: str, agent_id: str, actor: str | None = None
+    ) -> None:
+        path = f"/broadcasts/{encode(broadcast_id)}/subscribers/{encode(agent_id)}"
+        if actor:
+            await self._http.delete_directory_auth_as(path, actor)
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def list_messages(
+        self,
+        broadcast_id: str,
+        *,
+        agent_id: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        payment_authorization: str | None = None,
+    ) -> JsonDict:
+        path = f"/broadcasts/{encode(broadcast_id)}/messages"
+        query: JsonDict = {}
+        if limit is not None:
+            query["limit"] = limit
+        if offset is not None:
+            query["offset"] = offset
+        headers = (
+            {"X-Payment-Authorization": payment_authorization}
+            if payment_authorization
+            else None
+        )
+        if agent_id:
+            result = await self._http.get_directory_auth_as(path, agent_id, query, headers)
+        else:
+            result = await self._http.get_directory_auth(path, query, headers)
+        items = result.get("messages") if isinstance(result, dict) else None
+        return {"messages": items or []}
+
+    async def post_message(self, broadcast_id: str, message: JsonDict) -> Json:
+        body = {**message, "messageId": message.get("messageId") or _next_client_id("bmsg")}
+        path = f"/broadcasts/{encode(broadcast_id)}/messages"
+        publisher = body.get("publisher")
+        if publisher:
+            return await self._http.post_directory_auth_as(path, str(publisher), body)
+        return await self._http.post_directory_auth(path, body)
+
+    async def delete_message(
+        self, broadcast_id: str, message_id: str, actor: str | None = None
+    ) -> None:
+        path = f"/broadcasts/{encode(broadcast_id)}/messages/{encode(message_id)}"
+        if actor:
+            await self._http.delete_directory_auth_as(path, actor)
+            return
+        await self._http.delete_directory_auth(path)
+
+
+def _next_client_id(prefix: str) -> str:
+    return f"{prefix}_{int(time.time() * 1000):x}_{secrets.token_hex(6)}"

--- a/sdk/python/src/tinyplace/api/conversations.py
+++ b/sdk/python/src/tinyplace/api/conversations.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import secrets
+import time
+
+from ..http import HttpClient, encode
+from ..types import Json, JsonDict, Query
+
+
+class ConversationsApi:
+    """Multi-party conversations: membership, moderation and messages.
+
+    Conversations live under ``/conversations``. Public reads need no auth;
+    mutations are directory-signed, either as the configured signer
+    (``post_directory_auth``) or, when an actor/agent is supplied, on behalf of
+    that managed agent (``post_directory_auth_as``). Mirrors the TS SDK's
+    ``ConversationsApi`` (the websocket ``stream`` helper is omitted — the
+    Python SDK is REST-only).
+    """
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    async def list(self, params: Query = None) -> JsonDict:
+        result = await self._http.get("/conversations", params)
+        items = result.get("conversations") if isinstance(result, dict) else None
+        return {"conversations": items or []}
+
+    async def create(self, request: JsonDict) -> Json:
+        body = {
+            **request,
+            "conversationId": request.get("conversationId") or _next_client_id("conv"),
+        }
+        creator = body.get("creator")
+        if creator:
+            return await self._http.post_directory_auth_as("/conversations", str(creator), body)
+        return await self._http.post_directory_auth("/conversations", body)
+
+    async def get(self, conversation_id: str) -> Json:
+        return await self._http.get(f"/conversations/{encode(conversation_id)}")
+
+    async def update(
+        self, conversation_id: str, update: JsonDict, actor: str | None = None
+    ) -> Json:
+        path = f"/conversations/{encode(conversation_id)}"
+        if actor:
+            return await self._http.put_directory_auth_as(path, actor, update)
+        return await self._http.put_directory_auth(path, update)
+
+    async def remove(self, conversation_id: str, actor: str | None = None) -> None:
+        path = f"/conversations/{encode(conversation_id)}"
+        if actor:
+            await self._http.delete_directory_auth_as(path, actor)
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def join(self, conversation_id: str, agent_id: str | None = None) -> Json:
+        path = f"/conversations/{encode(conversation_id)}/join"
+        if agent_id:
+            return await self._http.post_directory_auth_as(path, agent_id, {"agentId": agent_id})
+        return await self._http.post_directory_auth(path)
+
+    async def leave(self, conversation_id: str, agent_id: str | None = None) -> None:
+        path = f"/conversations/{encode(conversation_id)}/leave"
+        if agent_id:
+            path = f"{path}?agentId={encode(agent_id)}"
+            await self._http.delete_directory_auth_as(path, agent_id)
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def members(self, conversation_id: str) -> JsonDict:
+        result = await self._http.get(f"/conversations/{encode(conversation_id)}/members")
+        items = result.get("members") if isinstance(result, dict) else None
+        return {"members": items or []}
+
+    async def add_member(
+        self, conversation_id: str, agent_id: str, manager_id: str | None = None
+    ) -> Json:
+        path = f"/conversations/{encode(conversation_id)}/members"
+        if manager_id:
+            return await self._http.post_directory_auth_as(path, manager_id, {"agentId": agent_id})
+        return await self._http.post_directory_auth(path, {"agentId": agent_id})
+
+    async def remove_member(
+        self, conversation_id: str, agent_id: str, manager_id: str | None = None
+    ) -> None:
+        path = f"/conversations/{encode(conversation_id)}/members/{encode(agent_id)}"
+        # A self-removal (no manager) still signs as the leaving agent.
+        await self._http.delete_directory_auth_as(path, manager_id or agent_id)
+
+    async def approve_member(
+        self, conversation_id: str, agent_id: str, manager_id: str | None = None
+    ) -> Json:
+        path = f"/conversations/{encode(conversation_id)}/approve"
+        if manager_id:
+            return await self._http.post_directory_auth_as(path, manager_id, {"agentId": agent_id})
+        return await self._http.post_directory_auth(path, {"agentId": agent_id})
+
+    async def reject_member(
+        self, conversation_id: str, agent_id: str, manager_id: str | None = None
+    ) -> None:
+        path = f"/conversations/{encode(conversation_id)}/reject"
+        if manager_id:
+            await self._http.post_directory_auth_as(path, manager_id, {"agentId": agent_id})
+            return
+        await self._http.post_directory_auth(path, {"agentId": agent_id})
+
+    async def list_messages(self, conversation_id: str, params: Query = None) -> JsonDict:
+        result = await self._http.get(
+            f"/conversations/{encode(conversation_id)}/messages", params
+        )
+        items = result.get("messages") if isinstance(result, dict) else None
+        return {"messages": items or []}
+
+    async def post_message(self, conversation_id: str, message: JsonDict) -> Json:
+        body = {**message, "messageId": message.get("messageId") or _next_client_id("msg")}
+        path = f"/conversations/{encode(conversation_id)}/messages"
+        author = body.get("author")
+        if author:
+            return await self._http.post_directory_auth_as(path, str(author), body)
+        return await self._http.post_directory_auth(path, body)
+
+    async def delete_message(
+        self, conversation_id: str, message_id: str, actor: str | None = None
+    ) -> None:
+        path = f"/conversations/{encode(conversation_id)}/messages/{encode(message_id)}"
+        if actor:
+            await self._http.delete_directory_auth_as(path, actor)
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def add_moderator(
+        self, conversation_id: str, agent_id: str, owner_id: str | None = None
+    ) -> Json:
+        path = f"/conversations/{encode(conversation_id)}/moderators"
+        if owner_id:
+            return await self._http.post_directory_auth_as(path, owner_id, {"agentId": agent_id})
+        return await self._http.post_directory_auth(path, {"agentId": agent_id})
+
+    async def remove_moderator(
+        self, conversation_id: str, agent_id: str, owner_id: str | None = None
+    ) -> None:
+        path = f"/conversations/{encode(conversation_id)}/moderators/{encode(agent_id)}"
+        if owner_id:
+            await self._http.delete_directory_auth_as(path, owner_id)
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def add_publisher(
+        self, conversation_id: str, agent_id: str, owner_id: str | None = None
+    ) -> Json:
+        path = f"/conversations/{encode(conversation_id)}/publishers"
+        if owner_id:
+            return await self._http.post_directory_auth_as(path, owner_id, {"agentId": agent_id})
+        return await self._http.post_directory_auth(path, {"agentId": agent_id})
+
+    async def remove_publisher(
+        self, conversation_id: str, agent_id: str, owner_id: str | None = None
+    ) -> None:
+        path = f"/conversations/{encode(conversation_id)}/publishers/{encode(agent_id)}"
+        if owner_id:
+            await self._http.delete_directory_auth_as(path, owner_id)
+            return
+        await self._http.delete_directory_auth(path)
+
+
+def _next_client_id(prefix: str) -> str:
+    return f"{prefix}_{int(time.time() * 1000):x}_{secrets.token_hex(6)}"

--- a/sdk/python/src/tinyplace/api/events.py
+++ b/sdk/python/src/tinyplace/api/events.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import secrets
+import time
+
+from ..http import HttpClient, encode
+from ..types import Json, JsonDict, Query
+
+
+class EventsApi:
+    """Live events: lifecycle, RSVPs, stage, speakers, Q&A, polls and series.
+
+    Events live under ``/events``. Public reads (``list``, ``get``, ``stage``,
+    ``questions``, ``polls``, ``recording``, series reads) need no auth;
+    mutations are directory-signed, either as the configured signer
+    (``post_directory_auth``) or, when a host/moderator/agent is supplied, on
+    behalf of that managed agent (``post_directory_auth_as``). Mirrors the TS
+    SDK's ``EventsApi`` (the websocket ``stream`` helper is omitted — the Python
+    SDK is REST-only).
+    """
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    # -- Lifecycle ----------------------------------------------------------
+
+    async def list(self, params: Query = None) -> JsonDict:
+        result = await self._http.get("/events", params)
+        items = result.get("events") if isinstance(result, dict) else None
+        return {"events": items or []}
+
+    async def create(self, event: JsonDict, host_id: str | None = None) -> Json:
+        body = {**event, "eventId": event.get("eventId") or _next_client_id("evt")}
+        host = host_id or event.get("host")
+        if host:
+            return await self._http.post_directory_auth_as("/events", str(host), body)
+        return await self._http.post_directory_auth("/events", body)
+
+    async def get(self, event_id: str) -> Json:
+        return await self._http.get(f"/events/{encode(event_id)}")
+
+    async def update(self, event_id: str, event: JsonDict, host_id: str | None = None) -> Json:
+        path = f"/events/{encode(event_id)}"
+        if host_id:
+            return await self._http.put_directory_auth_as(path, host_id, event)
+        return await self._http.put_directory_auth(path, event)
+
+    async def remove(self, event_id: str, host_id: str | None = None) -> None:
+        path = f"/events/{encode(event_id)}"
+        if host_id:
+            await self._http.delete_directory_auth_as(path, host_id)
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def start(self, event_id: str, host_id: str | None = None) -> Json:
+        path = f"/events/{encode(event_id)}/start"
+        if host_id:
+            return await self._http.post_directory_auth_as(path, host_id)
+        return await self._http.post_directory_auth(path)
+
+    async def end(self, event_id: str, host_id: str | None = None) -> Json:
+        path = f"/events/{encode(event_id)}/end"
+        if host_id:
+            return await self._http.post_directory_auth_as(path, host_id)
+        return await self._http.post_directory_auth(path)
+
+    # -- Attendance ---------------------------------------------------------
+
+    async def rsvp(
+        self,
+        event_id: str,
+        request: JsonDict | str | None = None,
+        agent_id_override: str | None = None,
+    ) -> Json:
+        normalized: JsonDict = {"tier": request} if isinstance(request, str) else (request or {})
+        agent_id = agent_id_override or normalized.get("agentId")
+        body = {k: v for k, v in normalized.items() if k != "agentId"}
+        if agent_id:
+            body["agentId"] = agent_id
+        payload = body or None
+        path = f"/events/{encode(event_id)}/rsvp"
+        if agent_id:
+            return await self._http.post_directory_auth_as(path, str(agent_id), payload)
+        return await self._http.post_directory_auth(path, payload)
+
+    async def cancel_rsvp(self, event_id: str, agent_id: str | None = None) -> None:
+        path = f"/events/{encode(event_id)}/rsvp"
+        if agent_id:
+            await self._http.delete_directory_auth_as(
+                f"{path}?agentId={encode(agent_id)}", agent_id
+            )
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def attendees(self, event_id: str, actor: str | None = None) -> JsonDict:
+        path = f"/events/{encode(event_id)}/attendees"
+        if actor:
+            result = await self._http.get_directory_auth_as(path, actor)
+        else:
+            result = await self._http.get_directory_auth(path)
+        items = result.get("attendees") if isinstance(result, dict) else None
+        return {"attendees": items or []}
+
+    async def remove_attendee(
+        self, event_id: str, agent_id: str, moderator_id: str | None = None
+    ) -> None:
+        path = f"/events/{encode(event_id)}/attendees/{encode(agent_id)}"
+        if moderator_id:
+            await self._http.delete_directory_auth_as(path, moderator_id)
+            return
+        await self._http.delete_directory_auth(path)
+
+    async def invite(self, event_id: str, agent_id: str, host_id: str | None = None) -> None:
+        path = f"/events/{encode(event_id)}/invite"
+        if host_id:
+            await self._http.post_directory_auth_as(path, host_id, {"agentId": agent_id})
+            return
+        await self._http.post_directory_auth(path, {"agentId": agent_id})
+
+    # -- Stage --------------------------------------------------------------
+
+    async def get_stage(self, event_id: str) -> JsonDict:
+        result = await self._http.get(f"/events/{encode(event_id)}/stage")
+        items = result.get("messages") if isinstance(result, dict) else None
+        return {"messages": items or []}
+
+    async def post_to_stage(
+        self, event_id: str, body: JsonDict, actor: str | None = None
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/stage"
+        actor_id = actor or body.get("sender") or body.get("speaker")
+        if actor_id:
+            return await self._http.post_directory_auth_as(path, str(actor_id), body)
+        return await self._http.post_directory_auth(path, body)
+
+    async def pause_stage(self, event_id: str, moderator_id: str | None = None) -> Json:
+        path = f"/events/{encode(event_id)}/stage/pause"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id)
+        return await self._http.post_directory_auth(path)
+
+    async def resume_stage(self, event_id: str, moderator_id: str | None = None) -> Json:
+        path = f"/events/{encode(event_id)}/stage/resume"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id)
+        return await self._http.post_directory_auth(path)
+
+    async def pin_stage_message(
+        self,
+        event_id: str,
+        message_id: str,
+        body: JsonDict | None = None,
+        moderator_id: str | None = None,
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/stage/{encode(message_id)}/pin"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id, body)
+        return await self._http.post_directory_auth(path, body)
+
+    async def unpin_stage_message(
+        self,
+        event_id: str,
+        message_id: str,
+        body: JsonDict | None = None,
+        moderator_id: str | None = None,
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/stage/{encode(message_id)}/unpin"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id, body)
+        return await self._http.post_directory_auth(path, body)
+
+    # -- Speakers -----------------------------------------------------------
+
+    async def add_speaker(
+        self, event_id: str, speaker_id: str, moderator_id: str | None = None
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/speakers/{encode(speaker_id)}"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id)
+        return await self._http.post_directory_auth(path)
+
+    async def remove_speaker(
+        self, event_id: str, speaker_id: str, moderator_id: str | None = None
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/speakers/{encode(speaker_id)}"
+        if moderator_id:
+            return await self._http.delete_directory_auth_as(path, moderator_id)
+        return await self._http.delete_directory_auth(path)
+
+    async def mute_speaker(
+        self,
+        event_id: str,
+        speaker_id: str,
+        body: JsonDict | None = None,
+        moderator_id: str | None = None,
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/speakers/{encode(speaker_id)}/mute"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id, body)
+        return await self._http.post_directory_auth(path, body)
+
+    async def unmute_speaker(
+        self,
+        event_id: str,
+        speaker_id: str,
+        body: JsonDict | None = None,
+        moderator_id: str | None = None,
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/speakers/{encode(speaker_id)}/unmute"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id, body)
+        return await self._http.post_directory_auth(path, body)
+
+    async def activate_agenda_item(
+        self,
+        event_id: str,
+        agenda_item_id: str,
+        body: JsonDict | None = None,
+        moderator_id: str | None = None,
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/agenda/{encode(agenda_item_id)}/activate"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id, body)
+        return await self._http.post_directory_auth(path, body)
+
+    # -- Q&A ----------------------------------------------------------------
+
+    async def questions(self, event_id: str) -> JsonDict:
+        result = await self._http.get(f"/events/{encode(event_id)}/questions")
+        items = result.get("questions") if isinstance(result, dict) else None
+        return {"questions": items or []}
+
+    async def post_question(
+        self, event_id: str, question: JsonDict, asker_id: str | None = None
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/questions"
+        asker = asker_id or (question.get("asker") if isinstance(question.get("asker"), str) else None)
+        if asker:
+            return await self._http.post_directory_auth_as(path, str(asker), question)
+        return await self._http.post_directory_auth(path, question)
+
+    async def upvote_question(
+        self,
+        event_id: str,
+        question_id: str,
+        body: JsonDict | None = None,
+        voter_id: str | None = None,
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/questions/{encode(question_id)}/upvote"
+        if voter_id:
+            return await self._http.post_directory_auth_as(path, voter_id, body)
+        return await self._http.post_directory_auth(path, body)
+
+    async def promote_question(
+        self,
+        event_id: str,
+        question_id: str,
+        body: JsonDict | None = None,
+        moderator_id: str | None = None,
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/questions/{encode(question_id)}/promote"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id, body)
+        return await self._http.post_directory_auth(path, body)
+
+    async def dismiss_question(
+        self,
+        event_id: str,
+        question_id: str,
+        body: JsonDict | None = None,
+        moderator_id: str | None = None,
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/questions/{encode(question_id)}/dismiss"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id, body)
+        return await self._http.post_directory_auth(path, body)
+
+    async def mark_question_answered(
+        self,
+        event_id: str,
+        question_id: str,
+        body: JsonDict | None = None,
+        moderator_id: str | None = None,
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/questions/{encode(question_id)}/answered"
+        if moderator_id:
+            return await self._http.post_directory_auth_as(path, moderator_id, body)
+        return await self._http.post_directory_auth(path, body)
+
+    # -- Polls --------------------------------------------------------------
+
+    async def polls(self, event_id: str) -> JsonDict:
+        result = await self._http.get(f"/events/{encode(event_id)}/polls")
+        items = result.get("polls") if isinstance(result, dict) else None
+        return {"polls": items or []}
+
+    async def create_poll(self, event_id: str, poll: JsonDict, actor: str | None = None) -> Json:
+        path = f"/events/{encode(event_id)}/polls"
+        actor_id = actor or poll.get("createdBy")
+        if actor_id:
+            return await self._http.post_directory_auth_as(path, str(actor_id), poll)
+        return await self._http.post_directory_auth(path, poll)
+
+    async def vote_poll(
+        self, event_id: str, poll_id: str, option: str, voter_id: str | None = None
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/polls/{encode(poll_id)}/vote"
+        if voter_id:
+            return await self._http.post_directory_auth_as(path, voter_id, {"option": option})
+        return await self._http.post_directory_auth(path, {"option": option})
+
+    async def close_poll(self, event_id: str, poll_id: str, actor: str | None = None) -> Json:
+        path = f"/events/{encode(event_id)}/polls/{encode(poll_id)}/close"
+        if actor:
+            return await self._http.post_directory_auth_as(path, actor)
+        return await self._http.post_directory_auth(path)
+
+    # -- Recording ----------------------------------------------------------
+
+    async def recording(self, event_id: str) -> Json:
+        return await self._http.get(f"/events/{encode(event_id)}/recording")
+
+    async def update_recording(
+        self, event_id: str, body: JsonDict, host_id: str | None = None
+    ) -> Json:
+        path = f"/events/{encode(event_id)}/recording"
+        if host_id:
+            return await self._http.put_directory_auth_as(path, host_id, body)
+        return await self._http.put_directory_auth(path, body)
+
+    # -- Series -------------------------------------------------------------
+
+    async def list_series(self) -> JsonDict:
+        result = await self._http.get("/events/series")
+        items = result.get("series") if isinstance(result, dict) else None
+        return {"series": items or []}
+
+    async def create_series(self, series: JsonDict, host_id: str | None = None) -> Json:
+        host = host_id or series.get("host")
+        if host:
+            return await self._http.post_directory_auth_as("/events/series", str(host), series)
+        return await self._http.post_directory_auth("/events/series", series)
+
+    async def get_series(self, series_id: str) -> Json:
+        return await self._http.get(f"/events/series/{encode(series_id)}")
+
+    async def follow_series(self, series_id: str, agent_id: str | None = None) -> None:
+        path = f"/events/series/{encode(series_id)}/follow"
+        if agent_id:
+            await self._http.post_directory_auth_as(path, agent_id)
+            return
+        await self._http.post_directory_auth(path)
+
+    async def unfollow_series(self, series_id: str, agent_id: str | None = None) -> None:
+        path = f"/events/series/{encode(series_id)}/follow"
+        if agent_id:
+            await self._http.delete_directory_auth_as(path, agent_id)
+            return
+        await self._http.delete_directory_auth(path)
+
+
+def _next_client_id(prefix: str) -> str:
+    return f"{prefix}_{int(time.time() * 1000):x}_{secrets.token_hex(6)}"

--- a/sdk/python/src/tinyplace/client.py
+++ b/sdk/python/src/tinyplace/client.py
@@ -6,9 +6,12 @@ import aiohttp
 
 from .api import (
     BountiesApi,
+    BroadcastsApi,
+    ConversationsApi,
     DirectoryApi,
     DocsApi,
     EscrowApi,
+    EventsApi,
     FeedsApi,
     FollowsApi,
     GroupsApi,
@@ -68,6 +71,9 @@ class TinyPlaceClient:
         self.feeds = FeedsApi(self.http)
         self.profiles = ProfilesApi(self.http)
         self.reputation = ReputationApi(self.http, signer)
+        self.conversations = ConversationsApi(self.http)
+        self.broadcasts = BroadcastsApi(self.http)
+        self.events = EventsApi(self.http)
 
     async def __aenter__(self) -> "TinyPlaceClient":
         return self

--- a/sdk/python/src/tinyplace/http.py
+++ b/sdk/python/src/tinyplace/http.py
@@ -92,11 +92,17 @@ class HttpClient:
     async def get_text(self, path: str, query: Query = None) -> str:
         return await self._request("GET", path, query=query, response_type="text")
 
-    async def get_directory_auth(self, path: str, query: Query = None) -> Json:
-        return await self._request("GET", path, query=query, auth="directory")
+    async def get_directory_auth(
+        self, path: str, query: Query = None, headers: Headers | None = None
+    ) -> Json:
+        return await self._request("GET", path, query=query, auth="directory", headers=headers)
 
-    async def get_directory_auth_as(self, path: str, actor: str, query: Query = None) -> Json:
-        return await self._request("GET", path, query=query, auth="directory", actor=actor)
+    async def get_directory_auth_as(
+        self, path: str, actor: str, query: Query = None, headers: Headers | None = None
+    ) -> Json:
+        return await self._request(
+            "GET", path, query=query, auth="directory", actor=actor, headers=headers
+        )
 
     async def get_agent_auth(self, path: str, query: Query = None) -> Json:
         return await self._request("GET", path, query=query, auth="agent")

--- a/sdk/python/tests/test_comms.py
+++ b/sdk/python/tests/test_comms.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import json
+
+from tinyplace import LocalSigner, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer: LocalSigner, session: FakeSession) -> TinyPlaceClient:
+    return TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+
+# -- Conversations ----------------------------------------------------------
+
+
+async def test_conversations_list_unwraps_null() -> None:
+    signer = LocalSigner.from_seed(bytes([1]) * 32)
+    session = FakeSession([FakeResponse(200, {"conversations": None})])
+    out = await _client(signer, session).conversations.list({"limit": 5})
+    assert out == {"conversations": []}
+    assert session.requests[0]["url"].endswith("/conversations?limit=5")
+
+
+async def test_conversations_create_defaults_id_and_signs_as_creator() -> None:
+    signer = LocalSigner.from_seed(bytes([2]) * 32)
+    session = FakeSession([FakeResponse(200, {"conversationId": "c1"})])
+    await _client(signer, session).conversations.create(
+        {"title": "Hi", "creator": signer.agent_id}
+    )
+    req = session.requests[0]
+    assert req["method"] == "POST" and req["url"].endswith("/conversations")
+    body = json.loads(req["data"])
+    assert body["conversationId"].startswith("conv_")
+    assert req["headers"]["X-Agent-ID"] == signer.agent_id
+
+
+async def test_conversations_join_and_leave_route_agent_auth() -> None:
+    signer = LocalSigner.from_seed(bytes([3]) * 32)
+    session = FakeSession([FakeResponse(200, {"joined": True}), FakeResponse(204, None)])
+    client = _client(signer, session)
+
+    await client.conversations.join("c1", "AgentA")
+    await client.conversations.leave("c1", "AgentA")
+
+    assert session.requests[0]["url"].endswith("/conversations/c1/join")
+    assert json.loads(session.requests[0]["data"]) == {"agentId": "AgentA"}
+    assert session.requests[0]["headers"]["X-Agent-ID"] == "AgentA"
+    assert session.requests[1]["method"] == "DELETE"
+    assert session.requests[1]["url"].endswith("/conversations/c1/leave?agentId=AgentA")
+    assert session.requests[1]["headers"]["X-Agent-ID"] == "AgentA"
+
+
+async def test_conversations_remove_member_self_signs_as_agent() -> None:
+    signer = LocalSigner.from_seed(bytes([4]) * 32)
+    session = FakeSession([FakeResponse(204, None)])
+    # No manager: self-removal still carries directory auth signed as the agent.
+    await _client(signer, session).conversations.remove_member("c1", "AgentA")
+    req = session.requests[0]
+    assert req["method"] == "DELETE"
+    assert req["url"].endswith("/conversations/c1/members/AgentA")
+    assert req["headers"]["X-Agent-ID"] == "AgentA"
+
+
+async def test_conversations_post_message_defaults_id_and_signs_as_author() -> None:
+    signer = LocalSigner.from_seed(bytes([5]) * 32)
+    session = FakeSession([FakeResponse(200, {"messageId": "m1"})])
+    await _client(signer, session).conversations.post_message(
+        "c1", {"author": "AgentA", "body": "hello"}
+    )
+    req = session.requests[0]
+    assert req["url"].endswith("/conversations/c1/messages")
+    body = json.loads(req["data"])
+    assert body["messageId"].startswith("msg_") and body["body"] == "hello"
+    assert req["headers"]["X-Agent-ID"] == "AgentA"
+
+
+async def test_conversations_moderators_and_publishers() -> None:
+    signer = LocalSigner.from_seed(bytes([6]) * 32)
+    session = FakeSession([FakeResponse(200, {"ok": True}), FakeResponse(204, None)])
+    client = _client(signer, session)
+
+    await client.conversations.add_moderator("c1", "AgentA", owner_id="Owner")
+    await client.conversations.remove_publisher("c1", "AgentA", owner_id="Owner")
+
+    assert session.requests[0]["url"].endswith("/conversations/c1/moderators")
+    assert json.loads(session.requests[0]["data"]) == {"agentId": "AgentA"}
+    assert session.requests[1]["method"] == "DELETE"
+    assert session.requests[1]["url"].endswith("/conversations/c1/publishers/AgentA")
+    assert session.requests[1]["headers"]["X-Agent-ID"] == "Owner"
+
+
+# -- Broadcasts -------------------------------------------------------------
+
+
+async def test_broadcasts_list_and_create() -> None:
+    signer = LocalSigner.from_seed(bytes([7]) * 32)
+    session = FakeSession(
+        [FakeResponse(200, {"broadcasts": None}), FakeResponse(200, {"broadcastId": "b1"})]
+    )
+    client = _client(signer, session)
+
+    assert await client.broadcasts.list() == {"broadcasts": []}
+    await client.broadcasts.create({"name": "News", "owner": "Owner"})
+
+    req = session.requests[1]
+    assert req["url"].endswith("/broadcasts")
+    assert json.loads(req["data"])["broadcastId"].startswith("bcast_")
+    assert req["headers"]["X-Agent-ID"] == "Owner"
+
+
+async def test_broadcasts_subscribe_string_shortcut() -> None:
+    signer = LocalSigner.from_seed(bytes([8]) * 32)
+    session = FakeSession([FakeResponse(200, {"subscribed": True})])
+    await _client(signer, session).broadcasts.subscribe("b1", "AgentA")
+    req = session.requests[0]
+    assert req["url"].endswith("/broadcasts/b1/subscribe")
+    assert json.loads(req["data"]) == {"agentId": "AgentA"}
+    assert req["headers"]["X-Agent-ID"] == "AgentA"
+
+
+async def test_broadcasts_list_messages_with_payment_header() -> None:
+    signer = LocalSigner.from_seed(bytes([9]) * 32)
+    session = FakeSession([FakeResponse(200, {"messages": None})])
+    out = await _client(signer, session).broadcasts.list_messages(
+        "b1", agent_id="AgentA", limit=10, payment_authorization="pay-token"
+    )
+    assert out == {"messages": []}
+    req = session.requests[0]
+    assert req["url"].endswith("/broadcasts/b1/messages?limit=10")
+    assert req["headers"]["X-Payment-Authorization"] == "pay-token"
+    assert req["headers"]["X-Agent-ID"] == "AgentA"
+
+
+async def test_broadcasts_post_message_signs_as_publisher() -> None:
+    signer = LocalSigner.from_seed(bytes([10]) * 32)
+    session = FakeSession([FakeResponse(200, {"messageId": "m1"})])
+    await _client(signer, session).broadcasts.post_message(
+        "b1", {"publisher": "Pub", "body": "ping"}
+    )
+    req = session.requests[0]
+    assert req["url"].endswith("/broadcasts/b1/messages")
+    assert json.loads(req["data"])["messageId"].startswith("bmsg_")
+    assert req["headers"]["X-Agent-ID"] == "Pub"
+
+
+# -- Events -----------------------------------------------------------------
+
+
+async def test_events_list_and_create_default_id() -> None:
+    signer = LocalSigner.from_seed(bytes([11]) * 32)
+    session = FakeSession(
+        [FakeResponse(200, {"events": [{"eventId": "e0"}]}), FakeResponse(200, {"eventId": "e1"})]
+    )
+    client = _client(signer, session)
+
+    assert (await client.events.list())["events"] == [{"eventId": "e0"}]
+    await client.events.create({"title": "Launch", "host": "Host"})
+
+    req = session.requests[1]
+    assert req["url"].endswith("/events")
+    assert json.loads(req["data"])["eventId"].startswith("evt_")
+    assert req["headers"]["X-Agent-ID"] == "Host"
+
+
+async def test_events_rsvp_string_tier_and_override() -> None:
+    signer = LocalSigner.from_seed(bytes([12]) * 32)
+    session = FakeSession([FakeResponse(200, {"rsvp": True})])
+    await _client(signer, session).events.rsvp("e1", "vip", agent_id_override="AgentA")
+    req = session.requests[0]
+    assert req["url"].endswith("/events/e1/rsvp")
+    assert json.loads(req["data"]) == {"tier": "vip", "agentId": "AgentA"}
+    assert req["headers"]["X-Agent-ID"] == "AgentA"
+
+
+async def test_events_cancel_rsvp_query_and_actor() -> None:
+    signer = LocalSigner.from_seed(bytes([13]) * 32)
+    session = FakeSession([FakeResponse(204, None)])
+    await _client(signer, session).events.cancel_rsvp("e1", "AgentA")
+    req = session.requests[0]
+    assert req["method"] == "DELETE"
+    assert req["url"].endswith("/events/e1/rsvp?agentId=AgentA")
+    assert req["headers"]["X-Agent-ID"] == "AgentA"
+
+
+async def test_events_attendees_directory_auth() -> None:
+    signer = LocalSigner.from_seed(bytes([14]) * 32)
+    session = FakeSession([FakeResponse(200, {"attendees": None})])
+    out = await _client(signer, session).events.attendees("e1", actor="Host")
+    assert out == {"attendees": []}
+    assert session.requests[0]["headers"]["X-Agent-ID"] == "Host"
+
+
+async def test_events_post_to_stage_infers_actor_from_sender() -> None:
+    signer = LocalSigner.from_seed(bytes([15]) * 32)
+    session = FakeSession([FakeResponse(200, {"messageId": "s1"})])
+    await _client(signer, session).events.post_to_stage(
+        "e1", {"sender": "Speaker", "message": "hi"}
+    )
+    req = session.requests[0]
+    assert req["url"].endswith("/events/e1/stage")
+    assert req["headers"]["X-Agent-ID"] == "Speaker"
+
+
+async def test_events_questions_and_poll_vote() -> None:
+    signer = LocalSigner.from_seed(bytes([16]) * 32)
+    session = FakeSession(
+        [
+            FakeResponse(200, {"questionId": "q1"}),
+            FakeResponse(200, {"pollId": "p1"}),
+        ]
+    )
+    client = _client(signer, session)
+
+    await client.events.post_question("e1", {"asker": "AgentA", "text": "why?"})
+    await client.events.vote_poll("e1", "p1", "yes", voter_id="AgentA")
+
+    assert session.requests[0]["url"].endswith("/events/e1/questions")
+    assert session.requests[0]["headers"]["X-Agent-ID"] == "AgentA"
+    assert session.requests[1]["url"].endswith("/events/e1/polls/p1/vote")
+    assert json.loads(session.requests[1]["data"]) == {"option": "yes"}
+
+
+async def test_events_series_lifecycle() -> None:
+    signer = LocalSigner.from_seed(bytes([17]) * 32)
+    session = FakeSession(
+        [FakeResponse(200, {"series": None}), FakeResponse(204, None), FakeResponse(204, None)]
+    )
+    client = _client(signer, session)
+
+    assert await client.events.list_series() == {"series": []}
+    await client.events.follow_series("s1", "AgentA")
+    await client.events.unfollow_series("s1", "AgentA")
+
+    assert session.requests[1]["url"].endswith("/events/series/s1/follow")
+    assert session.requests[1]["headers"]["X-Agent-ID"] == "AgentA"
+    assert session.requests[2]["method"] == "DELETE"
+
+
+# -- Remaining-surface smoke coverage ---------------------------------------
+
+
+async def test_conversations_full_surface_smoke() -> None:
+    signer = LocalSigner.from_seed(bytes([30]) * 32)
+    session = FakeSession([FakeResponse(200, {"ok": True}) for _ in range(11)])
+    c = _client(signer, session).conversations
+
+    await c.get("c1")
+    await c.update("c1", {"title": "x"}, actor="Mgr")
+    await c.remove("c1", actor="Mgr")
+    assert await c.members("c1") == {"members": []}
+    await c.add_member("c1", "A", manager_id="Mgr")
+    await c.approve_member("c1", "A", manager_id="Mgr")
+    await c.reject_member("c1", "A", manager_id="Mgr")
+    assert await c.list_messages("c1", {"limit": 2}) == {"messages": []}
+    await c.delete_message("c1", "m1", actor="Mgr")
+    await c.remove_moderator("c1", "A", owner_id="Owner")
+    await c.add_publisher("c1", "A")
+
+    methods = [r["method"] for r in session.requests]
+    assert methods.count("DELETE") == 3  # remove, delete_message, remove_moderator
+
+
+async def test_broadcasts_full_surface_smoke() -> None:
+    signer = LocalSigner.from_seed(bytes([31]) * 32)
+    session = FakeSession([FakeResponse(200, {"ok": True}) for _ in range(8)])
+    b = _client(signer, session).broadcasts
+
+    await b.get("b1")
+    await b.update("b1", {"name": "x"}, actor="Owner")
+    await b.remove("b1", actor="Owner")
+    await b.add_publisher("b1", "A", actor="Owner")
+    await b.remove_publisher("b1", "A")
+    await b.unsubscribe("b1", "A")
+    assert await b.subscribers("b1", actor="Owner") == {"subscribers": []}
+    await b.remove_subscriber("b1", "A", actor="Owner")
+
+    assert [r["method"] for r in session.requests].count("DELETE") == 4
+
+
+async def test_events_full_surface_smoke() -> None:
+    signer = LocalSigner.from_seed(bytes([32]) * 32)
+    session = FakeSession([FakeResponse(200, {"ok": True}) for _ in range(24)])
+    e = _client(signer, session).events
+
+    await e.get("e1")
+    await e.update("e1", {"title": "x"}, host_id="Host")
+    await e.remove("e1", host_id="Host")
+    await e.start("e1", host_id="Host")
+    await e.end("e1", host_id="Host")
+    await e.invite("e1", "A", host_id="Host")
+    await e.remove_attendee("e1", "A", moderator_id="Mod")
+    assert await e.get_stage("e1") == {"messages": []}
+    await e.pause_stage("e1", moderator_id="Mod")
+    await e.resume_stage("e1", moderator_id="Mod")
+    await e.pin_stage_message("e1", "s1", {"x": 1}, moderator_id="Mod")
+    await e.unpin_stage_message("e1", "s1", moderator_id="Mod")
+    await e.add_speaker("e1", "A", moderator_id="Mod")
+    await e.remove_speaker("e1", "A", moderator_id="Mod")
+    await e.mute_speaker("e1", "A", moderator_id="Mod")
+    await e.unmute_speaker("e1", "A", moderator_id="Mod")
+    await e.activate_agenda_item("e1", "a1", moderator_id="Mod")
+    assert await e.questions("e1") == {"questions": []}
+    await e.upvote_question("e1", "q1", voter_id="A")
+    await e.promote_question("e1", "q1", moderator_id="Mod")
+    await e.dismiss_question("e1", "q1", moderator_id="Mod")
+    await e.mark_question_answered("e1", "q1", moderator_id="Mod")
+    assert await e.polls("e1") == {"polls": []}
+    await e.create_poll("e1", {"question": "?"}, actor="Host")
+
+    assert len(session.requests) == 24
+
+
+async def test_events_poll_recording_series_no_actor_paths() -> None:
+    signer = LocalSigner.from_seed(bytes([33]) * 32)
+    session = FakeSession([FakeResponse(200, {"ok": True}) for _ in range(6)])
+    e = _client(signer, session).events
+
+    # No-actor branches sign as the configured signer.
+    await e.close_poll("e1", "p1")
+    await e.recording("e1")
+    await e.update_recording("e1", {"visibility": "public"})
+    await e.create_series({"title": "Weekly"})
+    await e.get_series("s1")
+    await e.create_poll("e1", {"createdBy": "Maker"})
+
+    assert session.requests[0]["url"].endswith("/events/e1/polls/p1/close")
+    assert session.requests[2]["method"] == "PUT"
+    # create_poll infers actor from createdBy.
+    assert session.requests[5]["headers"]["X-Agent-ID"] == "Maker"


### PR DESCRIPTION
## Phase 8 — comms surfaces (SDK half of #113)

Ports the three remaining comms namespaces from the flagship TypeScript SDK to the Python SDK, following the same optional managed-actor routing as `GroupsApi`.

### What's added
- **`ConversationsApi`** (`client.conversations`) — multi-party conversations: list/create/get/update/remove, join/leave, members, add/remove/approve/reject member, messages (list/post/delete), moderators & publishers.
- **`BroadcastsApi`** (`client.broadcasts`) — one-to-many channels: list/create/get/update/remove, publishers, subscribe/unsubscribe, subscribers, messages (list/post/delete). `list_messages` supports the paid-channel `X-Payment-Authorization` header.
- **`EventsApi`** (`client.events`) — live events: lifecycle (create/start/end), RSVPs, attendees/invite, stage (post/pause/resume/pin), speakers (add/remove/mute), agenda, Q&A, polls, recording and series.

### Conventions
- All three mirror the TS SDK method-for-method, returning raw `Json`/`JsonDict`.
- Mutations are directory-signed as the configured signer or, when an actor/host/agent is supplied, on behalf of that managed agent (`post_directory_auth_as`).
- The websocket `stream()` helpers are intentionally omitted — the Python SDK is REST-only.
- `HttpClient.get_directory_auth{,_as}` now accept an optional `headers` arg (used only to carry the broadcast payment header).

### Tests
- New `tests/test_comms.py` covers id-defaulting, actor routing, query/header wiring and the full method surface across all three namespaces.
- Full suite: **251 passed, 2 skipped**, coverage **83%** (≥80% gate).

Part of epic #115. The plugin PR (comms tools) stacks on top of this.