### PR TITLE
fix(website): distinguish connect-wallet from approve-session on write gates (closes #65)

### DIFF
--- a/website/src/components/explore/Broadcasts.tsx
+++ b/website/src/components/explore/Broadcasts.tsx
@@ -15,6 +15,7 @@ import {
 	firstActiveIdentity,
 	useOwnedIdentities,
 } from "@src/hooks/use-marketplace";
+import { useWriteGateMessage } from "@src/hooks/use-write-gate";
 import { useAuthStore } from "@src/store/auth";
 
 function panelClass(isDark: boolean): string {
@@ -135,6 +136,7 @@ export const Broadcasts = ({
 }): FunctionComponent => {
 	const { data, isLoading, isError, error } = useBroadcasts({ limit: 12 });
 	const agentId = useAuthStore((state) => state.agentId);
+	const gateMessage = useWriteGateMessage("create or post paid channels");
 	const ownedIdentities = useOwnedIdentities(agentId);
 	const broadcasterIdentity = firstActiveIdentity(
 		ownedIdentities.data?.identities
@@ -224,9 +226,7 @@ export const Broadcasts = ({
 								: "Connect your wallet to create or post paid channels."}
 					</p>
 				) : (
-					<p className="mt-2 text-xs text-red-500">
-						Connect your wallet before creating or posting paid channels.
-					</p>
+					<p className="mt-2 text-xs text-red-500">{gateMessage}</p>
 				)}
 			</form>
 

--- a/website/src/components/explore/Events.tsx
+++ b/website/src/components/explore/Events.tsx
@@ -10,6 +10,7 @@ import {
 	useEvents,
 	useRsvpEvent,
 } from "@src/hooks/use-events";
+import { useWriteGateMessage } from "@src/hooks/use-write-gate";
 import { useAuthStore } from "@src/store/auth";
 
 type EventsProperties = {
@@ -61,6 +62,7 @@ function errorMessage(error: unknown): string {
 
 export const Events = ({ isDark }: EventsProperties): FunctionComponent => {
 	const agentId = useAuthStore((state) => state.agentId);
+	const gateMessage = useWriteGateMessage("create and RSVP to events");
 	const { data, isLoading, isError, error } = useEvents();
 	const createEvent = useCreateEvent();
 	const rsvpEvent = useRsvpEvent();
@@ -153,10 +155,8 @@ export const Events = ({ isDark }: EventsProperties): FunctionComponent => {
 					</h3>
 					<span className="text-xs text-neutral-500">Signed write</span>
 				</div>
-				{!agentId ? (
-					<p className="mt-2 text-xs text-neutral-500">
-						Connect your wallet to create and RSVP to events.
-					</p>
+				{gateMessage ? (
+					<p className="mt-2 text-xs text-neutral-500">{gateMessage}</p>
 				) : null}
 				<div className="mt-3 grid gap-2 md:grid-cols-2">
 					<input

--- a/website/src/components/explore/Groups.tsx
+++ b/website/src/components/explore/Groups.tsx
@@ -17,6 +17,7 @@ import {
 	useJoinGroup,
 	useMyGroups,
 } from "@src/hooks/use-groups";
+import { useWriteGateMessage } from "@src/hooks/use-write-gate";
 import { useAuthStore } from "@src/store/auth";
 import { groupUnread } from "@src/store/group-conversations";
 
@@ -37,6 +38,7 @@ export const Groups = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 	// membership detection (member.agentId === actor), `groups.list({member})`,
 	// and group message delivery (fanout targets agent ids, not usernames).
 	const actor = agentId ?? "";
+	const gateMessage = useWriteGateMessage("create or join groups");
 
 	const myGroupsQuery = useMyGroups(actor);
 	const discoverQuery = useGroups();
@@ -476,9 +478,7 @@ export const Groups = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 					<p className="mt-2 text-xs text-red-500">{mutationError.message}</p>
 				) : null}
 				<p className={`mt-2 text-xs ${actor ? mutedClass : "text-red-500"}`}>
-					{actor
-						? `Acting as ${actor}`
-						: "Connect your wallet to create or join groups."}
+					{actor ? `Acting as ${actor}` : gateMessage}
 				</p>
 			</form>
 			<div

--- a/website/src/components/explore/Moderation.tsx
+++ b/website/src/components/explore/Moderation.tsx
@@ -13,6 +13,7 @@ import {
 	useCreateModerationReport,
 	useModerationActions,
 } from "@src/hooks/use-moderation";
+import { useWriteGateMessage } from "@src/hooks/use-write-gate";
 import { useAuthStore } from "@src/store/auth";
 
 type ModerationProperties = {
@@ -115,6 +116,8 @@ export const Moderation = ({
 	isDark,
 }: ModerationProperties): FunctionComponent => {
 	const agentId = useAuthStore((state) => state.agentId);
+	const reportGateMessage = useWriteGateMessage("sign moderation reports");
+	const appealGateMessage = useWriteGateMessage("sign appeals");
 	const [targetFilter, setTargetFilter] = useState("");
 	const [reportContentType, setReportContentType] =
 		useState<ModerationReportContentType>("channel-message");
@@ -200,9 +203,7 @@ export const Moderation = ({
 				<form className={panelClass(isDark)} onSubmit={handleReportSubmit}>
 					<SectionTitle isDark={isDark} title="Submit Report" />
 					{!agentId ? (
-						<p className="mb-3 text-xs text-neutral-500">
-							Connect your wallet to sign moderation reports.
-						</p>
+						<p className="mb-3 text-xs text-neutral-500">{reportGateMessage}</p>
 					) : null}
 					<div className="space-y-2">
 						<div>
@@ -293,9 +294,7 @@ export const Moderation = ({
 				<form className={panelClass(isDark)} onSubmit={handleAppealSubmit}>
 					<SectionTitle isDark={isDark} title="Appeal Action" />
 					{!agentId ? (
-						<p className="mb-3 text-xs text-neutral-500">
-							Connect your wallet to sign appeals.
-						</p>
+						<p className="mb-3 text-xs text-neutral-500">{appealGateMessage}</p>
 					) : null}
 					<div className="space-y-2">
 						<div>

--- a/website/src/hooks/use-write-gate.ts
+++ b/website/src/hooks/use-write-gate.ts
@@ -1,0 +1,30 @@
+import { useTinyplaceWallet } from "@src/common/tinyplace-wallet";
+import { useAuthStore } from "@src/store/auth";
+
+/**
+ * Empty-state message for a signed-write surface.
+ *
+ * The write gate keys on `agentId`, which is only set once the browser-session
+ * approval completes — not when the wallet first connects. Telling a user with a
+ * connected wallet to "connect your wallet" is misleading, so this distinguishes
+ * the two states:
+ *
+ * - no wallet connected → "Connect your wallet to {action}."
+ * - wallet connected, session not yet approved → "Approve the sign-in request to
+ *   {action}." (the approval dialog auto-opens on connect; this nudges the user
+ *   who hasn't completed it).
+ *
+ * Returns `undefined` once authenticated (`agentId` set), so the caller can
+ * render its normal "acting as …" state. `action` is the lowercase verb phrase,
+ * e.g. "create and RSVP to events".
+ */
+export function useWriteGateMessage(action: string): string | undefined {
+	const agentId = useAuthStore((state) => state.agentId);
+	const connected = useTinyplaceWallet().connected;
+	if (agentId) {
+		return undefined;
+	}
+	return connected
+		? `Approve the sign-in request to ${action}.`
+		: `Connect your wallet to ${action}.`;
+}


### PR DESCRIPTION
## Bug (#65)

Signed-write surfaces gate their empty state on `!agentId` and show **"Connect your wallet to …"**. But `agentId` is only set once the **browser-session approval** completes (`setSigner` in `store/auth.ts`) — not when the wallet first connects. So a user whose wallet *is* connected but whose session approval is still pending (or who hasn't completed the sign-in dialog) was told to "connect your wallet", which is misleading.

## Fix

New hook `useWriteGateMessage(action)` keys off **both** the wallet connection state (`useTinyplaceWallet().connected`) and `agentId`:

| State | Message |
|---|---|
| wallet not connected | `Connect your wallet to {action}.` |
| connected, session not approved | `Approve the sign-in request to {action}.` |
| authenticated (`agentId` set) | `undefined` → caller renders its normal "acting as …" state |

Applied to the four affected surfaces:
- `Events.tsx` — "create and RSVP to events"
- `Moderation.tsx` — "sign moderation reports" / "sign appeals"
- `Groups.tsx` — "create or join groups"
- `Broadcasts.tsx` — "create or post paid channels"

`Feedback.tsx` was listed in the issue but has no such gate, so it's untouched.

## Notes
- Copy/UX-only change; no behavior change to the gate condition itself.
- The session-establishment flow (`wallet-context.tsx`) auto-opens the approval dialog on connect and now falls back to a direct `WalletSigner` if the dialog is cancelled, so the connected-but-no-session state is largely transient — but the message is now accurate in that window instead of misleading.

## Validation
- `tsc --noEmit` ✅
- `eslint` (changed files) ✅
- Dev server: `/explore` compiles and serves 200, no errors.

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)