### PR TITLE
test(sdk/python): cover conversations, broadcasts and events namespaces

### DIFF
--- a/sdk/python/tests/test_broadcasts.py
+++ b/sdk/python/tests/test_broadcasts.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+
+from tinyplace import LocalSigner, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer, session):
+    return TinyPlaceClient(base_url="https://api.example.test", signer=signer, session=session)  # type: ignore[arg-type]
+
+
+async def test_list_is_public_and_coalesces_null() -> None:
+    signer = LocalSigner.from_seed(bytes([70]) * 32)
+    session = FakeSession([FakeResponse(200, {"broadcasts": None})])
+    client = _client(signer, session)
+    out = await client.broadcasts.list()
+    assert session.requests[0]["url"].endswith("/broadcasts")
+    assert "X-Agent-ID" not in session.requests[0]["headers"]  # public read
+    assert out == {"broadcasts": []}
+
+
+async def test_subscribe_accepts_bare_agent_id_and_routes_as_actor() -> None:
+    signer = LocalSigner.from_seed(bytes([71]) * 32)
+    session = FakeSession([FakeResponse(200, {"broadcastId": "b1"})])
+    client = _client(signer, session)
+    await client.broadcasts.subscribe("b1", signer.agent_id)  # bare-string overload
+    req = session.requests[0]
+    assert req["method"] == "POST" and req["url"].endswith("/broadcasts/b1/subscribe")
+    assert req["headers"]["X-Agent-ID"] == signer.agent_id
+    assert json.loads(req["data"]) == {"agentId": signer.agent_id}
+
+
+async def test_post_message_routes_as_publisher() -> None:
+    signer = LocalSigner.from_seed(bytes([72]) * 32)
+    session = FakeSession([FakeResponse(200, {"messageId": "bmsg1"})])
+    client = _client(signer, session)
+    await client.broadcasts.post_message("b1", {"publisher": signer.agent_id, "body": "ann"})
+    req = session.requests[0]
+    assert req["method"] == "POST" and req["url"].endswith("/broadcasts/b1/messages")
+    assert req["headers"]["X-Agent-ID"] == signer.agent_id
+    body = json.loads(req["data"])
+    assert body["publisher"] == signer.agent_id and body["body"] == "ann" and body["messageId"]

--- a/sdk/python/tests/test_conversations.py
+++ b/sdk/python/tests/test_conversations.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+
+from tinyplace import LocalSigner, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer, session):
+    return TinyPlaceClient(base_url="https://api.example.test", signer=signer, session=session)  # type: ignore[arg-type]
+
+
+async def test_list_is_public_and_coalesces_null() -> None:
+    signer = LocalSigner.from_seed(bytes([60]) * 32)
+    session = FakeSession([FakeResponse(200, {"conversations": None})])
+    client = _client(signer, session)
+    out = await client.conversations.list({"limit": 5})
+    assert "/conversations?limit=5" in session.requests[0]["url"]
+    assert "X-Agent-ID" not in session.requests[0]["headers"]  # public read
+    assert out == {"conversations": []}
+
+
+async def test_join_routes_as_actor() -> None:
+    signer = LocalSigner.from_seed(bytes([61]) * 32)
+    session = FakeSession([FakeResponse(200, {"conversationId": "c1", "agentId": signer.agent_id})])
+    client = _client(signer, session)
+    await client.conversations.join("c1", signer.agent_id)
+    req = session.requests[0]
+    assert req["method"] == "POST" and req["url"].endswith("/conversations/c1/join")
+    assert req["headers"]["X-Agent-ID"] == signer.agent_id  # directory-auth as the cryptoId
+    assert json.loads(req["data"]) == {"agentId": signer.agent_id}
+
+
+async def test_post_message_routes_as_author_and_defaults_message_id() -> None:
+    signer = LocalSigner.from_seed(bytes([62]) * 32)
+    session = FakeSession([FakeResponse(200, {"messageId": "m1"})])
+    client = _client(signer, session)
+    await client.conversations.post_message("c1", {"author": signer.agent_id, "body": "hello"})
+    req = session.requests[0]
+    assert req["method"] == "POST" and req["url"].endswith("/conversations/c1/messages")
+    assert req["headers"]["X-Agent-ID"] == signer.agent_id
+    body = json.loads(req["data"])
+    assert body["author"] == signer.agent_id and body["body"] == "hello" and body["messageId"]

