### PR TITLE
feat(website): localize the sidebar navigation (refs #131, #138)

### DIFF
--- a/website/src/assets/locales/en/translations.json
+++ b/website/src/assets/locales/en/translations.json
@@ -1,4 +1,24 @@
 {
+	"nav": {
+		"home": "Home",
+		"feed": "Feed",
+		"explore": "Explore",
+		"identities": "Identities",
+		"messaging": "Messaging",
+		"bounties": "Bounties",
+		"reputation": "Reputation",
+		"leaderboards": "Leaderboards",
+		"stats": "Stats",
+		"onramp": "On-ramp / Off-ramp",
+		"storefront": "Storefront",
+		"games": "Games",
+		"feedback": "Feedback",
+		"settings": "Settings",
+		"needAgent": "Need an Agent?",
+		"tryOpenHuman": "Try OpenHuman",
+		"openMenu": "Open menu",
+		"closeMenu": "Close menu"
+	},
 	"common": {
 		"loadMore": "Load more",
 		"loadingMore": "Loading…"

--- a/website/src/assets/locales/es/translations.json
+++ b/website/src/assets/locales/es/translations.json
@@ -1,4 +1,24 @@
 {
+	"nav": {
+		"home": "Inicio",
+		"feed": "Novedades",
+		"explore": "Explorar",
+		"identities": "Identidades",
+		"messaging": "Mensajes",
+		"bounties": "Recompensas",
+		"reputation": "Reputación",
+		"leaderboards": "Clasificaciones",
+		"stats": "Estadísticas",
+		"onramp": "Comprar / Vender",
+		"storefront": "Tienda",
+		"games": "Juegos",
+		"feedback": "Comentarios",
+		"settings": "Ajustes",
+		"needAgent": "¿Necesitas un agente?",
+		"tryOpenHuman": "Prueba OpenHuman",
+		"openMenu": "Abrir menú",
+		"closeMenu": "Cerrar menú"
+	},
 	"common": {
 		"loadMore": "Cargar más",
 		"loadingMore": "Cargando…"

--- a/website/src/components/layout/ExploreShell.tsx
+++ b/website/src/components/layout/ExploreShell.tsx
@@ -16,6 +16,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { usePathname } from "next/navigation";
 import type { ComponentType, ReactNode, SVGProps } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { FunctionComponent } from "@src/common/types";
 import { ActivityMarquee } from "@src/components/ActivityMarquee";
@@ -70,8 +71,15 @@ type ExploreShellProperties = {
 export const ExploreShell = ({
 	children,
 }: ExploreShellProperties): FunctionComponent => {
+	const { t } = useTranslation();
 	const theme = useAppStore((state) => state.theme);
 	const isDark = theme === "dark";
+	// Localize each section's label by its stable key; the hardcoded English
+	// label is the fallback if a translation is missing.
+	const localizedSections = sections.map((section) => ({
+		...section,
+		label: t(`nav.${section.key}`, { defaultValue: section.label }),
+	}));
 	const pathname = usePathname();
 	// The section is the first path segment so a tab sub-route (e.g.
 	// /identities/trading) still highlights its parent section in the sidebar.
@@ -91,7 +99,7 @@ export const ExploreShell = ({
 			<Sidebar
 				activeSection={activeSection}
 				isDark={isDark}
-				sections={sections}
+				sections={localizedSections}
 			/>
 			<main className="relative flex-1 min-h-0 overflow-y-auto">
 				{/* Hero backdrop: anchored to the top of the body, fading out down

--- a/website/src/components/layout/Sidebar.tsx
+++ b/website/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
 } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { type ComponentType, type SVGProps, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { FunctionComponent } from "@src/common/types";
 
@@ -90,6 +91,7 @@ const NavContent = ({
 	sections,
 	onNavigate,
 }: NavContentProps): FunctionComponent => {
+	const { t } = useTranslation();
 	const inactiveClasses = isDark
 		? "text-neutral-500 hover:text-neutral-300"
 		: "text-neutral-500 hover:text-neutral-700";
@@ -148,7 +150,7 @@ const NavContent = ({
 				onClick={onNavigate}
 			>
 				<ChatBubbleOvalLeftEllipsisIcon className="h-3.5 w-3.5 shrink-0" />
-				Feedback
+				{t("nav.feedback")}
 			</Link>
 			<Link
 				href="/settings"
@@ -162,13 +164,13 @@ const NavContent = ({
 				onClick={onNavigate}
 			>
 				<Cog6ToothIcon className="h-3.5 w-3.5 shrink-0" />
-				Settings
+				{t("nav.settings")}
 			</Link>
 			<div
 				className={`my-2 border-t ${isDark ? "border-neutral-800" : "border-neutral-200"}`}
 			/>
 			<p className={`px-2 pb-2 text-center text-xs ${inactiveClasses}`}>
-				Need an Agent?
+				{t("nav.needAgent")}
 			</p>
 			<a
 				className="theme-primary-action rounded-md px-2 py-2 text-center text-xs font-medium transition-colors"
@@ -177,7 +179,7 @@ const NavContent = ({
 				target="_blank"
 				onClick={onNavigate}
 			>
-				Try OpenHuman
+				{t("nav.tryOpenHuman")}
 			</a>
 		</nav>
 	);
@@ -188,6 +190,7 @@ export const Sidebar = ({
 	isDark,
 	sections,
 }: SidebarProps): FunctionComponent => {
+	const { t } = useTranslation();
 	const [isOpen, setIsOpen] = useState(false);
 	const openMenu = (): void => {
 		setIsOpen(true);
@@ -215,7 +218,7 @@ export const Sidebar = ({
 		<>
 			{/* Mobile: hamburger toggle (hidden on md and up) */}
 			<button
-				aria-label="Open menu"
+				aria-label={t("nav.openMenu")}
 				type="button"
 				className={`md:hidden fixed left-2 top-2 z-30 p-2 rounded border transition-colors ${
 					isDark
@@ -231,7 +234,7 @@ export const Sidebar = ({
 			{isOpen && (
 				<div className="md:hidden fixed inset-0 z-40 flex">
 					<button
-						aria-label="Close menu"
+						aria-label={t("nav.closeMenu")}
 						className="absolute inset-0 bg-black/50"
 						type="button"
 						onClick={closeMenu}
@@ -244,7 +247,7 @@ export const Sidebar = ({
 						>
 							{brand}
 							<button
-								aria-label="Close menu"
+								aria-label={t("nav.closeMenu")}
 								className={`p-1 rounded ${isDark ? "text-neutral-400 hover:text-white" : "text-neutral-500 hover:text-black"}`}
 								type="button"
 								onClick={closeMenu}


### PR DESCRIPTION
## Context (#131, #138)

#131: selecting **Español** translated the status-bar footer but the **sidebar nav and main chrome stayed English** — because those labels were hardcoded, not keyed through i18n. This is the most visible part of the report (the screenshot shows the English sidebar).

## Change

- New `nav` namespace in `en/` and `es/` `translations.json` (18 keys each, at parity).
- `ExploreShell` now builds each section's label via `t(\`nav.${key}\`)`, with the hardcoded English label kept as the `defaultValue` fallback.
- `Sidebar` localizes **Feedback**, **Settings**, **"Need an Agent?"**, **"Try OpenHuman"**, and the open/close-menu `aria-label`s. Brand/product names (Docs, Discord, X, GitHub, tiny.place) are intentionally left untranslated.

This is the **first slice** of the broader coverage effort (#138) — it fixes the navigation (highest-visibility surface); deeper explore views can follow the exact same pattern.

## Validation
- EN/ES `nav` keys at parity (18/18)
- `tsc --noEmit` ✅, `eslint` ✅

Refs #131, #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)