### PR TITLE
test(sdk): use raw v1 signers for canonical-payload assertions (unblock publish)

### DIFF
--- a/sdk/typescript/tests/marketplace.test.ts
+++ b/sdk/typescript/tests/marketplace.test.ts
@@ -145,7 +145,7 @@ describe("MarketplaceApi", () => {
   });
 
   it("opens marketplace streams with directory query auth", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(18));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(18), { siws: false });
     const openedUrls: Array<string> = [];
     const originalWebSocket = globalThis.WebSocket;
 
@@ -202,7 +202,7 @@ describe("MarketplaceApi", () => {
   });
 
   it("signs product reviews with a client-generated review ID", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(11));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(11), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -271,7 +271,7 @@ describe("MarketplaceApi", () => {
 
   it("buys products with Solana x402 pinned to the listing price and seller", async () => {
     const seed = new Uint8Array(32).fill(23);
-    const signer = await LocalSigner.fromSeed(seed);
+    const signer = await LocalSigner.fromSeed(seed, { siws: false });
     const secretKey = new Uint8Array(64);
     secretKey.set(seed, 0);
     secretKey.set(signer.publicKey, 32);
@@ -388,7 +388,7 @@ describe("MarketplaceApi", () => {
 
   it("buys identity listings with Solana x402 pinned to listing price and seller", async () => {
     const seed = new Uint8Array(32).fill(24);
-    const signer = await LocalSigner.fromSeed(seed);
+    const signer = await LocalSigner.fromSeed(seed, { siws: false });
     const secretKey = new Uint8Array(64);
     secretKey.set(seed, 0);
     secretKey.set(signer.publicKey, 32);
@@ -523,7 +523,7 @@ describe("MarketplaceApi", () => {
   });
 
   it("creates identity offers with an upto Solana x402 authorization", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(25));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(25), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -618,7 +618,7 @@ describe("MarketplaceApi", () => {
   });
 
   it("places identity bids with an upto Solana x402 authorization", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(26));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(26), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -740,7 +740,7 @@ describe("MarketplaceApi", () => {
   });
 
   it("signs product lifecycle requests with marketplace actors", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(14));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(14), { siws: false });
     const requests: Array<Request> = [];
     const price = { amount: "7", asset: "USDC", network: "eip155:8453" };
     const client = new TinyPlaceClient({
@@ -880,7 +880,7 @@ describe("MarketplaceApi", () => {
   });
 
   it("signs product delivery reads and fulfillment as the delivery actor", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(15));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(15), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -941,7 +941,7 @@ describe("MarketplaceApi", () => {
   });
 
   it("signs identity listing, purchase, and bid payloads", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(12));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(12), { siws: false });
     const requests: Array<Request> = [];
     const price = { amount: "10", asset: "USDC", network: "eip155:8453" };
     const client = new TinyPlaceClient({
@@ -1048,7 +1048,7 @@ describe("MarketplaceApi", () => {
   });
 
   it("signs identity offers and offer lifecycle requests", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(13));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(13), { siws: false });
     const requests: Array<Request> = [];
     const price = { amount: "12", asset: "USDC", network: "eip155:8453" };
     const client = new TinyPlaceClient({

--- a/sdk/typescript/tests/registry.test.ts
+++ b/sdk/typescript/tests/registry.test.ts
@@ -58,7 +58,7 @@ async function verifyFreshSignature(
 
 describe("RegistryApi", () => {
   it("signs registration over cryptoId, publicKey, username and null payment methods", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(19));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(19), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -109,7 +109,7 @@ describe("RegistryApi", () => {
   });
 
   it("presents the signing key so the backend can authorize a delegated session key", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(29));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(29), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -143,7 +143,7 @@ describe("RegistryApi", () => {
   });
 
   it("forwards actorType and primary unsigned and omits them from the signature", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(21));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(21), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -195,7 +195,7 @@ describe("RegistryApi", () => {
   });
 
   it("signs assign and unassign primary requests", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(22));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(22), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -247,7 +247,7 @@ describe("RegistryApi", () => {
   });
 
   it("normalizes bare registration names before signing", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(20));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(20), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -294,7 +294,7 @@ describe("RegistryApi", () => {
 
   it("executes and retries paid Solana registrations", async () => {
     const seed = new Uint8Array(32).fill(22);
-    const signer = await LocalSigner.fromSeed(seed);
+    const signer = await LocalSigner.fromSeed(seed, { siws: false });
     const secretKey = new Uint8Array(64);
     secretKey.set(seed, 0);
     secretKey.set(signer.publicKey, 32);
@@ -446,7 +446,7 @@ describe("RegistryApi", () => {
 
   it("uses x402 payment challenges for paid Solana registrations", async () => {
     const seed = new Uint8Array(32).fill(23);
-    const signer = await LocalSigner.fromSeed(seed);
+    const signer = await LocalSigner.fromSeed(seed, { siws: false });
     const secretKey = new Uint8Array(64);
     secretKey.set(seed, 0);
     secretKey.set(signer.publicKey, 32);
@@ -596,7 +596,7 @@ describe("RegistryApi", () => {
 
   it("recovers paid registrations that persist before a server error", async () => {
     const seed = new Uint8Array(32).fill(24);
-    const signer = await LocalSigner.fromSeed(seed);
+    const signer = await LocalSigner.fromSeed(seed, { siws: false });
     const secretKey = new Uint8Array(64);
     secretKey.set(seed, 0);
     secretKey.set(signer.publicKey, 32);
@@ -719,7 +719,7 @@ describe("RegistryApi", () => {
   });
 
   it("retries registration with an existing Solana transaction without resending payment", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(25));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(25), { siws: false });
     const registryRequests: Array<Request> = [];
     const onChainTx =
       "5q22im1eoEeoJMhsshDkoh4tNV1WPUfyaJXHwyGqcpfmtpY1ZCC665nc5chyEwwau4JoR7BUnCbxWn5BW5WzR3NC";
@@ -788,7 +788,7 @@ describe("RegistryApi", () => {
   });
 
   it("preserves existing Solana payment details on registration failures", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(26));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(26), { siws: false });
     const onChainTx =
       "5q22im1eoEeoJMhsshDkoh4tNV1WPUfyaJXHwyGqcpfmtpY1ZCC665nc5chyEwwau4JoR7BUnCbxWn5BW5WzR3NC";
     const client = new TinyPlaceClient({
@@ -834,7 +834,7 @@ describe("RegistryApi", () => {
 
   it("preserves fresh Solana payment details on registration failures", async () => {
     const seed = new Uint8Array(32).fill(27);
-    const signer = await LocalSigner.fromSeed(seed);
+    const signer = await LocalSigner.fromSeed(seed, { siws: false });
     const secretKey = new Uint8Array(64);
     secretKey.set(seed, 0);
     secretKey.set(signer.publicKey, 32);
@@ -984,7 +984,7 @@ describe("RegistryApi", () => {
   });
 
   it("signs registration payment methods in backend struct field order", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(21));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(21), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -1095,7 +1095,7 @@ describe("RegistryApi", () => {
   });
 
   it("signs profile visibility updates with null omitted fields", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(16));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(16), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -1157,7 +1157,7 @@ describe("RegistryApi", () => {
   });
 
   it("treats renewal and auction claim responses as identities", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(17));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(17), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -1195,7 +1195,7 @@ describe("RegistryApi", () => {
   });
 
   it("sends subname delete ownership signatures in the header", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(18));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(18), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",

--- a/sdk/typescript/tests/reputation.test.ts
+++ b/sdk/typescript/tests/reputation.test.ts
@@ -101,7 +101,7 @@ describe("ReputationApi", () => {
   });
 
   it("signs review, vouch, and attestation create requests", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(14));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(14), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -205,7 +205,7 @@ describe("ReputationApi", () => {
   });
 
   it("signs vouch and attestation revocations in the query string", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(15));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(15), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",

--- a/sdk/typescript/tests/users.test.ts
+++ b/sdk/typescript/tests/users.test.ts
@@ -32,7 +32,7 @@ describe("UsersApi", () => {
   });
 
   it("signs a profile update over the canonical user.profile payload", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(7));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(7), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -86,7 +86,7 @@ describe("UsersApi", () => {
     // Regression: the backend's canonical user.profile payload includes the
     // wallet-level `private` flag. If the SDK omits it from the signed payload,
     // the signature never verifies and profile saves fail with HTTP 401.
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(9));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(9), { siws: false });
     let captured: Request | undefined;
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -134,7 +134,7 @@ describe("UsersApi", () => {
   });
 
   it("starts and confirms email verification with signed wallet-scoped payloads", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(8));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(8), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",
@@ -196,7 +196,7 @@ describe("UsersApi", () => {
   });
 
   it("re-signs email verification when the backend rejects a stale signature", async () => {
-    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(10));
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(10), { siws: false });
     const requests: Array<Request> = [];
     const client = new TinyPlaceClient({
       baseUrl: "https://example.test",


### PR DESCRIPTION
## Why

The **Publish TypeScript SDK** workflow runs the SDK test suite before publishing, and it's been **red since `dbf9d64` ("default LocalSigner to SIWS auth")** — so **0.10.1 never reached npm** (including the onboarding-grant fix from #172). Until this is green, `tinyplace init` keeps installing the old CLI.

## Root cause

18 tests across `marketplace` / `registry` / `reputation` / `users` decode a `v1:<ts>:<nonce>:<sig>` **request** signature and verify it against the reconstructed canonical payload. Once `LocalSigner` defaulted to SIWS, requests carry a reusable `siws:` token instead of a per-request signature, so the assertions failed (and a couple surfaced as `fromBase64 InvalidCharacterError` from decoding a siws token as a v1 signature).

This is pre-existing test debt from the SIWS-default flip, unrelated to the product behavior — SIWS request auth works against the backend.

## Fix

Construct the affected signers with `{ siws: false }` so they exercise the raw `v1` path the assertions check (matching the existing `tests/x402.test.ts` pattern). No production code changes; SIWS remains the request-auth default.

## Validation

`pnpm --filter @tinyhumansai/tinyplace test` → **267 passed, 0 failed** (was 18 failed); `tsc --noEmit` clean.

Once merged, the publish workflow should go green and ship 0.10.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suites across marketplace, registry, reputation, and users modules to ensure consistent signer initialization patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->