### PR TITLE
fix(plugin-hermes): give tinyplace_create_bounty a submission window

### DIFF
--- a/sdk/plugin-hermes/src/tinyplace/schemas.py
+++ b/sdk/plugin-hermes/src/tinyplace/schemas.py
@@ -520,6 +520,21 @@ CREATE_BOUNTY = {
                 "type": "string",
                 "description": "Reward asset symbol. Defaults to 'USDC' when omitted.",
             },
+            "duration_days": {
+                "type": "integer",
+                "description": (
+                    "How many days the bounty stays open for submissions "
+                    "(1–31). Defaults to 7 when neither this nor 'deadline' "
+                    "is given."
+                ),
+            },
+            "deadline": {
+                "type": "string",
+                "description": (
+                    "Submission deadline as an ISO-8601 / RFC-3339 timestamp "
+                    "(e.g. '2026-07-01T00:00:00Z'). Overrides 'duration_days'."
+                ),
+            },
         },
         "required": ["title", "description", "amount"],
     },

--- a/sdk/plugin-hermes/src/tinyplace/schemas.py
+++ b/sdk/plugin-hermes/src/tinyplace/schemas.py
@@ -522,14 +522,17 @@ CREATE_BOUNTY = {
             },
             "duration_days": {
                 "type": "integer",
+                "minimum": 1,
+                "maximum": 31,
                 "description": (
                     "How many days the bounty stays open for submissions "
-                    "(1–31). Defaults to 7 when neither this nor 'deadline' "
+                    "(1-31). Defaults to 7 when neither this nor 'deadline' "
                     "is given."
                 ),
             },
             "deadline": {
                 "type": "string",
+                "format": "date-time",
                 "description": (
                     "Submission deadline as an ISO-8601 / RFC-3339 timestamp "
                     "(e.g. '2026-07-01T00:00:00Z'). Overrides 'duration_days'."

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -727,6 +727,14 @@ def create_bounty(args: dict[str, Any], ctx: dict[str, Any]) -> str:
         "amount": amount.strip(),
         "asset": asset,
     }
+    # The bounty needs a submission window: an explicit ISO-8601 'deadline', or a
+    # 'duration_days' the backend turns into one. The backend requires it (1 day
+    # to 1 month), so default to 7 days when the caller gives neither.
+    deadline = args.get("deadline")
+    if isinstance(deadline, str) and deadline.strip():
+        request["deadline"] = deadline.strip()
+    else:
+        request["durationDays"] = _coerce_limit(args.get("duration_days")) or 7
 
     async def _run() -> Any:
         client = await runtime.get_client()

--- a/sdk/plugin-hermes/src/tinyplace/tools.py
+++ b/sdk/plugin-hermes/src/tinyplace/tools.py
@@ -728,13 +728,19 @@ def create_bounty(args: dict[str, Any], ctx: dict[str, Any]) -> str:
         "asset": asset,
     }
     # The bounty needs a submission window: an explicit ISO-8601 'deadline', or a
-    # 'duration_days' the backend turns into one. The backend requires it (1 day
-    # to 1 month), so default to 7 days when the caller gives neither.
+    # 'duration_days' the backend turns into one. The backend bounds the window to
+    # 1 day-1 month, so validate 'duration_days' here (rather than passing a bad
+    # value through to a 400) and default to 7 days when the caller gives neither.
     deadline = args.get("deadline")
     if isinstance(deadline, str) and deadline.strip():
         request["deadline"] = deadline.strip()
+    elif args.get("duration_days") is None:
+        request["durationDays"] = 7
     else:
-        request["durationDays"] = _coerce_limit(args.get("duration_days")) or 7
+        duration_days = _coerce_limit(args.get("duration_days"))
+        if duration_days is None or not 1 <= duration_days <= 31:
+            return _error("'duration_days' must be an integer between 1 and 31")
+        request["durationDays"] = duration_days
 
     async def _run() -> Any:
         client = await runtime.get_client()

--- a/sdk/plugin-hermes/tests/test_bounties.py
+++ b/sdk/plugin-hermes/tests/test_bounties.py
@@ -71,6 +71,21 @@ def test_create_bounty_addresses_as_self(tmp_path, monkeypatch):
     created = rt._client.bounties.created[0]
     assert created["creator"] == rt.address and created["title"] == "Summarize X"
     assert created["amount"] == "10" and created["asset"] == "USDC"
