### PR TITLE
build: exclude all Rust target dirs from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,10 @@ website/playwright-report
 website/storybook-static
 
 # Rust / Anchor build artifacts (large, not needed for the web build).
+# Match every Cargo/Anchor target dir anywhere in the tree — the Rust SDK
+# (sdk/rust/target) alone is tens of GB and was previously shipped to the
+# daemon on every build, dominating the build-context transfer.
+**/target
 contracts-sol/target
 fuzz/target
 


### PR DESCRIPTION
## Summary

The Docker build context for the web image was ballooning to **~30GB** because `sdk/rust/target` (the Rust SDK's Cargo build dir, ~28GB on its own) was being shipped to the daemon on **every** image build. `.dockerignore` only excluded `contracts-sol/target` and `fuzz/target`; the Rust SDK target dir (added later) was never ignored.

This adds `**/target` so no Cargo/Anchor build artifacts ever enter the web image build context.

## Impact

- Build-context transfer drops from ~30GB to ~1GB — dramatically faster `docker compose up --build` / image builds.
- No effect on the produced image (target dirs are never needed for the Next.js/web build) or on CI lint/format/typecheck/unit/build.

## Test plan

- `docker compose up --build` (full local stack): build context transfer no longer ships the multi-GB Rust target dir; image builds as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build performance by excluding build artifact directories from the build context, reducing transfer volume during image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->