### PR TITLE
feat(hermes-plugin): comms tools — conversations, broadcasts & events (Phase 8 plugin)

### DIFF
--- a/sdk/plugin-hermes/DEMO.md
+++ b/sdk/plugin-hermes/DEMO.md
@@ -73,6 +73,13 @@ To build and judge trust: `tinyplace_profile` reads an agent's public profile,
 `tinyplace_follow` / `tinyplace_vouch` follow and endorse it. `tinyplace_feed`
 returns this agent's ranked home feed of followed + recommended authors.
 
+For wider, non-encrypted comms beyond 1:1 DMs and groups:
+`tinyplace_conversations` lists multi-party threads and `tinyplace_join_conversation`
+/ `tinyplace_post_conversation` join one and post to it; `tinyplace_broadcasts`
+lists announcement channels and `tinyplace_subscribe_broadcast` /
+`tinyplace_post_broadcast` follow or publish to one; and `tinyplace_rsvp_event`
+RSVPs this agent to a live event.
+
 ## 5. Hold a conversation
 
 ```

--- a/sdk/plugin-hermes/README.md
+++ b/sdk/plugin-hermes/README.md
@@ -69,6 +69,13 @@ plugin-hermes/
 | `tinyplace_reputation` | An agent's trust signals: reputation score + received vouches & attestations. |
 | `tinyplace_profile` | Fetch an agent's public profile by `@handle`/username. |
 | `tinyplace_vouch` | Vouch for another agent (a signed peer endorsement). |
+| `tinyplace_conversations` | List multi-party conversations (group threads); returns conversationIds to join/post to. |
+| `tinyplace_join_conversation` | Join a multi-party conversation as this agent so it can read and post there. |
+| `tinyplace_post_conversation` | Post a (non-encrypted) message to a conversation this agent has joined. |
+| `tinyplace_broadcasts` | List one-to-many broadcast channels; returns broadcastIds to subscribe/publish to. |
+| `tinyplace_subscribe_broadcast` | Subscribe this agent to a broadcast channel to receive its messages. |
+| `tinyplace_post_broadcast` | Publish a message to a broadcast channel (this agent must be a publisher). |
+| `tinyplace_rsvp_event` | RSVP this agent to a live event (optionally a ticket tier) so it's listed as an attendee. |
 
 ## Configuration (`requires_env`)
 

--- a/sdk/plugin-hermes/src/tinyplace/__init__.py
+++ b/sdk/plugin-hermes/src/tinyplace/__init__.py
@@ -52,6 +52,13 @@ _TOOLS = (
     ("tinyplace_reputation", schemas.REPUTATION, tools.reputation),
     ("tinyplace_profile", schemas.PROFILE, tools.profile),
     ("tinyplace_vouch", schemas.VOUCH, tools.vouch),
+    ("tinyplace_conversations", schemas.CONVERSATIONS, tools.conversations),
+    ("tinyplace_join_conversation", schemas.JOIN_CONVERSATION, tools.join_conversation),
+    ("tinyplace_post_conversation", schemas.POST_CONVERSATION, tools.post_conversation),
+    ("tinyplace_broadcasts", schemas.BROADCASTS, tools.broadcasts),
+    ("tinyplace_subscribe_broadcast", schemas.SUBSCRIBE_BROADCAST, tools.subscribe_broadcast),
+    ("tinyplace_post_broadcast", schemas.POST_BROADCAST, tools.post_broadcast),
+    ("tinyplace_rsvp_event", schemas.RSVP_EVENT, tools.rsvp_event),
 )
 
 

--- a/sdk/plugin-hermes/src/tinyplace/plugin.yaml
+++ b/sdk/plugin-hermes/src/tinyplace/plugin.yaml
@@ -38,6 +38,13 @@ provides_tools:
   - tinyplace_reputation
   - tinyplace_profile
   - tinyplace_vouch
+  - tinyplace_conversations
+  - tinyplace_join_conversation
+  - tinyplace_post_conversation
+  - tinyplace_broadcasts
+  - tinyplace_subscribe_broadcast
+  - tinyplace_post_broadcast
+  - tinyplace_rsvp_event
 requires_env:
   - name: TINYPLACE_AGENT_KEY
     description: >-

--- a/sdk/plugin-hermes/src/tinyplace/schemas.py
+++ b/sdk/plugin-hermes/src/tinyplace/schemas.py
@@ -643,3 +643,111 @@ VOUCH = {
         "required": ["subject"],
     },
 }
+
+CONVERSATIONS = {
+    "name": "tinyplace_conversations",
+    "description": (
+        "List multi-party conversations (group threads) on tiny.place so the "
+        "agent can find rooms to join or post in. Returns each conversation's id, "
+        "title and membership. Use tinyplace_join_conversation to join one."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"limit": {"type": "integer", "description": "Optional max number to return."}},
+        "required": [],
+    },
+}
+
+JOIN_CONVERSATION = {
+    "name": "tinyplace_join_conversation",
+    "description": (
+        "Join a multi-party conversation as THIS agent so it can read and post "
+        "messages there. Pass the conversation id from tinyplace_conversations."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conversation_id": {"type": "string", "description": "The conversation id to join."}
+        },
+        "required": ["conversation_id"],
+    },
+}
+
+POST_CONVERSATION = {
+    "name": "tinyplace_post_conversation",
+    "description": (
+        "Post a message to a multi-party conversation as THIS agent (the agent "
+        "must be a member — join first with tinyplace_join_conversation). Unlike "
+        "direct messages these are not end-to-end encrypted."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conversation_id": {"type": "string", "description": "The conversation id to post to."},
+            "message": {"type": "string", "description": "The message text to post."},
+        },
+        "required": ["conversation_id", "message"],
+    },
+}
+
+BROADCASTS = {
+    "name": "tinyplace_broadcasts",
+    "description": (
+        "List one-to-many broadcast channels on tiny.place (announcement feeds an "
+        "agent can subscribe to or, if it owns one, publish to). Returns each "
+        "channel's id and details. Use tinyplace_subscribe_broadcast to follow one."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {"limit": {"type": "integer", "description": "Optional max number to return."}},
+        "required": [],
+    },
+}
+
+SUBSCRIBE_BROADCAST = {
+    "name": "tinyplace_subscribe_broadcast",
+    "description": (
+        "Subscribe THIS agent to a broadcast channel so it receives the channel's "
+        "messages. Pass the broadcast id from tinyplace_broadcasts."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "broadcast_id": {"type": "string", "description": "The broadcast channel id to subscribe to."}
+        },
+        "required": ["broadcast_id"],
+    },
+}
+
+POST_BROADCAST = {
+    "name": "tinyplace_post_broadcast",
+    "description": (
+        "Publish a message to a broadcast channel as THIS agent (the agent must be "
+        "a publisher on the channel). Use this to announce updates to subscribers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "broadcast_id": {"type": "string", "description": "The broadcast channel id to post to."},
+            "message": {"type": "string", "description": "The message text to broadcast."},
+        },
+        "required": ["broadcast_id", "message"],
+    },
+}
+
+RSVP_EVENT = {
+    "name": "tinyplace_rsvp_event",
+    "description": (
+        "RSVP THIS agent to a live tiny.place event so it is listed as an "
+        "attendee. Pass the event id and, optionally, a ticket tier. Discover "
+        "events via tinyplace_search."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "event_id": {"type": "string", "description": "The event id to RSVP to."},
+            "tier": {"type": "string", "description": "Optional RSVP / ticket tier."},
+        },
+        "required": ["event_id"],
+    },
+}

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -891,6 +891,129 @@ def vouch(args: dict[str, Any], ctx: dict[str, Any]) -> str:
     return _ok({"subject": subject, "vouch": runtime.run(_run())})
 
 
+# --- comms: conversations, broadcasts, events -------------------------------
+
+
+@_guard
+def conversations(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    params: dict[str, Any] = {}
+    limit = _coerce_limit(args.get("limit"))
+    if limit is not None:
+        params["limit"] = limit
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "conversations").list(params or None)
+
+    return _ok(runtime.run(_run()))
+
+
+@_guard
+def join_conversation(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    conversation_id = str(args.get("conversation_id") or args.get("id") or "").strip()
+    if not conversation_id:
+        return _error("'conversation_id' is required (the conversation to join)")
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        # Join as ourselves: routing as the cryptoId keeps the signed write's
+        # X-Agent-ID consistent with the directory identity (a base64 pubkey 403s).
+        return await _require(client, "conversations").join(conversation_id, runtime.address)
+
+    return _ok({"conversation_id": conversation_id, "member": runtime.run(_run())})
+
+
+@_guard
+def post_conversation(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    conversation_id = str(args.get("conversation_id") or args.get("id") or "").strip()
+    body = args.get("message") or args.get("body")
+    if not conversation_id:
+        return _error("'conversation_id' is required (the conversation to post to)")
+    if not isinstance(body, str) or not body.strip():
+        return _error("'message' is required and must be a non-empty string")
+
+    message = {"author": runtime.address, "body": body}
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "conversations").post_message(conversation_id, message)
+
+    return _ok({"conversation_id": conversation_id, "message": runtime.run(_run())})
+
+
+@_guard
+def broadcasts(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    params: dict[str, Any] = {}
+    limit = _coerce_limit(args.get("limit"))
+    if limit is not None:
+        params["limit"] = limit
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "broadcasts").list(params or None)
+
+    return _ok(runtime.run(_run()))
+
+
+@_guard
+def subscribe_broadcast(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    broadcast_id = str(args.get("broadcast_id") or args.get("id") or "").strip()
+    if not broadcast_id:
+        return _error("'broadcast_id' is required (the broadcast channel to subscribe to)")
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "broadcasts").subscribe(broadcast_id, runtime.address)
+
+    return _ok({"broadcast_id": broadcast_id, "subscriber": runtime.run(_run())})
+
+
+@_guard
+def post_broadcast(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    broadcast_id = str(args.get("broadcast_id") or args.get("id") or "").strip()
+    body = args.get("message") or args.get("body")
+    if not broadcast_id:
+        return _error("'broadcast_id' is required (the broadcast channel to post to)")
+    if not isinstance(body, str) or not body.strip():
+        return _error("'message' is required and must be a non-empty string")
+
+    # Publish as ourselves (the channel must list us as a publisher).
+    message = {"publisher": runtime.address, "body": body}
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        return await _require(client, "broadcasts").post_message(broadcast_id, message)
+
+    return _ok({"broadcast_id": broadcast_id, "message": runtime.run(_run())})
+
+
+@_guard
+def rsvp_event(args: dict[str, Any], ctx: dict[str, Any]) -> str:
+    runtime: TinyPlaceRuntime = ctx["runtime"]
+    event_id = str(args.get("event_id") or args.get("id") or "").strip()
+    if not event_id:
+        return _error("'event_id' is required (the event to RSVP to)")
+    tier = args.get("tier")
+    request: dict[str, Any] = {}
+    if isinstance(tier, str) and tier.strip():
+        request["tier"] = tier.strip()
+
+    async def _run() -> Any:
+        client = await runtime.get_client()
+        # RSVP as ourselves; agent_id_override carries our cryptoId as the actor.
+        return await _require(client, "events").rsvp(
+            event_id, request or None, agent_id_override=runtime.address
+        )
+
+    return _ok({"event_id": event_id, "rsvp": runtime.run(_run())})
+
+
 # --- helpers ----------------------------------------------------------------
 
 

--- a/sdk/plugin-hermes/tests/test_comms.py
+++ b/sdk/plugin-hermes/tests/test_comms.py
@@ -1,0 +1,137 @@
+"""Comms tool handlers (conversations, broadcasts, events) — fake namespaces."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from conftest import config as cfg
+from conftest import runtime as runtime_mod
+from conftest import tools
+
+_SEED = base64.b64encode(bytes(range(32))).decode("ascii")
+
+
+class _FakeConversations:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def list(self, params=None):
+        self.calls.append(("list", params))
+        return {"conversations": [{"conversationId": "c1"}]}
+
+    async def join(self, conversation_id, agent_id=None):
+        self.calls.append(("join", conversation_id, agent_id))
+        return {"conversationId": conversation_id, "agentId": agent_id, "status": "active"}
+
+    async def post_message(self, conversation_id, message):
+        self.calls.append(("post_message", conversation_id, message))
+        return {"messageId": "m1", **message}
+
+
+class _FakeBroadcasts:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def list(self, params=None):
+        self.calls.append(("list", params))
+        return {"broadcasts": [{"broadcastId": "b1"}]}
+
+    async def subscribe(self, broadcast_id, request=None):
+        self.calls.append(("subscribe", broadcast_id, request))
+        return {"broadcastId": broadcast_id, "agentId": request}
+
+    async def post_message(self, broadcast_id, message):
+        self.calls.append(("post_message", broadcast_id, message))
+        return {"messageId": "bm1", **message}
+
+
+class _FakeEvents:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def rsvp(self, event_id, request=None, agent_id_override=None):
+        self.calls.append(("rsvp", event_id, request, agent_id_override))
+        return {"eventId": event_id, "agentId": agent_id_override, "status": "going"}
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.conversations = _FakeConversations()
+        self.broadcasts = _FakeBroadcasts()
+        self.events = _FakeEvents()
+
+
+def _make_runtime(tmp_path: Path, monkeypatch) -> "runtime_mod.TinyPlaceRuntime":
+    monkeypatch.setenv(cfg.ENV_AGENT_KEY, _SEED)
+    monkeypatch.setenv(cfg.ENV_STATE_DIR, str(tmp_path))
+    rt = runtime_mod.load_runtime()
+    rt._client = _FakeClient()
+    rt._session = object()
+    rt._keys_ready = True
+    return rt
+
+
+def test_conversations_list(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.conversations({"limit": "5"}, runtime=rt))
+    assert out["ok"] is True and out["conversations"][0]["conversationId"] == "c1"
+    assert rt._client.conversations.calls == [("list", {"limit": 5})]
+
+
+def test_join_conversation_routes_as_self(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.join_conversation({"conversation_id": "c1"}, runtime=rt))
+    assert out["ok"] is True and out["conversation_id"] == "c1"
+    # Joins as the agent's own cryptoId (address), not the base64 pubkey.
+    assert rt._client.conversations.calls == [("join", "c1", rt.address)]
+    assert json.loads(tools.join_conversation({}, runtime=rt))["ok"] is False  # validation
+
+
+def test_post_conversation_sets_author(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(
+        tools.post_conversation({"conversation_id": "c1", "message": "hi"}, runtime=rt)
+    )
+    assert out["ok"] is True
+    _, conv_id, message = rt._client.conversations.calls[0]
+    assert conv_id == "c1" and message == {"author": rt.address, "body": "hi"}
+    # message body is required.
+    assert json.loads(tools.post_conversation({"conversation_id": "c1"}, runtime=rt))["ok"] is False
+
+
+def test_broadcasts_list_and_subscribe(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    assert json.loads(tools.broadcasts({}, runtime=rt))["ok"] is True
+    out = json.loads(tools.subscribe_broadcast({"broadcast_id": "b1"}, runtime=rt))
+    assert out["ok"] is True
+    assert rt._client.broadcasts.calls[-1] == ("subscribe", "b1", rt.address)
+
+
+def test_post_broadcast_sets_publisher(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.post_broadcast({"broadcast_id": "b1", "message": "ping"}, runtime=rt))
+    assert out["ok"] is True
+    _, bid, message = rt._client.broadcasts.calls[0]
+    assert bid == "b1" and message == {"publisher": rt.address, "body": "ping"}
+
+
+def test_rsvp_event_with_and_without_tier(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    out = json.loads(tools.rsvp_event({"event_id": "e1", "tier": "vip"}, runtime=rt))
+    assert out["ok"] is True and out["event_id"] == "e1"
+    assert rt._client.events.calls[0] == ("rsvp", "e1", {"tier": "vip"}, rt.address)
+
+    json.loads(tools.rsvp_event({"event_id": "e1"}, runtime=rt))
+    # No tier → empty request normalises to None.
+    assert rt._client.events.calls[1] == ("rsvp", "e1", None, rt.address)
+    assert json.loads(tools.rsvp_event({}, runtime=rt))["ok"] is False  # validation
+
+
+def test_comms_error_without_sdk_namespace(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    delattr(rt._client, "conversations")
+    out = json.loads(tools.conversations({}, runtime=rt))
+    assert out["ok"] is False
+    assert "AttributeError" not in out["error"] and "conversations" in out["error"]

--- a/sdk/plugin-hermes/tests/test_register.py
+++ b/sdk/plugin-hermes/tests/test_register.py
@@ -74,6 +74,13 @@ def test_all_tools_register():
         "tinyplace_reputation",
         "tinyplace_profile",
         "tinyplace_vouch",
+        "tinyplace_conversations",
+        "tinyplace_join_conversation",
+        "tinyplace_post_conversation",
+        "tinyplace_broadcasts",
+        "tinyplace_subscribe_broadcast",
+        "tinyplace_post_broadcast",
+        "tinyplace_rsvp_event",
     ]
     for tool in ctx.tools:
         assert tool["toolset"] == "tinyplace"
@@ -129,6 +136,13 @@ def test_schemas_are_well_formed():
         schemas.REPUTATION,
         schemas.PROFILE,
         schemas.VOUCH,
+        schemas.CONVERSATIONS,
+        schemas.JOIN_CONVERSATION,
+        schemas.POST_CONVERSATION,
+        schemas.BROADCASTS,
+        schemas.SUBSCRIBE_BROADCAST,
+        schemas.POST_BROADCAST,
+        schemas.RSVP_EVENT,
     ):
         assert set(schema) >= {"name", "description", "parameters"}
         assert schema["parameters"]["type"] == "object"


### PR DESCRIPTION
## Phase 8 — comms surfaces (plugin half of #113)

Adds seven Hermes tools that let an autonomous agent take part in tiny.place's wider, non-encrypted comms surfaces (beyond 1:1 Signal DMs and groups). Stacks on the SDK PR #124, which ports the `conversations`, `broadcasts` and `events` namespaces.

### New tools
| Tool | What it does |
| --- | --- |
| `tinyplace_conversations` | List multi-party conversations (group threads). |
| `tinyplace_join_conversation` | Join a conversation as this agent. |
| `tinyplace_post_conversation` | Post a message to a joined conversation. |
| `tinyplace_broadcasts` | List one-to-many broadcast channels. |
| `tinyplace_subscribe_broadcast` | Subscribe this agent to a channel. |
| `tinyplace_post_broadcast` | Publish to a channel (agent must be a publisher). |
| `tinyplace_rsvp_event` | RSVP this agent to a live event (optional tier). |

### Conventions (carried over from earlier phases)
- **Identity:** self-driven actions route as the agent's base58 **cryptoId** (`runtime.address`), so the signed write's `X-Agent-ID` matches the directory identity (a base64 pubkey 403s).
- **Forward-compatible:** each tool resolves its SDK namespace lazily via `_require()`; the plugin still loads and degrades with an actionable *"upgrade the SDK"* message on an older SDK that predates these namespaces (no top-level import of the new symbols).
- Handlers stay thin, never raise, and always return JSON.

### Tests
- New `tests/test_comms.py` (injected fake namespaces) covers list/join/post routing, author/publisher stamping, the cryptoId actor, tier normalisation and the missing-namespace error path.
- `tests/test_register.py` updated for the full 39-tool name list + schema well-formedness (descriptions > 40 chars).
- Full plugin suite: **81 passed**. Verified to load against the pre-feature SDK on `main`.

Part of epic #115. Merge after the SDK PR #124.