### PR TITLE
fix(website): describe all activity kinds in the feed (closes #135)

### DIFF
--- a/website/src/components/explore/Activity.tsx
+++ b/website/src/components/explore/Activity.tsx
@@ -24,18 +24,27 @@ const KIND_ICONS: Record<string, string> = {
 	"identity.renewed": "♻️",
 	subscription: "🔁",
 	payment: "💸",
+	"group.fee": "👥",
 	"event.ticket": "🎟️",
 	"event.refund": "↩️",
 	"revenue.share": "💰",
 	"escrow.fund": "🔒",
 	"escrow.release": "🔓",
 	"escrow.refund": "↩️",
+	"arbitration.fee": "⚖️",
+	fee: "💸",
 	"game.won": "🏆",
 	"game.lost": "💀",
+	"social.post": "📝",
 };
 
 function iconFor(kind: string): string {
 	return KIND_ICONS[kind] ?? "•";
+}
+
+/** Turn an unknown kind like `foo.bar_baz` into readable `foo bar baz`. */
+function humanizeKind(kind: string): string {
+	return kind.replace(/[._]/g, " ").trim();
 }
 
 function shortName(value?: string | null): string {
@@ -68,8 +77,12 @@ function describe(event: ActivityEvent): string {
 			return `${actor} renewed their identity`;
 		case "subscription":
 			return `${actor} subscribed${amount}`;
+		case "group.fee":
+			return `${actor} paid a group fee${amount}`;
 		case "event.ticket":
 			return `${actor} bought an event ticket${amount}`;
+		case "event.refund":
+			return `${actor} was refunded for an event${amount}`;
 		case "revenue.share":
 			return `${actor} earned a revenue share${amount}`;
 		case "escrow.fund":
@@ -78,14 +91,22 @@ function describe(event: ActivityEvent): string {
 			return `escrow released${amount} to ${target}`;
 		case "escrow.refund":
 			return `escrow refunded${amount} to ${target}`;
+		case "arbitration.fee":
+			return `${actor} paid an arbitration fee${amount}`;
+		case "fee":
+			return `${actor} paid a fee${amount}`;
 		case "game.won":
 			return `${actor} won${amount || " a hand"}`;
 		case "game.lost":
 			return `${actor} lost${amount ? amount : " a hand"}`;
+		case "social.post":
+			return `${actor} posted`;
 		case "payment":
 			return `${actor} paid ${target}${amount}`;
 		default:
-			return `${actor}${amount ? ` —${amount}` : ""}`;
+			// Unknown/future kind: still describe the action from its kind name
+			// rather than showing just the actor id.
+			return `${actor} · ${humanizeKind(event.kind)}${amount}`;
 	}
 }
 

--- a/website/src/components/explore/Activity.tsx
+++ b/website/src/components/explore/Activity.tsx
@@ -82,7 +82,7 @@ function describe(event: ActivityEvent): string {
 		case "event.ticket":
 			return `${actor} bought an event ticket${amount}`;
 		case "event.refund":
-			return `${actor} was refunded for an event${amount}`;
+			return `event refunded${amount} to ${target}`;
 		case "revenue.share":
 			return `${actor} earned a revenue share${amount}`;
 		case "escrow.fund":
@@ -98,7 +98,7 @@ function describe(event: ActivityEvent): string {
 		case "game.won":
 			return `${actor} won${amount || " a hand"}`;
 		case "game.lost":
-			return `${actor} lost${amount ? amount : " a hand"}`;
+			return `${actor} lost${amount || " a hand"}`;
 		case "social.post":
 			return `${actor} posted`;
 		case "payment":


### PR DESCRIPTION
## Bug (#135)

The Explore → Activity feed showed only a wallet id for most entries, with no description of the action.

## Root cause

`Activity.tsx` `describe()` only had `switch` cases for a subset of the backend's `ActivityKind` values (`pkg/models/activity.go` defines 17). Events with kinds **`group.fee`, `event.refund`, `arbitration.fee`, `fee`, `social.post`** fell through to the `default` case, which returned just `${actor}` — the bare id.

## Fix

- Added explicit `describe()` cases for all 17 backend kinds (+ icons).
- Made the `default` case humanize the kind name (`foo.bar_baz` → `foo bar baz`) so any **future** backend kind still describes the action instead of showing only an id.

## Validation
- `tsc --noEmit` ✅
- `eslint` ✅

Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying additional activity types (including group fees, event refunds/tickets, arbitration fees, generic fees, social posts, and related payment/game activities) with appropriate icons.
* **Bug Fixes**
  * Improved activity description rendering with more readable, human-friendly text for a wider set of kinds, including a better fallback for unknown kinds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->