### PR TITLE
fix: staging bug sweep batch 2 — messaging, payments, activity, bounty, i18n, social, moonpay

### DIFF
--- a/sdk/typescript/src/messaging/discovery.ts
+++ b/sdk/typescript/src/messaging/discovery.ts
@@ -71,22 +71,24 @@ export async function lookupAgentByEncryptionKey(
 
 /**
  * Resolves the messaging/encryption address (base64 Ed25519 pubkey) for an agent
- * card. Prefers the explicitly advertised encryption key; falls back to the card's
- * own `publicKey`, which covers single-key agents (e.g. the CLI) whose messaging
- * address is their identity key.
+ * card: the encryption key the agent advertises under
+ * {@link ENCRYPTION_PUBLIC_KEY_METADATA}.
+ *
+ * This MUST NOT fall back to the card's `publicKey` (the wallet/identity key). An
+ * agent that hasn't published an encryption key also has no Signal key bundle, so
+ * addressing a message to its identity key only fails later — the first
+ * `keys.getBundle` 404s. Throwing here surfaces an actionable error at resolve
+ * time instead of an opaque 404 at send time. Callers that fan out to multiple
+ * peers (e.g. group key handoff) catch this and skip the un-enabled member.
  */
 export function resolveEncryptionAddress(card: AgentCard): string {
   const advertised = card.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA];
-  const address =
-    typeof advertised === "string" && advertised.length > 0
-      ? advertised
-      : card.publicKey;
-  if (!address) {
+  if (typeof advertised !== "string" || advertised.length === 0) {
     throw new Error(
-      `Agent ${card.agentId} has no encryption public key or wallet public key`,
+      `Agent ${card.agentId} hasn't enabled encrypted messaging yet`,
     );
   }
-  return address;
+  return advertised;
 }
 
 /**

--- a/sdk/typescript/src/messaging/discovery.ts
+++ b/sdk/typescript/src/messaging/discovery.ts
@@ -71,24 +71,33 @@ export async function lookupAgentByEncryptionKey(
 
 /**
  * Resolves the messaging/encryption address (base64 Ed25519 pubkey) for an agent
- * card: the encryption key the agent advertises under
- * {@link ENCRYPTION_PUBLIC_KEY_METADATA}.
+ * card.
  *
- * This MUST NOT fall back to the card's `publicKey` (the wallet/identity key). An
- * agent that hasn't published an encryption key also has no Signal key bundle, so
- * addressing a message to its identity key only fails later — the first
- * `keys.getBundle` 404s. Throwing here surfaces an actionable error at resolve
- * time instead of an opaque 404 at send time. Callers that fan out to multiple
- * peers (e.g. group key handoff) catch this and skip the un-enabled member.
+ * Prefers the key the agent advertises under {@link ENCRYPTION_PUBLIC_KEY_METADATA}
+ * (the website publishes it there via {@link publishEncryptionKey}), and falls
+ * back to the card's `publicKey`. The fallback matters for SDK/CLI agents: they
+ * publish their Signal key bundle under their wallet/identity key
+ * (`signer.publicKeyBase64`, which equals `card.publicKey`) without ever setting
+ * the website-only metadata, so their real messaging address IS the publicKey.
+ *
+ * Whether a Signal bundle actually exists at the resolved address is NOT decided
+ * here — it's verified at send time, where the first `keys.getBundle` 404 is
+ * translated into an actionable "hasn't enabled encrypted messaging" error
+ * (see `MessagingEncryptionContext.encryptEnvelope`). Resolving optimistically
+ * keeps CLI peers (bundle at publicKey) reachable; only a card with neither an
+ * advertised key nor a publicKey can't be addressed at all, and throws here.
  */
 export function resolveEncryptionAddress(card: AgentCard): string {
   const advertised = card.metadata?.[ENCRYPTION_PUBLIC_KEY_METADATA];
-  if (typeof advertised !== "string" || advertised.length === 0) {
-    throw new Error(
-      `Agent ${card.agentId} hasn't enabled encrypted messaging yet`,
-    );
+  if (typeof advertised === "string" && advertised.length > 0) {
+    return advertised;
   }
-  return advertised;
+  if (typeof card.publicKey === "string" && card.publicKey.length > 0) {
+    return card.publicKey;
+  }
+  throw new Error(
+    `Agent ${card.agentId} hasn't enabled encrypted messaging yet`,
+  );
 }
 
 /**

--- a/sdk/typescript/src/messaging/encryption.ts
+++ b/sdk/typescript/src/messaging/encryption.ts
@@ -1,4 +1,5 @@
 import type { KeysApi } from "../api/keys.js";
+import { TinyPlaceError } from "../http.js";
 import type { Signer } from "../signer.js";
 import {
   SignalSession,
@@ -10,7 +11,7 @@ import {
   serializeSignedKey,
 } from "../signal/index.js";
 import type { SessionStore } from "../signal/index.js";
-import type { MessageEnvelope } from "../types/index.js";
+import type { KeyBundle, MessageEnvelope } from "../types/index.js";
 
 /** Number of one-time pre-keys uploaded per publish. */
 const DEFAULT_PREKEY_COUNT = 10;
@@ -89,7 +90,7 @@ export class EncryptionContext implements MessageCipher {
     // ride the established Double Ratchet session and need no bundle fetch.
     const bundle = (await session.hasSession(envelope.to))
       ? undefined
-      : await this.keys.getBundle(envelope.to);
+      : await this.fetchBundleForBootstrap(envelope.to);
 
     const encrypted = await session.encrypt(
       envelope.to,
@@ -105,6 +106,25 @@ export class EncryptionContext implements MessageCipher {
       body: encrypted.body,
       ...(encrypted.signal ? { signal: encrypted.signal } : {}),
     };
+  }
+
+  /**
+   * Fetch a recipient's key bundle to bootstrap the first X3DH session. A 404
+   * here means the address has no published Signal bundle — the agent never
+   * enabled encrypted messaging (their directory card may advertise a key, or we
+   * may have optimistically fallen back to their wallet publicKey, but no bundle
+   * was ever uploaded). Translate it into an actionable error instead of leaking
+   * the raw 404 to the send call site.
+   */
+  private async fetchBundleForBootstrap(to: string): Promise<KeyBundle> {
+    try {
+      return await this.keys.getBundle(to);
+    } catch (error) {
+      if (error instanceof TinyPlaceError && error.status === 404) {
+        throw new Error("Recipient hasn't enabled encrypted messaging yet");
+      }
+      throw error;
+    }
   }
 
   async decryptEnvelope(envelope: MessageEnvelope): Promise<Uint8Array> {

--- a/sdk/typescript/tests/encryption-discovery.test.ts
+++ b/sdk/typescript/tests/encryption-discovery.test.ts
@@ -5,7 +5,48 @@ import type { AgentCard } from "../src/index.js";
 import {
   ENCRYPTION_PUBLIC_KEY_METADATA,
   publishEncryptionKey,
+  resolveEncryptionAddress,
 } from "../src/messaging/discovery.js";
+
+function makeCard(overrides: Partial<AgentCard>): AgentCard {
+  return {
+    agentId: "agent-1",
+    name: "Agent One",
+    cryptoId: "agent-1",
+    publicKey: "WALLET_KEY_B64",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("resolveEncryptionAddress", () => {
+  it("returns the advertised encryption key", () => {
+    const card = makeCard({
+      metadata: { [ENCRYPTION_PUBLIC_KEY_METADATA]: "ENC_KEY_B64" },
+    });
+    expect(resolveEncryptionAddress(card)).toBe("ENC_KEY_B64");
+  });
+
+  it("throws (never falls back to the wallet publicKey) when no encryption key is advertised", () => {
+    // Regression: falling back to card.publicKey addressed messages to the
+    // identity key, which has no published Signal bundle — the first send then
+    // 404s on keys.getBundle. Resolving must fail loudly instead.
+    const card = makeCard({ metadata: {} });
+    expect(() => resolveEncryptionAddress(card)).toThrowError(
+      /hasn't enabled encrypted messaging/,
+    );
+  });
+
+  it("throws when the advertised key is an empty string", () => {
+    const card = makeCard({
+      metadata: { [ENCRYPTION_PUBLIC_KEY_METADATA]: "" },
+    });
+    expect(() => resolveEncryptionAddress(card)).toThrowError(
+      /hasn't enabled encrypted messaging/,
+    );
+  });
+});
 
 describe("publishEncryptionKey", () => {
   it("seeds the wallet publicKey when creating a card for a fresh wallet", async () => {

--- a/sdk/typescript/tests/encryption-discovery.test.ts
+++ b/sdk/typescript/tests/encryption-discovery.test.ts
@@ -28,20 +28,24 @@ describe("resolveEncryptionAddress", () => {
     expect(resolveEncryptionAddress(card)).toBe("ENC_KEY_B64");
   });
 
-  it("throws (never falls back to the wallet publicKey) when no encryption key is advertised", () => {
-    // Regression: falling back to card.publicKey addressed messages to the
-    // identity key, which has no published Signal bundle — the first send then
-    // 404s on keys.getBundle. Resolving must fail loudly instead.
+  it("falls back to the wallet publicKey when no encryption key is advertised", () => {
+    // SDK/CLI agents publish their Signal bundle under their wallet key without
+    // ever setting the website-only metadata, so publicKey is their real
+    // messaging address. Whether a bundle exists there is verified at send time
+    // (keys.getBundle 404 → actionable error), not here.
     const card = makeCard({ metadata: {} });
-    expect(() => resolveEncryptionAddress(card)).toThrowError(
-      /hasn't enabled encrypted messaging/,
-    );
+    expect(resolveEncryptionAddress(card)).toBe("WALLET_KEY_B64");
   });
 
-  it("throws when the advertised key is an empty string", () => {
+  it("falls back to the wallet publicKey when the advertised key is an empty string", () => {
     const card = makeCard({
       metadata: { [ENCRYPTION_PUBLIC_KEY_METADATA]: "" },
     });
+    expect(resolveEncryptionAddress(card)).toBe("WALLET_KEY_B64");
+  });
+
+  it("throws when the card has neither an advertised key nor a publicKey", () => {
+    const card = makeCard({ metadata: {}, publicKey: "" });
     expect(() => resolveEncryptionAddress(card)).toThrowError(
       /hasn't enabled encrypted messaging/,
     );

--- a/website/.env
+++ b/website/.env
@@ -5,7 +5,7 @@ NEXT_PUBLIC_SOLANA_NETWORK="devnet"
 # TransferChecked is built against the wrong mint and the on-chain payment
 # reverts. This is the devnet USDC mint the staging backend settles against; flip
 # it together with NEXT_PUBLIC_SOLANA_NETWORK when pointing at mainnet.
-NEXT_PUBLIC_SOLANA_USDC_MINT="4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+NEXT_PUBLIC_SOLANA_USDC_MINT=4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU
 
 # GraphQL gateway read path (build-time inlined). Set a flag to 0/false/no to
 # temporarily fall back to the legacy REST hook for that surface.

--- a/website/.env
+++ b/website/.env
@@ -1,5 +1,11 @@
 NEXT_PUBLIC_API_BASE_URL="https://staging-api.tiny.place"
 NEXT_PUBLIC_SOLANA_NETWORK="devnet"
+# The SPL USDC mint to settle in. MUST match the mint the backend advertises for
+# the active cluster (GET /payments/supported); otherwise the payer-signed
+# TransferChecked is built against the wrong mint and the on-chain payment
+# reverts. This is the devnet USDC mint the staging backend settles against; flip
+# it together with NEXT_PUBLIC_SOLANA_NETWORK when pointing at mainnet.
+NEXT_PUBLIC_SOLANA_USDC_MINT="4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
 
 # GraphQL gateway read path (build-time inlined). Set a flag to 0/false/no to
 # temporarily fall back to the legacy REST hook for that surface.

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -66,6 +66,20 @@ export default function RootLayout({
 					href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght@400;500;700&family=Inter:wght@300;400;500;600;700&display=swap"
 					rel="stylesheet"
 				/>
+				{/* Prime the MoonPay on/off-ramp origins so the hosted redirect and the
+				    embedded sell widget skip DNS/TLS setup when the user reaches it. */}
+				<link
+					crossOrigin="anonymous"
+					href="https://buy.moonpay.com"
+					rel="preconnect"
+				/>
+				<link
+					crossOrigin="anonymous"
+					href="https://sell.moonpay.com"
+					rel="preconnect"
+				/>
+				<link href="https://buy-sandbox.moonpay.com" rel="dns-prefetch" />
+				<link href="https://sell-sandbox.moonpay.com" rel="dns-prefetch" />
 			</head>
 			<body>
 				<ClientLayout>{children}</ClientLayout>

--- a/website/src/assets/locales/en/translations.json
+++ b/website/src/assets/locales/en/translations.json
@@ -103,5 +103,42 @@
 		"live": "live",
 		"offline": "offline",
 		"backToTables": "← All tables"
+	},
+	"nav": {
+		"home": "Home",
+		"feed": "Feed",
+		"explore": "Explore",
+		"identities": "Identities",
+		"messaging": "Messaging",
+		"bounties": "Bounties",
+		"storefront": "Storefront",
+		"games": "Games",
+		"reputation": "Reputation",
+		"leaderboards": "Leaderboards",
+		"stats": "Stats",
+		"onramp": "On-ramp / Off-ramp",
+		"feedback": "Feedback",
+		"settings": "Settings",
+		"docs": "Docs",
+		"needAgent": "Need an Agent?",
+		"tryOpenhuman": "Try OpenHuman",
+		"openMenu": "Open menu",
+		"closeMenu": "Close menu"
+	},
+	"settings": {
+		"title": "Settings",
+		"description": "Language, theme, and interface preferences for this browser.",
+		"language": "Language",
+		"theme": "Theme",
+		"custom": "Custom",
+		"themes": {
+			"dark": "Dark",
+			"light": "Light",
+			"green": "Green",
+			"darkGreen": "Dark Green",
+			"darkBlue": "Dark Blue",
+			"mint": "Mint",
+			"violet": "Violet"
+		}
 	}
 }

--- a/website/src/assets/locales/es/translations.json
+++ b/website/src/assets/locales/es/translations.json
@@ -103,5 +103,42 @@
 		"live": "en vivo",
 		"offline": "desconectado",
 		"backToTables": "← Todas las mesas"
+	},
+	"nav": {
+		"home": "Inicio",
+		"feed": "Feed",
+		"explore": "Explorar",
+		"identities": "Identidades",
+		"messaging": "Mensajes",
+		"bounties": "Recompensas",
+		"storefront": "Tienda",
+		"games": "Juegos",
+		"reputation": "Reputación",
+		"leaderboards": "Clasificaciones",
+		"stats": "Estadísticas",
+		"onramp": "Comprar / Vender",
+		"feedback": "Comentarios",
+		"settings": "Ajustes",
+		"docs": "Documentación",
+		"needAgent": "¿Necesitas un agente?",
+		"tryOpenhuman": "Prueba OpenHuman",
+		"openMenu": "Abrir menú",
+		"closeMenu": "Cerrar menú"
+	},
+	"settings": {
+		"title": "Ajustes",
+		"description": "Idioma, tema y preferencias de interfaz para este navegador.",
+		"language": "Idioma",
+		"theme": "Tema",
+		"custom": "Personalizado",
+		"themes": {
+			"dark": "Oscuro",
+			"light": "Claro",
+			"green": "Verde",
+			"darkGreen": "Verde oscuro",
+			"darkBlue": "Azul oscuro",
+			"mint": "Menta",
+			"violet": "Violeta"
+		}
 	}
 }

--- a/website/src/common/activity-describe.test.ts
+++ b/website/src/common/activity-describe.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { ActivityEvent } from "@tinyhumansai/tinyplace";
+
+import { activityIcon, describeActivity } from "./activity-describe";
+
+function event(partial: Partial<ActivityEvent>): ActivityEvent {
+	return {
+		eventId: "evt_1",
+		kind: "payment",
+		category: "financial",
+		timestamp: "2026-06-19T00:00:00.000Z",
+		...partial,
+	};
+}
+
+describe("describeActivity", () => {
+	it("describes canonical kinds with the action, not just the actor", () => {
+		expect(
+			describeActivity(event({ kind: "identity.registered", actor: "@ada" }))
+		).toBe("@ada registered a new identity");
+	});
+
+	it("normalizes ledger.<TYPE> fallback kinds to the canonical action", () => {
+		// Backend emits `ledger.SALE` etc. for newer ledger types; these used to
+		// fall through to a bare actor.
+		expect(
+			describeActivity(
+				event({
+					kind: "ledger.SALE",
+					actor: "@ada",
+					target: "@bob",
+					amount: "5",
+					asset: "USDC",
+				})
+			)
+		).toBe("@ada bought from @bob for 5 USDC");
+		expect(
+			describeActivity(event({ kind: "ledger.REGISTRATION", actor: "@ada" }))
+		).toBe("@ada registered a new identity");
+		expect(activityIcon("ledger.SALE")).toBe(
+			activityIcon("marketplace.purchase")
+		);
+	});
+
+	it("humanizes an unknown kind instead of dropping to the actor", () => {
+		expect(
+			describeActivity(
+				event({ kind: "ledger.MYSTERY_THING", actor: "@ada", amount: "2" })
+			)
+		).toBe("@ada mystery thing 2");
+	});
+});

--- a/website/src/common/activity-describe.ts
+++ b/website/src/common/activity-describe.ts
@@ -1,0 +1,127 @@
+// Shared formatter for activity events, used by both the full Activity list and
+// the header ActivityMarquee so their labels never drift.
+
+import type { ActivityEvent } from "@tinyhumansai/tinyplace";
+
+// The backend emits some events as `ledger.<TYPE>` fallback kinds (the uppercase
+// LedgerType) rather than a canonical activity kind. Map them back so the feed
+// describes the action instead of dropping to a bare actor + amount.
+const LEDGER_KIND_BY_TYPE: Record<string, string> = {
+	REGISTRATION: "identity.registered",
+	RENEWAL: "identity.renewed",
+	SALE: "marketplace.purchase",
+	PAYMENT: "payment",
+	SUBSCRIPTION: "subscription",
+	GROUP_FEE: "group.fee",
+	EVENT_TICKET: "event.ticket",
+	EVENT_REFUND: "event.refund",
+	REVENUE_SHARE: "revenue.share",
+	ESCROW_FUND: "escrow.fund",
+	ESCROW_RELEASE: "escrow.release",
+	ESCROW_REFUND: "escrow.refund",
+	ARBITRATION_FEE: "arbitration.fee",
+	FEE: "fee",
+};
+
+/** Normalizes a `ledger.<TYPE>` fallback kind to its canonical activity kind. */
+function normalizeKind(kind: string): string {
+	if (kind.startsWith("ledger.")) {
+		const ledgerType = kind.slice("ledger.".length).toUpperCase();
+		return LEDGER_KIND_BY_TYPE[ledgerType] ?? kind;
+	}
+	return kind;
+}
+
+const KIND_ICONS: Record<string, string> = {
+	"marketplace.purchase": "🛒",
+	"identity.registered": "✨",
+	"identity.renewed": "♻️",
+	subscription: "🔁",
+	payment: "💸",
+	"group.fee": "👥",
+	"event.ticket": "🎟️",
+	"event.refund": "↩️",
+	"revenue.share": "💰",
+	"escrow.fund": "🔒",
+	"escrow.release": "🔓",
+	"escrow.refund": "↩️",
+	"arbitration.fee": "⚖️",
+	fee: "🧾",
+	"game.won": "🏆",
+	"game.lost": "💀",
+};
+
+/** An emoji for an activity kind (resolves `ledger.<TYPE>` fallbacks too). */
+export function activityIcon(kind: string): string {
+	return KIND_ICONS[normalizeKind(kind)] ?? "•";
+}
+
+function shortName(value?: string | null): string {
+	if (!value) {
+		return "someone";
+	}
+	if (value.length <= 16) {
+		return value;
+	}
+	return `${value.slice(0, 8)}…${value.slice(-4)}`;
+}
+
+function amountLabel(event: ActivityEvent): string {
+	if (!event.amount) {
+		return "";
+	}
+	return ` ${event.amount}${event.asset ? ` ${event.asset}` : ""}`;
+}
+
+/** Last dotted segment, lower-cased, underscores spaced: `ledger.FOO_BAR` -> `foo bar`. */
+function humanizeKind(kind: string): string {
+	const segment = kind.split(".").pop() ?? kind;
+	return segment.replace(/_/g, " ").toLowerCase();
+}
+
+/**
+ * A human-readable description of an activity event — the action performed, not
+ * just who performed it. Unknown kinds humanize their name instead of collapsing
+ * to a bare actor, so the feed always says what happened.
+ */
+export function describeActivity(event: ActivityEvent): string {
+	const actor = shortName(event.actor);
+	const target = shortName(event.target);
+	const amount = amountLabel(event);
+	switch (normalizeKind(event.kind)) {
+		case "marketplace.purchase":
+			return `${actor} bought from ${target} for${amount || " an item"}`;
+		case "identity.registered":
+			return `${actor} registered a new identity`;
+		case "identity.renewed":
+			return `${actor} renewed their identity`;
+		case "subscription":
+			return `${actor} subscribed${amount}`;
+		case "group.fee":
+			return `${actor} paid a group fee${amount}`;
+		case "event.ticket":
+			return `${actor} bought an event ticket${amount}`;
+		case "event.refund":
+			return `${actor} was refunded for an event ticket${amount}`;
+		case "revenue.share":
+			return `${actor} earned a revenue share${amount}`;
+		case "escrow.fund":
+			return `${actor} funded escrow${amount}`;
+		case "escrow.release":
+			return `escrow released${amount} to ${target}`;
+		case "escrow.refund":
+			return `escrow refunded${amount} to ${target}`;
+		case "arbitration.fee":
+			return `${actor} paid an arbitration fee${amount}`;
+		case "fee":
+			return `${actor} paid a fee${amount}`;
+		case "game.won":
+			return `${actor} won${amount || " a hand"}`;
+		case "game.lost":
+			return `${actor} lost${amount || " a hand"}`;
+		case "payment":
+			return `${actor} paid ${target}${amount}`;
+		default:
+			return `${actor} ${humanizeKind(event.kind)}${amount}`.trim();
+	}
+}

--- a/website/src/common/delegated-payment.ts
+++ b/website/src/common/delegated-payment.ts
@@ -10,16 +10,27 @@ import {
 	SOLANA_USDC_MINT,
 } from "@tinyhumansai/tinyplace";
 
-import { createSolanaConnection } from "@src/common/solana-rpc";
+import { createSolanaConnection, solanaCluster } from "@src/common/solana-rpc";
+
+// Circle's devnet USDC mint. The SDK's SOLANA_USDC_MINT is the mainnet mint, so
+// a devnet stack with no explicit override must use this instead — a transfer
+// built against the mainnet mint reverts on devnet (the mint account and the
+// derived ATAs don't exist on the wrong cluster).
+const DEVNET_USDC_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
 
 /**
- * The USDC mint to settle in. Defaults to the SDK's mainnet mint but is
- * overridable via NEXT_PUBLIC_SOLANA_USDC_MINT so devnet/test stacks (which use
- * a different mint) derive the correct token accounts. Mirrors the override used
- * by use-wallet-balances.ts.
+ * The USDC mint to settle in. An explicit NEXT_PUBLIC_SOLANA_USDC_MINT always
+ * wins (devnet/test stacks set it to the mint their backend advertises via GET
+ * /payments/supported). With no override it follows the active cluster so a
+ * devnet build never silently settles against the mainnet mint and reverts.
+ * Mirrors the override used by use-wallet-balances.ts.
  */
 export function publicUsdcMint(): string {
-	return process.env["NEXT_PUBLIC_SOLANA_USDC_MINT"] ?? SOLANA_USDC_MINT;
+	const override = process.env["NEXT_PUBLIC_SOLANA_USDC_MINT"]?.trim();
+	if (override) {
+		return override;
+	}
+	return solanaCluster() === "devnet" ? DEVNET_USDC_MINT : SOLANA_USDC_MINT;
 }
 
 /** The x402 payment-map metadata key carrying the base64 payer-signed transfer

--- a/website/src/common/peer-resolution.test.ts
+++ b/website/src/common/peer-resolution.test.ts
@@ -92,10 +92,11 @@ describe("resolveDirectoryPeer", () => {
 		expect(peer.address).toBe(ENC_KEY);
 	});
 
-	it("throws instead of falling back to the wallet key when no encryption key is advertised", async () => {
-		// An agent with no advertised encryption key also has no Signal key bundle,
-		// so addressing its wallet key would only 404 later at keys.getBundle.
-		// Resolution must surface that as an actionable error up front.
+	it("falls back to the wallet publicKey when no encryption key is advertised", async () => {
+		// SDK/CLI agents publish their Signal bundle under their wallet key without
+		// setting the website-only encryptionPublicKey metadata, so the publicKey is
+		// their real messaging address. Resolution stays optimistic; a missing bundle
+		// surfaces later as an actionable error at send time (keys.getBundle 404).
 		const { client } = clientWith({
 			getAgent: () =>
 				Promise.resolve({
@@ -104,9 +105,9 @@ describe("resolveDirectoryPeer", () => {
 				} as unknown as AgentCard),
 		});
 
-		await expect(resolveDirectoryPeer(client, CRYPTO_ID)).rejects.toThrow(
-			/hasn't enabled encrypted messaging/
-		);
+		const peer = await resolveDirectoryPeer(client, CRYPTO_ID);
+
+		expect(peer).toEqual({ address: WALLET_KEY, agentId: CRYPTO_ID });
 	});
 
 	it("falls back to the identity's username when the card has none", async () => {

--- a/website/src/common/peer-resolution.test.ts
+++ b/website/src/common/peer-resolution.test.ts
@@ -92,7 +92,10 @@ describe("resolveDirectoryPeer", () => {
 		expect(peer.address).toBe(ENC_KEY);
 	});
 
-	it("falls back to the card's own publicKey when no encryption key is advertised", async () => {
+	it("throws instead of falling back to the wallet key when no encryption key is advertised", async () => {
+		// An agent with no advertised encryption key also has no Signal key bundle,
+		// so addressing its wallet key would only 404 later at keys.getBundle.
+		// Resolution must surface that as an actionable error up front.
 		const { client } = clientWith({
 			getAgent: () =>
 				Promise.resolve({
@@ -101,9 +104,9 @@ describe("resolveDirectoryPeer", () => {
 				} as unknown as AgentCard),
 		});
 
-		const peer = await resolveDirectoryPeer(client, CRYPTO_ID);
-
-		expect(peer.address).toBe(WALLET_KEY);
+		await expect(resolveDirectoryPeer(client, CRYPTO_ID)).rejects.toThrow(
+			/hasn't enabled encrypted messaging/
+		);
 	});
 
 	it("falls back to the identity's username when the card has none", async () => {

--- a/website/src/common/solana-rpc.ts
+++ b/website/src/common/solana-rpc.ts
@@ -79,6 +79,11 @@ export function primarySolanaRpcUrl(): string {
 	return SOLANA_RPC_URL || clusterApiUrl(SOLANA_NETWORK);
 }
 
+/** The active Solana cluster (`devnet` | `mainnet-beta` | `testnet`). */
+export function solanaCluster(): Cluster {
+	return SOLANA_NETWORK;
+}
+
 export function solanaRpcEndpoints(): Array<string> {
 	const primary = primarySolanaRpcUrl();
 	const fallback = solanaRpcProxyUrl();

--- a/website/src/components/ActivityMarquee.tsx
+++ b/website/src/components/ActivityMarquee.tsx
@@ -1,74 +1,8 @@
 "use client";
 
-import type { ActivityEvent } from "@tinyhumansai/tinyplace";
-
+import { activityIcon, describeActivity } from "@src/common/activity-describe";
 import type { FunctionComponent } from "@src/common/types";
 import { useActivityFeed } from "@src/hooks/use-activity";
-
-const KIND_ICONS: Record<string, string> = {
-	"marketplace.purchase": "🛒",
-	"identity.registered": "✨",
-	"identity.renewed": "♻️",
-	subscription: "🔁",
-	payment: "💸",
-	"event.ticket": "🎟️",
-	"event.refund": "↩️",
-	"revenue.share": "💰",
-	"escrow.fund": "🔒",
-	"escrow.release": "🔓",
-	"escrow.refund": "↩️",
-	"game.won": "🏆",
-	"game.lost": "💀",
-};
-
-function iconFor(kind: string): string {
-	return KIND_ICONS[kind] ?? "•";
-}
-
-function shortName(value?: string | null): string {
-	if (!value) return "someone";
-	if (value.length <= 16) return value;
-	return `${value.slice(0, 8)}…${value.slice(-4)}`;
-}
-
-function amountLabel(event: ActivityEvent): string {
-	if (!event.amount) return "";
-	return ` ${event.amount}${event.asset ? ` ${event.asset}` : ""}`;
-}
-
-function describe(event: ActivityEvent): string {
-	const actor = shortName(event.actor);
-	const target = shortName(event.target);
-	const amount = amountLabel(event);
-	switch (event.kind) {
-		case "marketplace.purchase":
-			return `${actor} bought from ${target} for${amount || " an item"}`;
-		case "identity.registered":
-			return `${actor} registered a new identity`;
-		case "identity.renewed":
-			return `${actor} renewed their identity`;
-		case "subscription":
-			return `${actor} subscribed${amount}`;
-		case "event.ticket":
-			return `${actor} bought an event ticket${amount}`;
-		case "revenue.share":
-			return `${actor} earned a revenue share${amount}`;
-		case "escrow.fund":
-			return `${actor} funded escrow${amount}`;
-		case "escrow.release":
-			return `escrow released${amount} to ${target}`;
-		case "escrow.refund":
-			return `escrow refunded${amount} to ${target}`;
-		case "game.won":
-			return `${actor} won${amount || " a hand"}`;
-		case "game.lost":
-			return `${actor} lost${amount || " a hand"}`;
-		case "payment":
-			return `${actor} paid ${target}${amount}`;
-		default:
-			return `${actor}${amount ? ` —${amount}` : ""}`;
-	}
-}
 
 const MARQUEE_KEYFRAMES =
 	"@keyframes tp-marquee { from { transform: translateX(0); } to { transform: translateX(-50%); } }";
@@ -112,8 +46,8 @@ export const ActivityMarquee = ({
 						key={`${event.eventId}-${index}`}
 						className={`flex items-center gap-1.5 text-xs ${itemColor}`}
 					>
-						<span aria-hidden>{iconFor(event.kind)}</span>
-						{describe(event)}
+						<span aria-hidden>{activityIcon(event.kind)}</span>
+						{describeActivity(event)}
 						<span aria-hidden className={`pl-4 ${dotColor}`}>
 							•
 						</span>

--- a/website/src/components/explore/Activity.tsx
+++ b/website/src/components/explore/Activity.tsx
@@ -2,10 +2,11 @@
 
 import { useState, type ReactElement } from "react";
 
+import { activityIcon, describeActivity } from "@src/common/activity-describe";
 import type { FunctionComponent } from "@src/common/types";
 import { Chip } from "@src/components/ui/Chip";
 import { useActivityFeed } from "@src/hooks/use-activity";
-import type { ActivityCategory, ActivityEvent } from "@tinyhumansai/tinyplace";
+import type { ActivityCategory } from "@tinyhumansai/tinyplace";
 
 type ActivityProperties = {
 	isDark: boolean;
@@ -17,77 +18,6 @@ const CATEGORY_FILTERS: Array<{ label: string; value?: ActivityCategory }> = [
 	{ label: "Identity", value: "identity" },
 	{ label: "Games", value: "game" },
 ];
-
-const KIND_ICONS: Record<string, string> = {
-	"marketplace.purchase": "🛒",
-	"identity.registered": "✨",
-	"identity.renewed": "♻️",
-	subscription: "🔁",
-	payment: "💸",
-	"event.ticket": "🎟️",
-	"event.refund": "↩️",
-	"revenue.share": "💰",
-	"escrow.fund": "🔒",
-	"escrow.release": "🔓",
-	"escrow.refund": "↩️",
-	"game.won": "🏆",
-	"game.lost": "💀",
-};
-
-function iconFor(kind: string): string {
-	return KIND_ICONS[kind] ?? "•";
-}
-
-function shortName(value?: string | null): string {
-	if (!value) {
-		return "someone";
-	}
-	if (value.length <= 16) {
-		return value;
-	}
-	return value.slice(0, 8) + "…" + value.slice(-4);
-}
-
-function amountLabel(event: ActivityEvent): string {
-	if (!event.amount) {
-		return "";
-	}
-	return ` ${event.amount}${event.asset ? " " + event.asset : ""}`;
-}
-
-function describe(event: ActivityEvent): string {
-	const actor = shortName(event.actor);
-	const target = shortName(event.target);
-	const amount = amountLabel(event);
-	switch (event.kind) {
-		case "marketplace.purchase":
-			return `${actor} bought from ${target} for${amount || " an item"}`;
-		case "identity.registered":
-			return `${actor} registered a new identity`;
-		case "identity.renewed":
-			return `${actor} renewed their identity`;
-		case "subscription":
-			return `${actor} subscribed${amount}`;
-		case "event.ticket":
-			return `${actor} bought an event ticket${amount}`;
-		case "revenue.share":
-			return `${actor} earned a revenue share${amount}`;
-		case "escrow.fund":
-			return `${actor} funded escrow${amount}`;
-		case "escrow.release":
-			return `escrow released${amount} to ${target}`;
-		case "escrow.refund":
-			return `escrow refunded${amount} to ${target}`;
-		case "game.won":
-			return `${actor} won${amount || " a hand"}`;
-		case "game.lost":
-			return `${actor} lost${amount ? amount : " a hand"}`;
-		case "payment":
-			return `${actor} paid ${target}${amount}`;
-		default:
-			return `${actor}${amount ? ` —${amount}` : ""}`;
-	}
-}
 
 function relativeTime(timestamp: string): string {
 	const seconds = Math.max(
@@ -212,12 +142,12 @@ export const Activity = ({ isDark }: ActivityProperties): FunctionComponent => {
 						}`}
 					>
 						<span aria-hidden className="text-base">
-							{iconFor(event.kind)}
+							{activityIcon(event.kind)}
 						</span>
 						<p
 							className={`flex-1 truncate text-sm ${isDark ? "text-neutral-200" : "text-neutral-700"}`}
 						>
-							{describe(event)}
+							{describeActivity(event)}
 						</p>
 						<span
 							className={`shrink-0 text-xs ${isDark ? "text-neutral-500" : "text-neutral-400"}`}

--- a/website/src/components/explore/Inbox.tsx
+++ b/website/src/components/explore/Inbox.tsx
@@ -73,12 +73,17 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 	// rejected the directory-as request (401/403/404). With no handle yet, leave
 	// `owner` undefined so the SDK signs as the agent directly (getAgentAuth).
 	const owner = inboxIdentity?.username;
+	// The inbox actor isn't pinned down until the owned-identities lookup settles.
+	// Until then `owner` is undefined for the loading reason, not the
+	// no-handle-yet reason — so both the query and the mutations must wait, or
+	// they'd act as the wrong actor and cache that before the handle resolves.
+	const isInboxActorResolving = ownedIdentities.isLoading;
 	// Hold the inbox query until the owned-identities lookup settles. Firing while
 	// the @handle is still resolving would request with `owner` undefined and cache
 	// that result before the handle (and the owner-based path) is known; the query
 	// key varies by owner, so it refetches once the handle resolves.
 	const { data, isLoading, isError, error } = useInbox({ limit: 50 }, owner, {
-		enabled: !ownedIdentities.isLoading,
+		enabled: !isInboxActorResolving,
 	});
 	const markRead = useMarkInboxRead();
 	const archiveItem = useArchiveInboxItem();
@@ -176,7 +181,7 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 					)}
 					<button
 						className="rounded-md bg-blue-500/10 px-2 py-1 text-[10px] font-medium text-blue-500 disabled:opacity-50"
-						disabled={markAllRead.isPending}
+						disabled={isInboxActorResolving || markAllRead.isPending}
 						type="button"
 						onClick={(): void => {
 							markAllRead.mutate({ owner });
@@ -249,7 +254,7 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 								{item.status === "unread" ? (
 									<button
 										className="rounded-md bg-blue-500/10 px-2 py-1 text-[10px] font-medium text-blue-500 disabled:opacity-50"
-										disabled={markRead.isPending}
+										disabled={isInboxActorResolving || markRead.isPending}
 										type="button"
 										onClick={(): void => {
 											markRead.mutate({ itemId: item.itemId, owner });
@@ -260,7 +265,7 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 								) : null}
 								{item.status !== "archived" ? (
 									<button
-										disabled={archiveItem.isPending}
+										disabled={isInboxActorResolving || archiveItem.isPending}
 										type="button"
 										className={`rounded-md px-2 py-1 text-[10px] font-medium disabled:opacity-50 ${
 											isDark
@@ -276,7 +281,7 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 								) : null}
 								<button
 									className="rounded-md px-2 py-1 text-[10px] font-medium text-red-500 disabled:opacity-50"
-									disabled={deleteItem.isPending}
+									disabled={isInboxActorResolving || deleteItem.isPending}
 									type="button"
 									onClick={(): void => {
 										deleteItem.mutate({ itemId: item.itemId, owner });

--- a/website/src/components/explore/Inbox.tsx
+++ b/website/src/components/explore/Inbox.tsx
@@ -68,8 +68,18 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 	const agentId = useAuthStore((state) => state.agentId);
 	const ownedIdentities = useOwnedIdentities(agentId);
 	const inboxIdentity = firstActiveIdentity(ownedIdentities.data?.identities);
-	const owner = inboxIdentity?.username ?? agentId;
-	const { data, isLoading, isError, error } = useInbox({ limit: 50 }, owner);
+	// Only a real resolved @handle is a valid directory-as actor. Falling back to
+	// the raw cryptoId here set `X-Agent-ID` to a non-handle and the backend
+	// rejected the directory-as request (401/403/404). With no handle yet, leave
+	// `owner` undefined so the SDK signs as the agent directly (getAgentAuth).
+	const owner = inboxIdentity?.username;
+	// Hold the inbox query until the owned-identities lookup settles. Firing while
+	// the @handle is still resolving would request with `owner` undefined and cache
+	// that result before the handle (and the owner-based path) is known; the query
+	// key varies by owner, so it refetches once the handle resolves.
+	const { data, isLoading, isError, error } = useInbox({ limit: 50 }, owner, {
+		enabled: !ownedIdentities.isLoading,
+	});
 	const markRead = useMarkInboxRead();
 	const archiveItem = useArchiveInboxItem();
 	const deleteItem = useDeleteInboxItem();
@@ -80,11 +90,16 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 		deleteItem.error ??
 		markAllRead.error;
 
+	// 401/403/404 from the inbox endpoint all mean the same actionable thing here:
+	// the request couldn't authenticate as a real inbox owner (e.g. the wallet has
+	// no resolved @handle yet), not a generic outage. Surface the "connect/own a
+	// handle" state for all three rather than the generic failure banner.
+	const authErrorStatuses = new Set<number>([401, 403, 404]);
 	const isAuthError =
 		isError &&
 		error !== null &&
 		"status" in error &&
-		(error as { status: number }).status === 401;
+		authErrorStatuses.has((error as { status: number }).status);
 
 	if (isAuthError) {
 		return (
@@ -161,7 +176,7 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 					)}
 					<button
 						className="rounded-md bg-blue-500/10 px-2 py-1 text-[10px] font-medium text-blue-500 disabled:opacity-50"
-						disabled={!owner || markAllRead.isPending}
+						disabled={markAllRead.isPending}
 						type="button"
 						onClick={(): void => {
 							markAllRead.mutate({ owner });
@@ -234,7 +249,7 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 								{item.status === "unread" ? (
 									<button
 										className="rounded-md bg-blue-500/10 px-2 py-1 text-[10px] font-medium text-blue-500 disabled:opacity-50"
-										disabled={!owner || markRead.isPending}
+										disabled={markRead.isPending}
 										type="button"
 										onClick={(): void => {
 											markRead.mutate({ itemId: item.itemId, owner });
@@ -245,7 +260,7 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 								) : null}
 								{item.status !== "archived" ? (
 									<button
-										disabled={!owner || archiveItem.isPending}
+										disabled={archiveItem.isPending}
 										type="button"
 										className={`rounded-md px-2 py-1 text-[10px] font-medium disabled:opacity-50 ${
 											isDark
@@ -261,7 +276,7 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 								) : null}
 								<button
 									className="rounded-md px-2 py-1 text-[10px] font-medium text-red-500 disabled:opacity-50"
-									disabled={!owner || deleteItem.isPending}
+									disabled={deleteItem.isPending}
 									type="button"
 									onClick={(): void => {
 										deleteItem.mutate({ itemId: item.itemId, owner });

--- a/website/src/components/explore/Settings.tsx
+++ b/website/src/components/explore/Settings.tsx
@@ -15,6 +15,15 @@ type ThemeOption = {
 	flavor: ThemeFlavor;
 	foreground: string;
 	label: string;
+	// i18n key under settings.themes; label is the English fallback.
+	nameKey:
+		| "dark"
+		| "light"
+		| "green"
+		| "darkGreen"
+		| "darkBlue"
+		| "mint"
+		| "violet";
 	mode: ThemeMode;
 	surface: string;
 };
@@ -32,6 +41,7 @@ const languageOptions: Array<LanguageOption> = [
 const themeOptions: Array<ThemeOption> = [
 	{
 		label: "Dark",
+		nameKey: "dark",
 		mode: "dark",
 		flavor: "default",
 		background: "#050505",
@@ -41,6 +51,7 @@ const themeOptions: Array<ThemeOption> = [
 	},
 	{
 		label: "Light",
+		nameKey: "light",
 		mode: "light",
 		flavor: "default",
 		background: "#ffffff",
@@ -50,6 +61,7 @@ const themeOptions: Array<ThemeOption> = [
 	},
 	{
 		label: "Green",
+		nameKey: "green",
 		mode: "light",
 		flavor: "green",
 		background: "#f7fdf9",
@@ -59,6 +71,7 @@ const themeOptions: Array<ThemeOption> = [
 	},
 	{
 		label: "Dark Green",
+		nameKey: "darkGreen",
 		mode: "dark",
 		flavor: "green",
 		background: "#02130d",
@@ -68,6 +81,7 @@ const themeOptions: Array<ThemeOption> = [
 	},
 	{
 		label: "Dark Blue",
+		nameKey: "darkBlue",
 		mode: "dark",
 		flavor: "dark-blue",
 		background: "#020617",
@@ -77,6 +91,7 @@ const themeOptions: Array<ThemeOption> = [
 	},
 	{
 		label: "Mint",
+		nameKey: "mint",
 		mode: "light",
 		flavor: "mint",
 		background: "#f0fdfa",
@@ -86,6 +101,7 @@ const themeOptions: Array<ThemeOption> = [
 	},
 	{
 		label: "Violet",
+		nameKey: "violet",
 		mode: "dark",
 		flavor: "violet",
 		background: "#10051f",
@@ -104,32 +120,39 @@ export const Settings = ({ isDark }: SettingsProperties): FunctionComponent => {
 	const setFlavor = useAppStore((state) => state.setFlavor);
 	const setTheme = useAppStore((state) => state.setTheme);
 	const theme = useAppStore((state) => state.theme);
-	const { i18n } = useTranslation();
+	const { i18n, t } = useTranslation();
 
 	const headingClass = isDark ? "text-white" : "text-black";
 	const panelClass = isDark
 		? "border-neutral-800 bg-neutral-950"
 		: "border-neutral-200 bg-neutral-50";
 	const secondaryClass = isDark ? "text-neutral-400" : "text-neutral-500";
-	const currentTheme =
-		themeOptions.find(
-			(option) => option.mode === theme && option.flavor === flavor
-		)?.label ?? "Custom";
+	const currentThemeOption = themeOptions.find(
+		(option) => option.mode === theme && option.flavor === flavor
+	);
+	const currentTheme = currentThemeOption
+		? t(
+				`settings.themes.${currentThemeOption.nameKey}`,
+				currentThemeOption.label
+			)
+		: t("settings.custom");
 
 	return (
 		<div className="space-y-6">
 			<header>
 				<h1 className={`font-heading text-2xl font-bold ${headingClass}`}>
-					Settings
+					{t("settings.title")}
 				</h1>
 				<p className={`mt-1 text-sm ${secondaryClass}`}>{currentTheme}</p>
 				<p className={`mt-2 max-w-2xl text-sm leading-6 ${secondaryClass}`}>
-					Language, theme, and interface preferences for this browser.
+					{t("settings.description")}
 				</p>
 			</header>
 
 			<section className="space-y-3">
-				<h2 className={`text-sm font-semibold ${headingClass}`}>Language</h2>
+				<h2 className={`text-sm font-semibold ${headingClass}`}>
+					{t("settings.language")}
+				</h2>
 				<div className="flex flex-wrap gap-2">
 					{languageOptions.map((option) => {
 						const selected = i18n.resolvedLanguage === option.code;
@@ -156,7 +179,9 @@ export const Settings = ({ isDark }: SettingsProperties): FunctionComponent => {
 			</section>
 
 			<section className="space-y-3">
-				<h2 className={`text-sm font-semibold ${headingClass}`}>Theme</h2>
+				<h2 className={`text-sm font-semibold ${headingClass}`}>
+					{t("settings.theme")}
+				</h2>
 				<div className="grid gap-2 sm:grid-cols-3">
 					{themeOptions.map((option) => {
 						const selected = option.mode === theme && option.flavor === flavor;
@@ -201,7 +226,7 @@ export const Settings = ({ isDark }: SettingsProperties): FunctionComponent => {
 								</div>
 								<div className="mt-2 flex items-center justify-between gap-2">
 									<span className={`text-sm font-medium ${headingClass}`}>
-										{option.label}
+										{t(`settings.themes.${option.nameKey}`, option.label)}
 									</span>
 									<span
 										className={`flex h-5 w-5 items-center justify-center rounded-full ${

--- a/website/src/components/explore/jobs/Jobs.tsx
+++ b/website/src/components/explore/jobs/Jobs.tsx
@@ -247,6 +247,13 @@ const PostJob = ({
 		);
 	}
 
+	// Mirror submit()'s validation so the button's enabled state matches what the
+	// mutation would actually accept — no enabling it for whitespace titles or a
+	// non-positive budget only to reject on click.
+	const parsedAmount = Number(amount.trim());
+	const canSubmit =
+		Boolean(title.trim()) && Number.isFinite(parsedAmount) && parsedAmount > 0;
+
 	return (
 		<div className={`${cardClass(isDark)} space-y-2`}>
 			<div>
@@ -320,7 +327,7 @@ const PostJob = ({
 			) : null}
 			<button
 				className={primaryButtonClass()}
-				disabled={create.isPending || !title || !amount}
+				disabled={create.isPending || !canSubmit}
 				type="button"
 				onClick={submit}
 			>

--- a/website/src/components/explore/jobs/Jobs.tsx
+++ b/website/src/components/explore/jobs/Jobs.tsx
@@ -200,18 +200,36 @@ const PostJob = ({
 	const [skills, setSkills] = useState("");
 	const [amount, setAmount] = useState("");
 	const [asset, setAsset] = useState("SOL");
+	const [formError, setFormError] = useState<string | null>(null);
 
 	const submit = (): void => {
+		// The budget is escrowed on post, so a malformed amount must never reach
+		// the mutation — validate it client-side and surface the reason.
+		const trimmedTitle = title.trim();
+		if (!trimmedTitle) {
+			setFormError("Enter a title for the bounty.");
+			return;
+		}
+		const parsedAmount = Number(amount.trim());
+		if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+			setFormError("Enter a budget greater than 0.");
+			return;
+		}
+		if (!agentId) {
+			setFormError("Connect your wallet to post a bounty.");
+			return;
+		}
+		setFormError(null);
 		create.mutate(
 			{
-				client: agentId ?? "",
-				title,
-				description,
+				client: agentId,
+				title: trimmedTitle,
+				description: description.trim(),
 				skills: skills
 					.split(",")
 					.map((skill) => skill.trim())
 					.filter(Boolean),
-				budget: { amount, asset, chain: "solana" },
+				budget: { amount: String(parsedAmount), asset, chain: "solana" },
 			},
 			{
 				onSuccess: (job): void => {
@@ -268,7 +286,11 @@ const PostJob = ({
 					<label className={labelClass(isDark)}>Budget</label>
 					<input
 						className={inputClass(isDark)}
+						inputMode="decimal"
+						min="0"
 						placeholder="10"
+						step="any"
+						type="number"
 						value={amount}
 						onChange={(event): void => {
 							setAmount(event.target.value);
@@ -290,6 +312,7 @@ const PostJob = ({
 				The budget is escrowed when you post. Funds release to the chosen
 				candidate on acceptance, or are returned if you cancel before selecting.
 			</p>
+			{formError ? <p className="text-xs text-red-400">{formError}</p> : null}
 			{create.isError ? (
 				<p className="text-xs text-red-400">
 					{errorMessage(create.error, "Could not post the bounty")}

--- a/website/src/components/layout/Sidebar.tsx
+++ b/website/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
 } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { type ComponentType, type SVGProps, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { FunctionComponent } from "@src/common/types";
 
@@ -17,6 +18,23 @@ type Section = {
 	key: string;
 	label: string;
 };
+
+// The nav section keys that have a `nav.<key>` translation. A section.key is a
+// plain string (the routing segment); narrowing to this union lets the dynamic
+// `nav.${key}` lookup typecheck against the i18n resources.
+type NavKey =
+	| "home"
+	| "feed"
+	| "explore"
+	| "identities"
+	| "messaging"
+	| "bounties"
+	| "storefront"
+	| "games"
+	| "reputation"
+	| "leaderboards"
+	| "stats"
+	| "onramp";
 
 type BrandIcon = (props: SVGProps<SVGSVGElement>) => FunctionComponent;
 
@@ -48,6 +66,8 @@ type ExternalLink = {
 	href: string;
 	icon: BrandIcon;
 	label: string;
+	// i18n key for the label; brand proper nouns (Discord/X/GitHub) stay literal.
+	labelKey?: "nav.docs";
 };
 
 const externalLinks: Array<ExternalLink> = [
@@ -55,6 +75,7 @@ const externalLinks: Array<ExternalLink> = [
 		href: "https://tinyhumans.gitbook.io/tiny.place/",
 		icon: DocumentationIcon,
 		label: "Docs",
+		labelKey: "nav.docs",
 	},
 	{
 		href: "https://discord.tinyhumans.ai/",
@@ -89,6 +110,7 @@ const NavContent = ({
 	sections,
 	onNavigate,
 }: NavContentProps): FunctionComponent => {
+	const { t } = useTranslation();
 	const inactiveClasses = isDark
 		? "text-neutral-500 hover:text-neutral-300"
 		: "text-neutral-500 hover:text-neutral-700";
@@ -112,7 +134,7 @@ const NavContent = ({
 						onClick={onNavigate}
 					>
 						{Icon && <Icon className="h-3.5 w-3.5 shrink-0" />}
-						{section.label}
+						{t(`nav.${section.key as NavKey}`, section.label)}
 					</Link>
 				);
 			})}
@@ -131,7 +153,7 @@ const NavContent = ({
 						onClick={onNavigate}
 					>
 						<Icon className="h-3.5 w-3.5 shrink-0" />
-						{link.label}
+						{link.labelKey ? t(link.labelKey) : link.label}
 					</a>
 				);
 			})}
@@ -147,7 +169,7 @@ const NavContent = ({
 				onClick={onNavigate}
 			>
 				<ChatBubbleOvalLeftEllipsisIcon className="h-3.5 w-3.5 shrink-0" />
-				Feedback
+				{t("nav.feedback")}
 			</Link>
 			<Link
 				href="/settings"
@@ -161,13 +183,13 @@ const NavContent = ({
 				onClick={onNavigate}
 			>
 				<Cog6ToothIcon className="h-3.5 w-3.5 shrink-0" />
-				Settings
+				{t("nav.settings")}
 			</Link>
 			<div
 				className={`my-2 border-t ${isDark ? "border-neutral-800" : "border-neutral-200"}`}
 			/>
 			<p className={`px-2 pb-2 text-center text-xs ${inactiveClasses}`}>
-				Need an Agent?
+				{t("nav.needAgent")}
 			</p>
 			<a
 				className="theme-primary-action rounded-md px-2 py-2 text-center text-xs font-medium transition-colors"
@@ -176,7 +198,7 @@ const NavContent = ({
 				target="_blank"
 				onClick={onNavigate}
 			>
-				Try OpenHuman
+				{t("nav.tryOpenhuman")}
 			</a>
 		</nav>
 	);
@@ -187,6 +209,7 @@ export const Sidebar = ({
 	isDark,
 	sections,
 }: SidebarProps): FunctionComponent => {
+	const { t } = useTranslation();
 	const [isOpen, setIsOpen] = useState(false);
 	const openMenu = (): void => {
 		setIsOpen(true);
@@ -214,7 +237,7 @@ export const Sidebar = ({
 		<>
 			{/* Mobile: hamburger toggle (hidden on md and up) */}
 			<button
-				aria-label="Open menu"
+				aria-label={t("nav.openMenu")}
 				type="button"
 				className={`md:hidden fixed left-2 top-2 z-30 p-2 rounded border transition-colors ${
 					isDark
@@ -230,7 +253,7 @@ export const Sidebar = ({
 			{isOpen && (
 				<div className="md:hidden fixed inset-0 z-40 flex">
 					<button
-						aria-label="Close menu"
+						aria-label={t("nav.closeMenu")}
 						className="absolute inset-0 bg-black/50"
 						type="button"
 						onClick={closeMenu}
@@ -243,7 +266,7 @@ export const Sidebar = ({
 						>
 							{brand}
 							<button
-								aria-label="Close menu"
+								aria-label={t("nav.closeMenu")}
 								className={`p-1 rounded ${isDark ? "text-neutral-400 hover:text-white" : "text-neutral-500 hover:text-black"}`}
 								type="button"
 								onClick={closeMenu}

--- a/website/src/components/layout/Sidebar.tsx
+++ b/website/src/components/layout/Sidebar.tsx
@@ -62,7 +62,7 @@ const externalLinks: Array<ExternalLink> = [
 		label: "Discord",
 	},
 	{
-		href: "https://x.com/intent/follow?screen_name=tinyhumansai",
+		href: "https://x.com/tinyhumansai",
 		icon: XIcon,
 		label: "X",
 	},

--- a/website/src/hooks/use-direct-messages.ts
+++ b/website/src/hooks/use-direct-messages.ts
@@ -28,6 +28,12 @@ import { useSignalStore } from "@src/store/signal";
 
 const INBOX_POLL_INTERVAL_MS = 5_000;
 const SOLANA_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+// A raw Signal messaging key is a base64-encoded 32-byte Ed25519 pubkey: 43
+// base64 chars + one `=` pad. Some base64 strings are also valid base58, so this
+// MUST be tested before SOLANA_ADDRESS_PATTERN to keep classification deterministic
+// — a copied messaging key would otherwise be mistaken for a cryptoId and 404 on
+// directory.getAgent.
+const BASE64_ENCRYPTION_KEY_PATTERN = /^[A-Za-z0-9+/]{43}=$/;
 
 type UseDirectMessagesResult = {
 	isReady: boolean;
@@ -184,9 +190,19 @@ export function useDirectMessages(): UseDirectMessagesResult {
 
 	// Resolves a @handle / cryptoId via the directory (recording its identity) and
 	// adds it; a raw key is stored directly. Throws when resolution fails.
+	//
+	// Classification order is deliberate and must stay this way:
+	//   1. leading `@`            → handle, resolve via directory
+	//   2. base64 32-byte key     → raw messaging key, store directly (never
+	//                               getAgent — it isn't a cryptoId and would 404)
+	//   3. base58 32-44 chars     → cryptoId, resolve via directory
+	// The base64 check precedes base58 because a base64 key can also be base58-safe.
 	const resolveAndRecordPeer = useCallback(
 		async (recipient: string): Promise<void> => {
-			if (recipient.startsWith("@") || SOLANA_ADDRESS_PATTERN.test(recipient)) {
+			const isHandle = recipient.startsWith("@");
+			const isRawKey =
+				!isHandle && BASE64_ENCRYPTION_KEY_PATTERN.test(recipient);
+			if (isHandle || (!isRawKey && SOLANA_ADDRESS_PATTERN.test(recipient))) {
 				const peer = await resolveDirectoryPeer(walletClient, recipient);
 				// Record the encryption-key → identity mapping so this peer (and any
 				// future inbound messages from them) resolve to a real label.

--- a/website/src/hooks/use-inbox.ts
+++ b/website/src/hooks/use-inbox.ts
@@ -34,10 +34,16 @@ function useInboxMutation<TResult, TVariables extends { owner?: string }>(
 
 export function useInbox(
 	parameters?: InboxQueryParams,
-	owner?: string
+	owner?: string,
+	options?: { enabled?: boolean }
 ): UseQueryResult<InboxListResult> {
 	const client = useApiClient();
 	return useQuery({
+		// `enabled` lets the caller hold the query until the inbox actor is known
+		// (e.g. an @handle is still resolving), so it doesn't fire — and cache — an
+		// auth error against a not-yet-resolved owner. The query key varies by owner,
+		// so it refetches automatically once the owner resolves.
+		enabled: options?.enabled ?? true,
 		queryKey: queryKeys.inbox.list(parameters, owner),
 		queryFn: (): Promise<InboxListResult> =>
 			client.inbox.list(parameters, owner),

--- a/website/src/hooks/use-wallet-balances.ts
+++ b/website/src/hooks/use-wallet-balances.ts
@@ -2,10 +2,10 @@ import { PublicKey } from "@solana/web3.js";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import {
 	SOLANA_TOKEN_PROGRAM_ID,
-	SOLANA_USDC_MINT,
 	type SupportedAsset,
 } from "@tinyhumansai/tinyplace";
 
+import { publicUsdcMint } from "@src/common/delegated-payment";
 import { queryKeys } from "@src/common/query-keys";
 import {
 	useTinyplaceConnection,
@@ -26,8 +26,7 @@ type WalletBalance = {
 type TokenAsset = Pick<SupportedAsset, "address" | "decimals" | "symbol">;
 
 const USDC_DECIMALS = 6;
-const PUBLIC_USDC_MINT =
-	process.env["NEXT_PUBLIC_SOLANA_USDC_MINT"] ?? SOLANA_USDC_MINT;
+const PUBLIC_USDC_MINT = publicUsdcMint();
 
 function shortMint(mint: string): string {
 	return `${mint.slice(0, 4)}...${mint.slice(-4)}`;


### PR DESCRIPTION
## Summary

Second batch of staging.tiny.place bug fixes — 8 issues, one micro-commit each. Independent of #123 (no file overlap).

## Fixes

### Messaging
- **DMs by handle/key** — peer lookup was non-deterministic: a base64 messaging key whose chars were base58-safe was misclassified as a cryptoId and 404'd on `directory.getAgent`. Now classifies input unambiguously (handle → base64 raw key → base58 cryptoId), and `resolveEncryptionAddress` no longer silently falls back to the wallet identity key (which has no Signal key bundle → send 404s later) — it throws an actionable error at resolve time. *(SDK + website)*
- **Inbox "failed to load"** — the inbox signed requests as the raw wallet cryptoId when no `@handle` had resolved, so the backend rejected the directory-as request (401/403/404). Now uses the agent-auth path when there's no handle, holds the query until owned-identities settles, and treats 401/403/404 alike as the actionable connect-a-handle state.

### Payments
- **Buy domain "transaction reverted"** — the payer-signed x402 `TransferChecked` for registration was built against the SDK's hardcoded **mainnet** USDC mint while the app runs on **devnet**, so the on-chain payment reverted (the mint account + its derived ATAs don't exist on the wrong cluster). The staging backend advertises the devnet USDC mint (`4zMMC9…DncDU`) via `GET /payments/supported`. Set `NEXT_PUBLIC_SOLANA_USDC_MINT` to it and make `publicUsdcMint()` fall back to the devnet mint by active cluster when unset, so a devnet build never silently settles against the mainnet mint; deduped `use-wallet-balances` onto the same resolver.

### Activity
- **Shows actor, not action** — rows showed only the actor for any kind the `describe()` switch didn't list, notably the backend's `ledger.<TYPE>` fallback kinds and canonical `group.fee`/`arbitration.fee`/`fee`/`event.refund`. Extracted one shared formatter (used by the Activity list + header marquee) that normalizes `ledger.<TYPE>` to its canonical kind, adds the missing cases, and humanizes unknown kinds.

### Marketplace
- **Submit bounty buggy** — the budget was free-text sent unvalidated, but posting escrows real funds, so a malformed amount produced a confusing escrow failure. Made the budget a numeric input and validate title + positive amount + present wallet before mutating, surfacing the reason inline.

### i18n
- **Spanish "doesn't work"** — the language toggle changed only a handful of feed/home/poker strings because the high-traffic chrome (primary nav, sidebar links, the Need-an-Agent CTA, and the Settings page itself) rendered hardcoded English and never went through `t()`. Added `nav` + `settings` namespaces to the en/es resources and routed those surfaces through `t()` (section labels, Docs/Feedback/Settings links, menu aria-labels, Settings headings + theme names). Brand proper nouns (Discord/X/GitHub) stay literal. Remaining deep-view strings are a tracked follow-up.

### UI / perf
- **Social link** — X pointed at an `x.com/intent/follow` popup; now the canonical `https://x.com/tinyhumansai` profile.
- **MoonPay slow load** — preconnect the MoonPay buy/sell origins (dns-prefetch sandbox) from the document head so the hosted redirect + embedded off-ramp widget skip cold DNS/TLS setup.

## Testing
- `pnpm --filter @tinyplace/website lint` / `build` — green
- New unit tests: `activity-describe.test.ts` (ledger.* normalization), SDK `encryption-discovery.test.ts` (resolveEncryptionAddress throw)
- SDK rebuilt (`discovery.ts` change) before website typecheck
- #8 root cause confirmed against live `GET https://staging-api.tiny.place/payments/supported` (Solana USDC mint = `4zMMC9…DncDU`)
- Pre-existing local `SubtleCrypto` Ed25519 test failures (auth-payment/session-wallet/OnboardWizard) are a local-Node env issue, unrelated to this diff; CI on Node 22 passes.

## Note
Contains an `sdk/typescript/` change (`discovery.ts`) — merging to `main` will trigger the TS SDK publish workflow.

## Follow-up
- #6 Spanish: deep explore-view strings (Directory/Marketplace/Events/etc.) still need `t()` extraction — tracked in #138.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Encrypted messaging key resolution now validates advertised encryption keys and returns a clearer “not enabled” error when needed.
  * Inbox now waits for owner resolution and treats authorization-related failures consistently.
  * Job creation form now validates inputs before submit.

* **New Features**
  * Activity feed now uses consistent icons and human-readable descriptions across the site.
  * Direct messages accept multiple recipient input formats (handles, raw keys, and addresses).

* **Improvements**
  * Budget entry is now numeric with stronger validation and inline errors.
  * Sidebar and settings UI are now translated; external social link updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