--- a/sdk/python/tests/test_events.py
+++ b/sdk/python/tests/test_events.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+
+from tinyplace import LocalSigner, TinyPlaceClient
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(signer, session):
+    return TinyPlaceClient(base_url="https://api.example.test", signer=signer, session=session)  # type: ignore[arg-type]
+
+
+async def test_list_is_public_and_coalesces_null() -> None:
+    signer = LocalSigner.from_seed(bytes([80]) * 32)
+    session = FakeSession([FakeResponse(200, {"events": None})])
+    client = _client(signer, session)
+    out = await client.events.list()
+    assert session.requests[0]["url"].endswith("/events")
+    assert "X-Agent-ID" not in session.requests[0]["headers"]  # public read
+    assert out == {"events": []}
+
+
+async def test_rsvp_routes_as_override_agent() -> None:
+    signer = LocalSigner.from_seed(bytes([81]) * 32)
+    session = FakeSession([FakeResponse(200, {"eventId": "e1", "status": "going"})])
+    client = _client(signer, session)
+    await client.events.rsvp("e1", None, agent_id_override=signer.agent_id)
+    req = session.requests[0]
+    assert req["method"] == "POST" and req["url"].endswith("/events/e1/rsvp")
+    assert req["headers"]["X-Agent-ID"] == signer.agent_id  # directory-auth as the cryptoId
+    assert json.loads(req["data"]) == {"agentId": signer.agent_id}
+
+
+async def test_rsvp_bare_string_is_tier() -> None:
+    signer = LocalSigner.from_seed(bytes([82]) * 32)
+    session = FakeSession([FakeResponse(200, {"eventId": "e1"})])
+    client = _client(signer, session)
+    await client.events.rsvp("e1", "vip", agent_id_override=signer.agent_id)
+    body = json.loads(session.requests[0]["data"])
+    assert body == {"tier": "vip", "agentId": signer.agent_id}
+
+
+async def test_cancel_rsvp_adds_agent_query() -> None:
+    signer = LocalSigner.from_seed(bytes([83]) * 32)
+    session = FakeSession([FakeResponse(204, None)])
+    client = _client(signer, session)
+    await client.events.cancel_rsvp("e1", signer.agent_id)
+    req = session.requests[0]
+    assert req["method"] == "DELETE"
+    assert f"/events/e1/rsvp?agentId={signer.agent_id}" in req["url"]
+    assert req["headers"]["X-Agent-ID"] == signer.agent_id


### PR DESCRIPTION
## What

Adds unit tests for the Python SDK's `conversations`, `broadcasts`, and `events` namespaces, which shipped on `main` without test coverage (`tests/test_{conversations,broadcasts,events}.py` did not exist).

## Coverage

`FakeSession`-based tests (mirroring `test_marketplace.py` / `test_follows.py`) assert path/verb, public reads vs directory-auth writes, actor routing (`X-Agent-ID` == the acting cryptoId), null-coalescing of list responses, and the overloads the Hermes plugin relies on:

- **conversations** — `list` (public), `join` (routes as agent, body `{agentId}`), `post_message` (routes as author, defaults `messageId`)
- **broadcasts** — `list` (public), `subscribe` (bare-string `agentId` overload), `post_message` (routes as publisher)
- **events** — `list` (public), `rsvp` (`agent_id_override` routing + bare-string `tier`), `cancel_rsvp` (`?agentId=` query)

## Verification

- `pytest tests/test_conversations.py tests/test_broadcasts.py tests/test_events.py` → **10 passed**.
- End-to-end against the local stack (`backend-tinyplace` + `solana-test-validator`): the 7 Hermes plugin tools backed by these namespaces — `tinyplace_conversations`/`join_conversation`/`post_conversation`, `tinyplace_broadcasts`/`subscribe_broadcast`/`post_broadcast`, `tinyplace_rsvp_event` — all pass (full plugin smoke: 38 PASS / 8 SKIP / 0 FAIL).

## Context

While testing the Hermes plugin I found these 7 tools were SKIPping locally only because the installed/editable SDK was on an older branch missing the namespaces — `main` already implements them. This PR closes the remaining gap (test coverage) and supersedes issues #140, #141, #142 (which proposed adding the namespaces; they already exist on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for broadcasts, conversations, and events APIs in the Python SDK to validate core functionality and expected client behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->