### PR TITLE
fix(sdk): normalize date-only job proposalDeadline to RFC3339 (closes #159)

### DIFF
--- a/sdk/typescript/src/api/jobs.ts
+++ b/sdk/typescript/src/api/jobs.ts
@@ -8,6 +8,13 @@ import type {
   SelectCandidateResult,
 } from "../types/index.js";
 
+// Backend POST /jobs requires an RFC3339 timestamp; a bare `YYYY-MM-DD` date
+// (e.g. from an `<input type="date">`) must be expanded or it fails with
+// `parsing time "2026-06-20" ... cannot parse`. Full timestamps pass through.
+function toRfc3339Deadline(value: string): string {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00Z` : value;
+}
+
 // JobsApi covers the jobs marketplace: post + fund, browse, apply, candidate
 // selection (which spawns the escrow contract), and the AI-judged dispute flow.
 export class JobsApi {
@@ -27,10 +34,16 @@ export class JobsApi {
   }
 
   create(request: JobCreateRequest): Promise<JobPosting> {
+    const normalized = request.proposalDeadline
+      ? {
+          ...request,
+          proposalDeadline: toRfc3339Deadline(request.proposalDeadline),
+        }
+      : request;
     return this.http.postDirectoryAuthAs<JobPosting>(
       "/jobs",
-      request.client,
-      request,
+      normalized.client,
+      normalized,
     );
   }
 

--- a/sdk/typescript/tests/jobs.test.ts
+++ b/sdk/typescript/tests/jobs.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { LocalSigner, TinyPlaceClient } from "../src/index.js";
+import type { JobCreateRequest } from "../src/index.js";
+
+function jobPostingResponse(proposalDeadline?: string): Record<string, unknown> {
+  return {
+    jobId: "job-1",
+    client: "WalletCrypto111",
+    title: "Build a thing",
+    description: "",
+    budget: { amount: "10", asset: "USDC", chain: "solana" },
+    status: "open",
+    proposalCount: 0,
+    proposalDeadline,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+async function captureCreate(
+  request: JobCreateRequest,
+): Promise<Record<string, unknown>> {
+  const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(5));
+  const requests: Array<Request> = [];
+  const client = new TinyPlaceClient({
+    baseUrl: "https://example.test",
+    signer,
+    fetch: async (input, init) => {
+      const captured = new Request(input, init);
+      requests.push(captured);
+      return Response.json(jobPostingResponse(request.proposalDeadline));
+    },
+  });
+
+  await client.jobs.create(request);
+
+  const sent = requests[0]!;
+  expect(sent.method).toBe("POST");
+  expect(new URL(sent.url).pathname).toBe("/jobs");
+  return (await sent.json()) as Record<string, unknown>;
+}
+
+describe("JobsApi.create", () => {
+  const base: JobCreateRequest = {
+    client: "WalletCrypto111",
+    title: "Build a thing",
+    budget: { amount: "10", asset: "USDC", chain: "solana" },
+  };
+
+  it("expands a date-only proposalDeadline to an RFC3339 timestamp", async () => {
+    const body = await captureCreate({
+      ...base,
+      proposalDeadline: "2026-06-20",
+    });
+    expect(body["proposalDeadline"]).toBe("2026-06-20T00:00:00Z");
+  });
+
+  it("passes a full RFC3339 proposalDeadline through unchanged", async () => {
+    const body = await captureCreate({
+      ...base,
+      proposalDeadline: "2026-06-20T09:30:00Z",
+    });
+    expect(body["proposalDeadline"]).toBe("2026-06-20T09:30:00Z");
+  });
+
+  it("omits proposalDeadline when none is provided", async () => {
+    const body = await captureCreate(base);
+    expect("proposalDeadline" in body).toBe(false);
+  });
+});


### PR DESCRIPTION
## Bug (#159)

Posting a job failed with:
```
HTTP 400: /jobs: parsing time "2026-06-20" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "T"
```

## Root cause

A consumer (OpenHuman) sends `proposalDeadline` as a **date-only** `"2026-06-20"` (e.g. from `<input type="date">`), but the backend `POST /jobs` requires a full **RFC3339** timestamp. `JobsApi.create` forwarded the value unchanged. (The website's own PostJob form doesn't send a deadline, so this had to be fixed in the SDK to cover all consumers.)

## Fix

Normalize in `JobsApi.create`: a bare `YYYY-MM-DD` expands to `${value}T00:00:00Z` (exact RFC3339, no fractional seconds — matches Go's strict layout); full timestamps pass through unchanged.

## Tests

New `tests/jobs.test.ts`: date-only → `...T00:00:00Z`; full RFC3339 unchanged; omitted deadline stays absent.

## Validation
- `tsc --noEmit` (SDK lint) ✅
- `vitest run tests/jobs.test.ts` ✅ (3/3)

Closes #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced proposal deadline handling in job creation. Date-only deadline strings (YYYY-MM-DD format) are now automatically converted to RFC3339 timestamps at midnight UTC for consistent processing, while full RFC3339 timestamps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->