### PR TITLE
fix(website): gate inbox on an active session (refs #128)

### DIFF
--- a/website/src/components/explore/Inbox.tsx
+++ b/website/src/components/explore/Inbox.tsx
@@ -16,6 +16,7 @@ import {
 	firstActiveIdentity,
 	useOwnedIdentities,
 } from "@src/hooks/use-marketplace";
+import { useWriteGateMessage } from "@src/hooks/use-write-gate";
 import { useAuthStore } from "@src/store/auth";
 
 const filterOptions = ["All", "Tasks", "Payments", "Invites"] as const;
@@ -69,6 +70,7 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 	const ownedIdentities = useOwnedIdentities(agentId);
 	const inboxIdentity = firstActiveIdentity(ownedIdentities.data?.identities);
 	const owner = inboxIdentity?.username ?? agentId;
+	const gateMessage = useWriteGateMessage("view your inbox");
 	const { data, isLoading, isError, error } = useInbox({ limit: 50 }, owner);
 	const markRead = useMarkInboxRead();
 	const archiveItem = useArchiveInboxItem();
@@ -86,7 +88,10 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 		"status" in error &&
 		(error as { status: number }).status === 401;
 
-	if (isAuthError) {
+	// No session yet (wallet not connected, or connected but session not
+	// approved): show a connect/approve prompt rather than letting the query run
+	// keyless and surface a misleading "Failed to load inbox". Covers a 401 too.
+	if (gateMessage || isAuthError) {
 		return (
 			<div
 				className={`flex h-full flex-col items-center justify-center overflow-hidden rounded-lg border ${isDark ? "border-neutral-800 bg-neutral-950" : "border-neutral-200 bg-neutral-50"}`}
@@ -94,7 +99,7 @@ export const Inbox = ({ isDark }: { isDark: boolean }): FunctionComponent => {
 				<p
 					className={`text-sm ${isDark ? "text-neutral-400" : "text-neutral-500"}`}
 				>
-					Connect your wallet to view your inbox
+					{gateMessage ?? "Connect your wallet to view your inbox"}
 				</p>
 			</div>
 		);

--- a/website/src/hooks/use-inbox.ts
+++ b/website/src/hooks/use-inbox.ts
@@ -41,6 +41,10 @@ export function useInbox(
 		queryKey: queryKeys.inbox.list(parameters, owner),
 		queryFn: (): Promise<InboxListResult> =>
 			client.inbox.list(parameters, owner),
+		// Don't fetch until a session owner is known — otherwise the request signs
+		// with no key and throws a non-401 client error that surfaces as a
+		// misleading "Failed to load inbox" instead of a connect prompt.
+		enabled: Boolean(owner),
 	});
 }
 
@@ -49,6 +53,7 @@ export function useInboxCounts(owner?: string): UseQueryResult<InboxCounts> {
 	return useQuery({
 		queryKey: queryKeys.inbox.counts(owner),
 		queryFn: (): Promise<InboxCounts> => client.inbox.counts(owner),
+		enabled: Boolean(owner),
 	});
 }
 


### PR DESCRIPTION
## Bug (#128)

The inbox showed **"Failed to load inbox"** for users who'd connected but whose session wasn't fully established.

## Root cause

`owner = inboxIdentity?.username ?? agentId`. When there's no session (`agentId` undefined — e.g. wallet connected but browser-session approval not completed, the #65 family), `owner` is undefined but `useInbox` **still fired**. `inbox.list` then calls `getAgentAuth` with no signing key, which throws a **client-side (non-401)** error. The component's connect-prompt only triggers on `error.status === 401`, so this fell through to the generic **"Failed to load inbox"**.

## Fix

- `enabled: Boolean(owner)` on `useInbox`/`useInboxCounts` — don't run the query keyless.
- Show the connect/approve gate via `useWriteGateMessage("view your inbox")` (consistent with #65) when there's no session, instead of a misleading error. Still falls back to the prompt on a real 401.

Marked **Refs** (not Closes): this fixes the no-session path, which is the most likely trigger. If there's a *separate* logged-in failure (a 500 / data-shape error), that needs a captured network response to root-cause — noted on the issue.

## Validation
- `tsc --noEmit` ✅, `eslint` ✅

Refs #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling in the inbox view to display a unified prompt for missing or invalid sessions.
  * Optimized inbox data fetching to only execute when necessary, enhancing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->