### PR TITLE
fix(sdk/python): retry marketplace x402 settlement through confirmation lag

### DIFF
--- a/sdk/python/src/tinyplace/api/marketplace.py
+++ b/sdk/python/src/tinyplace/api/marketplace.py
@@ -1,16 +1,46 @@
 from __future__ import annotations
 
+import asyncio
 import secrets
 import time
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from ..auth import sign_fresh_canonical_payload
 from ..crypto import canonical_payload
-from ..http import HttpClient, encode
+from ..http import HttpClient, TinyPlaceError, encode
 from ..signer import Signer
 from ..solana import SOLANA_USDC_MINT, execute_solana_x402_payment
 from ..types import Json, JsonDict, Query
 from ..x402 import build_x402_payment_map
+
+# After an `exact` on-chain settlement the backend may not yet see the transfer,
+# returning 402 "transaction not found" / "insufficient confirmations". Retry the
+# (idempotent — same payment map, no new transfer) POST through that window, as
+# registry.register_with_solana_payment and bounties.fund_with_solana_payment do.
+DEFAULT_SETTLEMENT_ATTEMPTS = 30
+DEFAULT_SETTLEMENT_INTERVAL_MS = 3000
+_SETTLEMENT_RETRY_ERRORS = ("transaction not found", "insufficient confirmations")
+
+
+def _should_retry_settlement(exc: TinyPlaceError) -> bool:
+    haystack = f"{exc} {exc.body}".lower()
+    return any(error in haystack for error in _SETTLEMENT_RETRY_ERRORS)
+
+
+async def _retry_settled(
+    action: Callable[[], Awaitable[Json]], attempts: int, interval_ms: int
+) -> Json:
+    """Retry ``action`` (the post-settlement POST) while the chain confirms."""
+    attempts = max(1, attempts)
+    for attempt in range(attempts):
+        try:
+            return await action()
+        except TinyPlaceError as exc:
+            if attempt == attempts - 1 or not _should_retry_settlement(exc):
+                raise
+        if interval_ms > 0:
+            await asyncio.sleep(interval_ms / 1000)
+    raise RuntimeError("unreachable: settlement retry loop exhausted")
 
 
 class MarketplaceApi:
@@ -86,6 +116,8 @@ class MarketplaceApi:
         nonce: str | None = None,
         expires_at: str | None = None,
         metadata: dict[str, Any] | None = None,
