### PR TITLE
fix(profile): scale Volume (USD) from micro-USDC base units

### DIFF
--- a/website/src/common/format-amount.test.ts
+++ b/website/src/common/format-amount.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	formatTokenAmount,
+	formatUsdFromBaseUnits,
 	minorUnitsToDecimal,
 	tokenDecimals,
 } from "@src/common/format-amount";
@@ -41,5 +42,24 @@ describe("formatTokenAmount", () => {
 
 	it("uppercases the asset symbol", () => {
 		expect(formatTokenAmount("1000000", "cash")).toBe("1 CASH");
+	});
+});
+
+describe("formatUsdFromBaseUnits", () => {
+	it("scales 6-decimal base units to a dollar string", () => {
+		// Regression: profile activity volume arrives in micro-USDC; rendering it
+		// behind a literal "$" without scaling showed 1 USDC as "$1000000.00".
+		expect(formatUsdFromBaseUnits("1000000", "USDC")).toBe("$1.00");
+		expect(formatUsdFromBaseUnits("2500000")).toBe("$2.50");
+		expect(formatUsdFromBaseUnits("120000", "USDC")).toBe("$0.12");
+	});
+
+	it("groups thousands and always shows two decimals", () => {
+		expect(formatUsdFromBaseUnits("1234560000")).toBe("$1,234.56");
+		expect(formatUsdFromBaseUnits("0")).toBe("$0.00");
+	});
+
+	it("returns $0.00 for non-finite input", () => {
+		expect(formatUsdFromBaseUnits("not-a-number")).toBe("$0.00");
 	});
 });

--- a/website/src/common/format-amount.ts
+++ b/website/src/common/format-amount.ts
@@ -45,3 +45,20 @@ export function formatTokenAmount(baseUnits: string, asset?: string): string {
 		maximumFractionDigits: decimals,
 	})} ${symbol}`;
 }
+
+/**
+ * Formats a base-unit amount of a USD-pegged asset (USDC/CASH) as a dollar
+ * string, e.g. ("1000000", "USDC") => "$1.00". The backend reports activity
+ * volume in 6-decimal base units, so rendering it behind a literal "$" without
+ * scaling overstates the figure by 10^decimals (1 USDC shows as "$1000000.00").
+ */
+export function formatUsdFromBaseUnits(
+	baseUnits: string,
+	asset?: string
+): string {
+	const dollars = Number(minorUnitsToDecimal(baseUnits, tokenDecimals(asset)));
+	return `$${dollars.toLocaleString(undefined, {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	})}`;
+}

--- a/website/src/components/profile/ProfileActivityPanel.tsx
+++ b/website/src/components/profile/ProfileActivityPanel.tsx
@@ -3,6 +3,7 @@
 import type { AgentProfile, ProfileActivity } from "@tinyhumansai/tinyplace";
 import type { ReactElement } from "react";
 
+import { formatUsdFromBaseUnits } from "@src/common/format-amount";
 import { useProfileActivity } from "@src/hooks/use-profiles";
 
 type ProfileActivityPanelProperties = {
@@ -49,7 +50,7 @@ function ActivityStats({
 			<div>
 				<dt className={`text-xs ${t.muted}`}>Volume (USD)</dt>
 				<dd className={`text-base font-semibold ${t.primary}`}>
-					${activity.totalVolumeUsd}
+					{formatUsdFromBaseUnits(activity.totalVolumeUsd)}
 				</dd>
 			</div>
 			<div>

--- a/website/src/components/profile/ProfileView.tsx
+++ b/website/src/components/profile/ProfileView.tsx
@@ -2,6 +2,8 @@ import type { AgentProfile, ProfileAttestation } from "@tinyhumansai/tinyplace";
 import { CheckBadgeIcon } from "@heroicons/react/24/solid";
 import type { ReactElement, ReactNode } from "react";
 
+import { formatUsdFromBaseUnits } from "@src/common/format-amount";
+
 import { ProfileEntityLink } from "./EntityLink";
 
 /** Human label + external profile URL for a verified external account. */
@@ -314,7 +316,7 @@ export function ProfileView({
 						<div>
 							<dt className={`text-xs ${t.muted}`}>Volume (USD)</dt>
 							<dd className={`text-base font-semibold ${t.primary}`}>
-								${profile.activity.totalVolumeUsd}
+								{formatUsdFromBaseUnits(profile.activity.totalVolumeUsd)}
 							</dd>
 						</div>
 						<div>


### PR DESCRIPTION
## Problem

A profile's **Volume (USD)** stat renders ~10⁶× too large. A single 1 USDC transaction shows as **`$1000000.00`** instead of **`$1.00`**.

`profile.activity.totalVolumeUsd` arrives from the backend in the asset's **6-decimal base units** (micro-USDC), but both profile components interpolate it directly behind a literal `$`:

```tsx
<dd …>${profile.activity.totalVolumeUsd}</dd>   // "1000000" → "$1000000.00"
```

This is exactly the mistake the repo's own `format-amount.ts` header warns against — base units "MUST be divided by 10^decimals before display, or the UI shows a number that is 10^decimals larger".

## Solution

- Add `formatUsdFromBaseUnits(baseUnits, asset?)` to `website/src/common/format-amount.ts`, reusing the existing `minorUnitsToDecimal` + `tokenDecimals` helpers to scale base units to a 2-decimal dollar string (`"1000000" → "$1.00"`).
- Use it in both `Volume (USD)` cells (`ProfileView.tsx`, `ProfileActivityPanel.tsx`) in place of the raw `${…totalVolumeUsd}` interpolation.
- Add regression tests covering the off-by-10⁶ case, thousands grouping, and non-finite input.

## Verification

- `vitest run src/common/format-amount.test.ts` — 9 passed (3 new).
- `tsc --noEmit` (after `pnpm --filter @tinyhumansai/tinyplace build`) — clean.
- `eslint` + `prettier --check` on touched files — clean.
- Pre-push hook (`format && lint && build`) — green.

## Impact

Display-only; no data, API, or type changes. `totalVolumeUsd` keeps its base-unit contract — only the render is corrected. Same helper is reusable for any other USD-pegged base-unit figure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * USD volume amounts are now consistently formatted across profile sections with standardized dollar display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->