### PR TITLE
fix(website): enable Buy on listings for wallets without a handle (closes #126)

### DIFF
--- a/website/src/components/explore/IdentityListingCard.tsx
+++ b/website/src/components/explore/IdentityListingCard.tsx
@@ -99,8 +99,15 @@ export function IdentityListingCard({
 		(listing.sellerCryptoId === agentId ||
 			listing.seller === buyerIdentity?.username)
 	);
+	// Bidding and making offers act as one of the buyer's owned @handles.
 	const canActAsBuyer = Boolean(
 		agentId && buyerIdentity && listing.status === "active" && !isOwnListing
+	);
+	// A fixed-price purchase transfers the @handle to the buyer's wallet cryptoId
+	// (see gitbooks/identity/trading.md), so it does NOT require the buyer to
+	// already own a handle — only a connected, session-authorized wallet.
+	const canBuy = Boolean(
+		agentId && listing.status === "active" && !isOwnListing
 	);
 	const expired = isExpired(listing.expiresAt);
 	const highest = listing.highestBid?.price;
@@ -224,16 +231,17 @@ export function IdentityListingCard({
 					) : (
 						<button
 							className={`${accentButtonClass(isDark, "blue")} px-3 py-1`}
-							disabled={!canActAsBuyer || buyListing.isPending}
+							disabled={!canBuy || buyListing.isPending}
 							type="button"
 							onClick={(): void => {
 								const wallet = agentId;
-								const buyer = buyerIdentity;
-								if (!wallet || !buyer) {
+								if (!wallet) {
 									return;
 								}
+								// Act as the buyer's @handle if they own one, else as the
+								// wallet cryptoId — the name transfers to this wallet either way.
 								buyListing.mutate({
-									buyer: buyer.username,
+									buyer: buyerIdentity?.username ?? wallet,
 									buyerCryptoId: wallet,
 									listingId: listing.listingId,
 								});


### PR DESCRIPTION
## Bug (#126)

A domain listed for sale (valid price, not the viewer's own) showed a **greyed-out Buy button** — users couldn't purchase.

## Root cause

The Buy button was gated on `canActAsBuyer`, which requires `buyerIdentity` — an **active @handle the buyer already owns**. A connected, session-authorized wallet that doesn't own a handle (or whose identities hadn't loaded) could never buy.

But per `gitbooks/identity/trading.md`, a fixed-price purchase **transfers the @handle to the buyer's wallet `cryptoId`** — it does *not* require the buyer to pre-own a handle (the spec's example even uses a raw address as `buyer`). The SDK's `buyIdentityListing` already supports this (it falls back to plain directory auth when no `buyer` handle is given).

## Fix

- New `canBuy` gate for the fixed-price Buy button: connected wallet + active listing + not own listing (no handle required).
- Buy sends `buyer = owned @handle ?? wallet cryptoId`, `buyerCryptoId = wallet`.
- **Bid** and **Offer** are left unchanged (they still act as an owned handle) — scoped strictly to the reported Buy-button bug.

## Validation
- `tsc --noEmit` ✅
- `eslint` ✅

Closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)