+        attempts: int = DEFAULT_SETTLEMENT_ATTEMPTS,
+        interval_ms: int = DEFAULT_SETTLEMENT_INTERVAL_MS,
     ) -> dict[str, Any]:
         """Buy a product, settling its USDC price on chain (exact x402), then retrying
         the buy with the signed payment map. Mirrors the TS ``buyProductWithSolanaPayment``.
@@ -116,8 +148,10 @@ class MarketplaceApi:
                 "metadata": {"productId": product_id, "kind": "product", **(metadata or {})},
             },
         )
-        purchase = await self.buy_product(
-            product_id, {**request, "payment": execution["payment"]}
+        purchase = await _retry_settled(
+            lambda: self.buy_product(product_id, {**request, "payment": execution["payment"]}),
+            attempts,
+            interval_ms,
         )
         return {"product": product, "purchase": purchase, "payment": execution}
 
@@ -194,6 +228,8 @@ class MarketplaceApi:
         nonce: str | None = None,
         expires_at: str | None = None,
         metadata: dict[str, Any] | None = None,
+        attempts: int = DEFAULT_SETTLEMENT_ATTEMPTS,
+        interval_ms: int = DEFAULT_SETTLEMENT_INTERVAL_MS,
     ) -> dict[str, Any]:
         """Buy an identity listing, settling its USDC price on chain (exact x402)."""
         if self._signer is None:
@@ -226,8 +262,10 @@ class MarketplaceApi:
                 },
             },
         )
-        sale = await self.buy_identity_listing(
-            listing_id, {**request, "payment": execution["payment"]}
+        sale = await _retry_settled(
+            lambda: self.buy_identity_listing(listing_id, {**request, "payment": execution["payment"]}),
+            attempts,
+            interval_ms,
         )
         return {"listing": listing, "sale": sale, "payment": execution}
 

--- a/sdk/python/tests/test_marketplace.py
+++ b/sdk/python/tests/test_marketplace.py
@@ -152,6 +152,41 @@ async def test_buy_product_with_solana_payment_settles_then_buys(monkeypatch) ->
     assert out["purchase"]["purchaseId"] == "pur1" and out["payment"]["signature"] == "sig"
 
 
+async def test_buy_product_retries_through_confirmation_lag(monkeypatch) -> None:
+    signer = LocalSigner.from_seed(bytes([91]) * 32)
+    session = FakeSession(
+        [
+            FakeResponse(
+                200,
+                {
+                    "productId": "prod1",
+                    "sellerCryptoId": "SellerWallet111",
+                    "price": {"network": "solana:x", "asset": "USDC", "amount": "5"},
+                },
+            ),
+            FakeResponse(402, {"error": "transaction not found"}),  # buy: not confirmed yet
+            FakeResponse(200, {"purchaseId": "pur1"}),  # buy: confirmed
+        ]
+    )
+    client = _client(signer, session)
+
+    async def fake_exec(**kwargs):
+        return {"signature": "sig", "payment": {"signature": "s"}}
+
+    monkeypatch.setattr("tinyplace.api.marketplace.execute_solana_x402_payment", fake_exec)
+
+    out = await client.marketplace.buy_product_with_solana_payment(
+        "prod1",
+        {"buyer": "BuyerId"},
+        rpc_url="https://rpc.example",
+        secret_key=bytes([91]) * 32,
+        interval_ms=0,  # no real sleep in the test
+    )
+    # Probe + two buy attempts (the first 402 "transaction not found" is retried).
+    assert len(session.requests) == 3
+    assert out["purchase"]["purchaseId"] == "pur1" and out["payment"]["signature"] == "sig"
+
+
 async def test_buy_product_with_solana_payment_requires_buyer() -> None:
     import pytest
 


### PR DESCRIPTION
## Problem

`marketplace.buy_product_with_solana_payment` and `buy_identity_listing_with_solana_payment` settle an **`exact`** USDC transfer on chain, then POST the buy **once**. The backend's `rpc` verifier frequently can't see the just-submitted transfer yet and returns `402 {"error":"transaction not found"}` (or `"insufficient confirmations"`), so the buy fails even though the payment already landed on chain — the buyer can pay without receiving the product.

`registry.register_with_solana_payment` and `bounties.fund_with_solana_payment` already handle this by **polling** the action through the confirmation window; the marketplace `exact` helpers were the odd ones out.

## Fix

Retry the post-settlement POST (idempotent — same signed payment map, **no new transfer**) while the chain confirms, using the same matcher/cadence as the bounty fund helper:

- new `attempts` / `interval_ms` params (default **30 × 3s**),
- retry only on `transaction not found` / `insufficient confirmations`, otherwise surface the error,
- shared `_retry_settled` helper + `_should_retry_settlement` matcher.

The `upto`-scheme `place_bid` / `create_offer` helpers are intentionally left unchanged — they attach a signed authorization with **no immediate transfer**, so there's nothing to confirm.

## How it was found

The tiny.place **Hermes plugin**'s `tinyplace_buy_product` returned a 402 against a funded local stack even though the USDC transfer was on chain. With this fix it settles and completes, returning the `onChainTx`.

## Test

Added `test_buy_product_retries_through_confirmation_lag` (`tests/test_marketplace.py`): a first buy that 402s with "transaction not found" is retried and succeeds (probe + 2 buy attempts). `tests/test_marketplace.py` passes (9 tests). Verified end-to-end against the running stack via the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Solana-backed product and identity listing purchases now include configurable retry options to handle settlement delays and improve transaction reliability.

* **Tests**
  * Added test coverage for automatic purchase retry functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->