+    # The backend requires a submission window; default to 7 days when unspecified.
+    assert created["durationDays"] == 7 and "deadline" not in created
+
+
+def test_create_bounty_window_from_duration_or_deadline(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    base = {"title": "X", "description": "do it", "amount": "10"}
+
+    json.loads(tools.create_bounty({**base, "duration_days": 14}, runtime=rt))
+    assert rt._client.bounties.created[-1]["durationDays"] == 14
+
+    json.loads(tools.create_bounty({**base, "deadline": "2026-07-01T00:00:00Z"}, runtime=rt))
+    last = rt._client.bounties.created[-1]
+    # An explicit deadline wins; no durationDays is sent alongside it.
+    assert last["deadline"] == "2026-07-01T00:00:00Z" and "durationDays" not in last
 
 
 def test_submit_bounty_addresses_as_self(tmp_path, monkeypatch):

--- a/sdk/plugin-hermes/tests/test_bounties.py
+++ b/sdk/plugin-hermes/tests/test_bounties.py
@@ -87,6 +87,26 @@ def test_create_bounty_window_from_duration_or_deadline(tmp_path, monkeypatch):
     # An explicit deadline wins; no durationDays is sent alongside it.
     assert last["deadline"] == "2026-07-01T00:00:00Z" and "durationDays" not in last
 
+    # When both are given, the explicit deadline still wins.
+    json.loads(
+        tools.create_bounty(
+            {**base, "duration_days": 14, "deadline": "2026-07-02T00:00:00Z"}, runtime=rt
+        )
+    )
+    both = rt._client.bounties.created[-1]
+    assert both["deadline"] == "2026-07-02T00:00:00Z" and "durationDays" not in both
+
+
+def test_create_bounty_rejects_out_of_range_duration_days(tmp_path, monkeypatch):
+    rt = _make_runtime(tmp_path, monkeypatch)
+    base = {"title": "X", "description": "do it", "amount": "10"}
+    before = len(rt._client.bounties.created)
+    for bad in (0, 32):
+        out = json.loads(tools.create_bounty({**base, "duration_days": bad}, runtime=rt))
+        assert out["ok"] is False and "1 and 31" in out["error"]
+    # No bounty was created for the rejected inputs.
+    assert len(rt._client.bounties.created) == before
+
 
 def test_submit_bounty_addresses_as_self(tmp_path, monkeypatch):
     rt = _make_runtime(tmp_path, monkeypatch)


### PR DESCRIPTION
## Problem

`POST /bounties` requires a submission window — an explicit `deadline`, or a `durationDays` the backend derives one from (`validateWindow`: 1 day to 1 month). The Hermes `tinyplace_create_bounty` tool sent neither, so creating a bounty failed with **400 `deadline is required`**, making the tool (and the `fund_bounty`/`submit_bounty` flow that follows it) unusable.

## Fix (plugin-only)

Add two optional args to the tool + schema:

- `duration_days` (int, 1–31) — how long the bounty accepts submissions;
- `deadline` (ISO-8601 / RFC-3339) — an explicit cutoff that overrides `duration_days`.

An explicit `deadline` wins; otherwise the tool sends `durationDays`, **defaulting to 7 days** when the caller supplies neither, so the tool works out of the box. The SDK's `bounties.create(request)` passes the field straight through — no SDK change required.

## Verification

- `pytest tests/test_bounties.py` (plugin) → all pass, incl. updated `test_create_bounty_addresses_as_self` (asserts default `durationDays == 7`) and new `test_create_bounty_window_from_duration_or_deadline` (explicit duration / explicit deadline).
- End-to-end against the local stack: `tinyplace_create_bounty` now succeeds and returns a bounty (was 400). 

Out of scope (separate, pre-existing): on this backend `fund_bounty` returns 503 `bounty funding is not configured` (needs a bounty escrow wallet) and `submit_bounty` returns 409 `bounty is not accepting submissions` (a draft bounty must be funded/opened first) — both config/lifecycle, not the create gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced bounty creation to support a submission window via either `deadline` (overrides duration) or `duration` in days (defaults to 7 when neither is provided).
* **Bug Fixes**
  * Ensures the correct submission-window fields are sent to the backend, including omitting `deadline` when not provided.
* **Tests**
  * Added/updated coverage to verify default behavior, deadline-vs-duration precedence, and rejection of out-of-range duration values (only 1–31 days accepted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->