### PR TITLE
fix(sdk): sign onboarding grant with v1 signature, not SIWS token

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhumansai/tinyplace",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "license": "GPL-3.0-or-later",
   "description": "SDK for agents to interact with tiny.place",

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -100,7 +100,11 @@ export async function mintOnboardGrant(
     scope,
     wallet,
   });
-  const signature = await signFreshCanonicalPayload(key, payload);
+  // The grant's signature must bind to THIS canonical payload — the server
+  // reconstructs and verifies it. Use the v1-only signer so a SIWS-mode key
+  // does not substitute its reusable sign-in token (which signs a different
+  // message and the verifier rejects as "invalid signature").
+  const signature = await signV1FreshCanonicalPayload(key, payload);
   const grant = `${ONBOARD_TOKEN_PREFIX}${toBase64Url(JSON.stringify(claims))}.${signature}`;
   return onboardCredential(wallet, grant, ownerPublicKeyBase64);
 }
@@ -286,6 +290,22 @@ export async function signFreshCanonicalPayload(
   if (siws) {
     return siws;
   }
+  return signV1FreshCanonicalPayload(key, payload);
+}
+
+/**
+ * Always produces a real `v1:<ts>:<nonce>:<sig>` freshness signature over the
+ * canonical payload, signed with the key itself. Unlike
+ * {@link signFreshCanonicalPayload} it never substitutes a reusable SIWS
+ * sign-in token: callers whose verifier reconstructs and checks the exact
+ * canonical payload (e.g. onboarding-grant minting) must bind the signature to
+ * that payload, and a SIWS proof signs a different "sign in" message that the
+ * verifier would reject as an invalid signature.
+ */
+async function signV1FreshCanonicalPayload(
+  key: SigningKey,
+  payload: string,
+): Promise<string> {
   const timestamp = new Date().toISOString();
   const nonce = generateNonce();
   const payloadBytes = new TextEncoder().encode(

--- a/sdk/typescript/tests/onboard-grant.test.ts
+++ b/sdk/typescript/tests/onboard-grant.test.ts
@@ -9,8 +9,8 @@ import {
 } from "../src/index.js";
 
 function base64UrlToBytes(value: string): Uint8Array {
-  const b64 = value.replace(/-/g, "+").replace(/_/g, "/");
-  return Uint8Array.from(Buffer.from(b64, "base64"));
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  return Uint8Array.from(Buffer.from(base64, "base64"));
 }
 
 describe("onboarding bearer grant", () => {
@@ -60,7 +60,8 @@ describe("onboarding bearer grant", () => {
     // SIWS sign-in token, which signs a different message the backend rejects as
     // "invalid signature" (backend/internal/onboardgrant/onboardgrant.go).
     const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(11));
-    expect(signer.siwsSignature()).not.toBe(""); // SIWS is active on this signer
+    // SIWS is active on this signer (the precondition the fix must survive).
+    expect(signer.siwsSignature().startsWith("siws:")).toBe(true);
 
     const credential = await mintOnboardGrant(
       signer,
@@ -72,7 +73,7 @@ describe("onboarding bearer grant", () => {
     // Token shape: og1.<b64url(claims)>.<signature>
     const rest = credential.grant.slice("og1.".length);
     const dot = rest.indexOf(".");
-    const claimsB64 = rest.slice(0, dot);
+    const claimsBase64Url = rest.slice(0, dot);
     const signature = rest.slice(dot + 1);
     expect(signature.startsWith("v1:")).toBe(true);
     expect(signature.startsWith("siws:")).toBe(false);
@@ -80,7 +81,7 @@ describe("onboarding bearer grant", () => {
     // The v1 signature must verify against the canonical payload the server
     // reconstructs from the claims, with the freshness ts/nonce appended.
     const claims = JSON.parse(
-      Buffer.from(claimsB64, "base64url").toString("utf8"),
+      Buffer.from(claimsBase64Url, "base64url").toString("utf8"),
     ) as {
       wallet: string;
       ownerPublicKey: string;
@@ -93,11 +94,14 @@ describe("onboarding bearer grant", () => {
       scope: claims.scope,
       wallet: claims.wallet,
     });
-    const [, tsB64, nonceB64, sigB64] = signature.split(":");
+    const [, timestampBase64Url, nonceBase64Url, signatureBase64] =
+      signature.split(":");
     const timestamp = Buffer.from(
-      base64UrlToBytes(tsB64!),
+      base64UrlToBytes(timestampBase64Url!),
     ).toString("utf8");
-    const nonce = Buffer.from(base64UrlToBytes(nonceB64!)).toString("utf8");
+    const nonce = Buffer.from(base64UrlToBytes(nonceBase64Url!)).toString(
+      "utf8",
+    );
     const signedBytes = new TextEncoder().encode(
       `${payload}\n${timestamp}\n${nonce}`,
     );
@@ -111,7 +115,7 @@ describe("onboarding bearer grant", () => {
     const valid = await webcrypto.subtle.verify(
       "Ed25519",
       publicKey,
-      Uint8Array.from(Buffer.from(sigB64!, "base64")),
+      Uint8Array.from(Buffer.from(signatureBase64!, "base64")),
       signedBytes,
     );
     expect(valid).toBe(true);

--- a/sdk/typescript/tests/onboard-grant.test.ts
+++ b/sdk/typescript/tests/onboard-grant.test.ts
@@ -1,3 +1,4 @@
+import { webcrypto } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   canonicalPayload,
@@ -6,6 +7,11 @@ import {
   parseOnboardGrant,
   TinyPlaceClient,
 } from "../src/index.js";
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const b64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  return Uint8Array.from(Buffer.from(b64, "base64"));
+}
 
 describe("onboarding bearer grant", () => {
   // Pins the exact bytes the wallet signs. The matching assertion lives in
@@ -46,6 +52,69 @@ describe("onboarding bearer grant", () => {
     // The public key is recovered from the token claims so the web flow can
     // publish a discovery card without holding the private key.
     expect(parsed?.ownerPublicKey).toBe(signer.publicKeyBase64);
+  });
+
+  it("signs the grant with a v1 freshness signature even for a SIWS-mode key", async () => {
+    // LocalSigner defaults to SIWS auth. The grant signature must still be a real
+    // v1 signature bound to the canonical onboard.grant payload — NOT the reusable
+    // SIWS sign-in token, which signs a different message the backend rejects as
+    // "invalid signature" (backend/internal/onboardgrant/onboardgrant.go).
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(11));
+    expect(signer.siwsSignature()).not.toBe(""); // SIWS is active on this signer
+
+    const credential = await mintOnboardGrant(
+      signer,
+      signer.publicKeyBase64,
+      ["user.profile"],
+      15 * 60 * 1000,
+    );
+
+    // Token shape: og1.<b64url(claims)>.<signature>
+    const rest = credential.grant.slice("og1.".length);
+    const dot = rest.indexOf(".");
+    const claimsB64 = rest.slice(0, dot);
+    const signature = rest.slice(dot + 1);
+    expect(signature.startsWith("v1:")).toBe(true);
+    expect(signature.startsWith("siws:")).toBe(false);
+
+    // The v1 signature must verify against the canonical payload the server
+    // reconstructs from the claims, with the freshness ts/nonce appended.
+    const claims = JSON.parse(
+      Buffer.from(claimsB64, "base64url").toString("utf8"),
+    ) as {
+      wallet: string;
+      ownerPublicKey: string;
+      scope: Array<string>;
+      expiresAt: string;
+    };
+    const payload = canonicalPayload("onboard.grant", {
+      expiresAt: claims.expiresAt,
+      ownerPublicKey: claims.ownerPublicKey,
+      scope: claims.scope,
+      wallet: claims.wallet,
+    });
+    const [, tsB64, nonceB64, sigB64] = signature.split(":");
+    const timestamp = Buffer.from(
+      base64UrlToBytes(tsB64!),
+    ).toString("utf8");
+    const nonce = Buffer.from(base64UrlToBytes(nonceB64!)).toString("utf8");
+    const signedBytes = new TextEncoder().encode(
+      `${payload}\n${timestamp}\n${nonce}`,
+    );
+    const publicKey = await webcrypto.subtle.importKey(
+      "raw",
+      signer.publicKey,
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    const valid = await webcrypto.subtle.verify(
+      "Ed25519",
+      publicKey,
+      Uint8Array.from(Buffer.from(sigB64!, "base64")),
+      signedBytes,
+    );
+    expect(valid).toBe(true);
   });
 
   it("attaches the bearer header and omits the body signature on onboarding writes", async () => {


### PR DESCRIPTION
## Symptom

Onboarding via the CLI fails at email verification with **`invalid signature`**. The grant in the `#grant=…` fragment carries a `siws:` token in its signature slot instead of a `v1:` freshness signature.

## Root cause

`mintOnboardGrant` (`sdk/typescript/src/auth.ts`) signed the grant via `signFreshCanonicalPayload`, which **short-circuits to the reusable SIWS sign-in token** for SIWS-mode keys:

```ts
const siws = siwsSignature(key);
if (siws) return siws;   // ignores the payload entirely
```

Since `LocalSigner` now **defaults to SIWS**, every CLI-minted grant got a SIWS proof in the signature slot. But that token signs the `"tiny.place wants you to sign in…"` message — **not** the canonical `onboard.grant` payload the backend reconstructs and verifies (`internal/onboardgrant/onboardgrant.go` → `VerifyFreshSignatureNoReplay`, which expects `v1:<ts>:<nonce>:<sig>`). Mismatched message ⇒ `ErrInvalidSignature`.

Verified by decoding a real failing grant: `wallet`, `ownerPublicKey`, and the SIWS account line are the **same** Ed25519 key (no key mismatch), and the SIWS signature does not verify against the canonical `onboard.grant` payload.

## Fix

- Add `signV1FreshCanonicalPayload`, which always emits a real `v1:<ts>:<nonce>:<sig>` signature bound to the payload, and use it in `mintOnboardGrant`.
- `signFreshCanonicalPayload` stays SIWS-aware for ordinary request auth, where the SIWS token is the intended credential.
- Bump SDK to **0.10.1**.

## Test

New regression test in `tests/onboard-grant.test.ts` mints a grant with a SIWS-mode key and asserts the signature segment is `v1:` (not `siws:`) **and** cryptographically verifies against the canonical payload. **Red→green confirmed** (fails before the fix, passes after); `tsc --noEmit` clean; all grant tests green.

## User impact

Wallet keys are unaffected (the bug was only in grant *minting*). After this ships to npm, re-running `tinyplace init` produces a working onboarding link; existing grants must be re-minted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding grant freshness-signature generation to ensure the minted onboarding grant token binds correctly to its canonical payload, including when using SIWS-mode keys.
* **Tests**
  * Added verification coverage to confirm the onboarding grant signature uses the expected `v1:` freshness format and validates correctly against reconstructed canonical payload bytes.
* **Chores**
  * Updated the SDK TypeScript package version to `0.10.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->