### PR TITLE
Backward-compatible, resilient SDKs (TS/Rust/Python)

### DIFF
--- a/sdk/python/src/tinyplace/__init__.py
+++ b/sdk/python/src/tinyplace/__init__.py
@@ -18,7 +18,8 @@ from .crypto import (
     public_key_to_solana_address,
     sha256_hex,
 )
-from .http import PaymentChallenge, PaymentRequiredChallenge, TinyPlaceError
+from .http import PaymentChallenge, PaymentRequiredChallenge, RetryOptions, TinyPlaceError
+from .safe import as_bool, as_dict, as_int, as_list, as_str, field, list_field
 from .signer import LocalSigner, Signer
 from .solana import (
     SOLANA_MAINNET_NETWORK,
@@ -49,6 +50,7 @@ __all__ = [
     "LocalSigner",
     "PaymentChallenge",
     "PaymentRequiredChallenge",
+    "RetryOptions",
     "SOLANA_MAINNET_NETWORK",
     "SOLANA_NATIVE_ASSET",
     "SOLANA_USDC_MINT",
@@ -57,6 +59,13 @@ __all__ = [
     "Signer",
     "TinyPlaceClient",
     "TinyPlaceError",
+    "as_bool",
+    "as_dict",
+    "as_int",
+    "as_list",
+    "as_str",
+    "field",
+    "list_field",
     "build_canonical_message",
     "build_auth_header",
     "build_x402_payment_authorization",

--- a/sdk/python/src/tinyplace/api/graphql.py
+++ b/sdk/python/src/tinyplace/api/graphql.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ..http import HttpClient
+from ..safe import field, list_field
 from ..types import Json
 
 # Co-located GraphQL query documents for the read-only gateway. Each query
@@ -572,7 +573,7 @@ class GraphQLApi:
             {"limit": limit, "offset": offset, "includeSelf": include_self},
             auth="agent",
         )
-        return data["homeFeed"]
+        return field(data, "homeFeed")
 
     async def post_comments(
         self,
@@ -586,7 +587,7 @@ class GraphQLApi:
             POST_COMMENTS_QUERY,
             {"postId": post_id, "feedId": feed_id, "limit": limit, "after": after},
         )
-        return data["comments"]
+        return list_field(data, "comments")
 
     async def posts(
         self,
@@ -600,7 +601,7 @@ class GraphQLApi:
             USER_POSTS_QUERY,
             {"handle": handle, "limit": limit, "before": before, "viewer": viewer},
         )
-        return data["posts"]
+        return field(data, "posts")
 
     async def post(
         self,
@@ -625,7 +626,7 @@ class GraphQLApi:
                 "likerOffset": liker_offset,
             },
         )
-        return data["post"]
+        return field(data, "post")
 
     async def post_likers(
         self,
@@ -638,32 +639,32 @@ class GraphQLApi:
             POST_LIKERS_QUERY,
             {"postId": post_id, "limit": limit, "offset": offset},
         )
-        return data["postLikers"]
+        return field(data, "postLikers")
 
     async def profile(self, username: str) -> Json:
         """A wallet profile resolved from an @handle, attestations embedded. Public."""
         data = await self._http.graphql(USER_PROFILE_QUERY, {"username": username})
-        return data["profile"]
+        return field(data, "profile")
 
     async def user(self, crypto_id: str) -> Json:
         """A wallet profile by raw crypto ID, including owned identities. Public."""
         data = await self._http.graphql(USER_BY_CRYPTO_ID_QUERY, {"cryptoId": crypto_id})
-        return data["user"]
+        return field(data, "user")
 
     async def identity(self, username: str) -> Json:
         """A single @handle identity record, optionally with owner details. Public."""
         data = await self._http.graphql(IDENTITY_QUERY, {"username": username})
-        return data["identity"]
+        return field(data, "identity")
 
     async def identities(self, crypto_id: str) -> Json:
         """All identities owned by a wallet crypto ID. Public."""
         data = await self._http.graphql(IDENTITIES_QUERY, {"cryptoId": crypto_id})
-        return data["identities"]
+        return list_field(data, "identities")
 
     async def agent_card(self, agent_id: str) -> Json:
         """A single agent directory card. Public."""
         data = await self._http.graphql(AGENT_CARD_QUERY, {"id": agent_id})
-        return data["agentCard"]
+        return field(data, "agentCard")
 
     async def products(
         self,
@@ -692,12 +693,12 @@ class GraphQLApi:
                 "offset": offset,
             },
         )
-        return data["products"]
+        return field(data, "products")
 
     async def product(self, product_id: str) -> Json:
         """A single marketplace product with seller embedded. Public."""
         data = await self._http.graphql(PRODUCT_QUERY, {"id": product_id})
-        return data["product"]
+        return field(data, "product")
 
     async def identity_listings(
         self,
@@ -730,7 +731,7 @@ class GraphQLApi:
                 "offset": offset,
             },
         )
-        return data["identityListings"]
+        return field(data, "identityListings")
 
     async def identity_listing(
         self,
@@ -751,7 +752,7 @@ class GraphQLApi:
                 "historyOffset": history_offset,
             },
         )
-        return data["identityListing"]
+        return field(data, "identityListing")
 
     async def identity_bids(
         self,
@@ -764,7 +765,7 @@ class GraphQLApi:
             IDENTITY_BIDS_QUERY,
             {"listingId": listing_id, "limit": limit, "offset": offset},
         )
-        return data["identityBids"]
+        return field(data, "identityBids")
 
     async def identity_offers(
         self,
@@ -787,7 +788,7 @@ class GraphQLApi:
                 "offset": offset,
             },
         )
-        return data["identityOffers"]
+        return field(data, "identityOffers")
 
     async def identity_sales(
         self,
@@ -800,7 +801,7 @@ class GraphQLApi:
             IDENTITY_SALES_QUERY,
             {"name": name, "limit": limit, "offset": offset},
         )
-        return data["identitySales"]
+        return field(data, "identitySales")
 
     async def jobs(
         self,
@@ -823,12 +824,12 @@ class GraphQLApi:
                 "offset": offset,
             },
         )
-        return data["jobs"]
+        return field(data, "jobs")
 
     async def job(self, job_id: str) -> Json:
         """A single bounty/job with client profile embedded. Public."""
         data = await self._http.graphql(JOB_QUERY, {"id": job_id})
-        return data["job"]
+        return field(data, "job")
 
     async def ledger_transactions(
         self,
@@ -863,12 +864,12 @@ class GraphQLApi:
                 "offset": offset,
             },
         )
-        return data["ledgerTransactions"]
+        return field(data, "ledgerTransactions")
 
     async def ledger_transaction(self, transaction_id: str) -> Json:
         """A single ledger transaction. Public."""
         data = await self._http.graphql(LEDGER_TRANSACTION_QUERY, {"id": transaction_id})
-        return data["ledgerTransaction"]
+        return field(data, "ledgerTransaction")
 
     async def bounties(
         self,
@@ -882,9 +883,9 @@ class GraphQLApi:
             BOUNTIES_QUERY,
             {"status": status, "creator": creator, "limit": limit, "offset": offset},
         )
-        return data["bounties"]
+        return list_field(data, "bounties")
 
     async def bounty(self, bounty_id: str) -> Json:
         """A single bounty by id. Public."""
         data = await self._http.graphql(BOUNTY_QUERY, {"id": bounty_id})
-        return data["bounty"]
+        return field(data, "bounty")

--- a/sdk/python/src/tinyplace/client.py
+++ b/sdk/python/src/tinyplace/client.py
@@ -28,7 +28,7 @@ from .api import (
     SearchApi,
 )
 from .auth import AdminSigningOptions
-from .http import AuthInvalidHook, HttpClient
+from .http import AuthInvalidHook, HttpClient, RetryOptions
 from .signer import Signer
 from .types import Json, JsonDict
 
@@ -43,6 +43,8 @@ class TinyPlaceClient:
         admin: AdminSigningOptions | None = None,
         session: aiohttp.ClientSession | None = None,
         on_auth_invalid: AuthInvalidHook | None = None,
+        timeout: float | None = None,
+        retry: RetryOptions | None = None,
     ) -> None:
         self._signer = signer
         self.http = HttpClient(
@@ -52,6 +54,8 @@ class TinyPlaceClient:
             admin=admin,
             session=session,
             on_auth_invalid=on_auth_invalid,
+            timeout=timeout,
+            retry=retry,
         )
         self.registry = RegistryApi(self.http, signer)
         self.keys = KeysApi(self.http)

--- a/sdk/python/src/tinyplace/http.py
+++ b/sdk/python/src/tinyplace/http.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
+import random
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 from urllib.parse import quote, urlencode
@@ -13,6 +15,50 @@ from .signer import Signer
 from .types import Headers, Json, JsonDict, Query
 
 AuthInvalidHook = Callable[[int, Json], None]
+
+#: Default per-request timeout in seconds when none is configured.
+DEFAULT_TIMEOUT = 30.0
+
+
+@dataclass(frozen=True)
+class RetryOptions:
+    """Controls automatic retry-with-backoff for transient failures.
+
+    To avoid silently duplicating a write, only idempotent methods are retried
+    by default.
+    """
+
+    #: Max retry attempts after the first try. ``0`` disables retries.
+    retries: int = 2
+    #: Base backoff delay in seconds (exponential, with jitter).
+    base_delay: float = 0.2
+    #: Upper bound on a single backoff delay in seconds.
+    max_delay: float = 5.0
+    #: HTTP statuses treated as transient.
+    retryable_statuses: frozenset[int] = frozenset({408, 429, 500, 502, 503, 504})
+    #: HTTP methods eligible for retry (idempotent reads only by default).
+    retry_methods: frozenset[str] = frozenset({"GET", "HEAD", "OPTIONS"})
+    #: Retry connection-level failures (timeout, refused, DNS) for eligible methods.
+    retry_network_errors: bool = True
+
+
+def _backoff_delay(retry: RetryOptions, attempt: int) -> float:
+    """Exponential backoff (capped) with half jitter for ``attempt``."""
+    ceiling = min(retry.max_delay, retry.base_delay * (2**attempt))
+    half = ceiling / 2
+    return half + random.random() * half
+
+
+def _retry_after_delay(response: Any) -> float | None:
+    """Parse a ``Retry-After`` header (delta-seconds form) into seconds."""
+    headers = getattr(response, "headers", None) or {}
+    value = headers.get("Retry-After") or headers.get("retry-after")
+    if not value:
+        return None
+    try:
+        return max(0.0, float(str(value).strip()))
+    except ValueError:
+        return None
 
 
 @dataclass(frozen=True)
@@ -62,6 +108,8 @@ class HttpClient:
         admin: AdminSigningOptions | None = None,
         session: aiohttp.ClientSession | None = None,
         on_auth_invalid: AuthInvalidHook | None = None,
+        timeout: float | None = None,
+        retry: RetryOptions | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.signer = signer
@@ -71,6 +119,8 @@ class HttpClient:
         self._session = session
         self._owns_session = session is None
         self._on_auth_invalid = on_auth_invalid
+        self._timeout = DEFAULT_TIMEOUT if timeout is None else timeout
+        self._retry = retry or RetryOptions()
 
     async def close(self) -> None:
         if self._session and self._owns_session:
@@ -203,19 +253,50 @@ class HttpClient:
         request_uri = f"{path}{query_string}"
         url = f"{self.base_url}{request_uri}"
         body_text = "" if body is None else json.dumps(body, separators=(",", ":"))
-        request_headers = {"Content-Type": "application/json", **(headers or {})}
 
-        await self._apply_auth(request_headers, auth, method, request_uri, body_text, actor)
-        session = self._get_session()
-        response = await session.request(
-            method,
-            url,
-            headers=request_headers,
-            data=body_text or None,
-        )
+        retry = self._retry
+        eligible = retry.retries > 0 and method.upper() in retry.retry_methods
+        attempt = 0
+        while True:
+            # Re-sign on every attempt so retries carry a fresh timestamp/nonce
+            # and are never rejected as a replay.
+            request_headers = {"Content-Type": "application/json", **(headers or {})}
+            await self._apply_auth(
+                request_headers, auth, method, request_uri, body_text, actor
+            )
+            session = self._get_session()
+            try:
+                response = await session.request(
+                    method,
+                    url,
+                    headers=request_headers,
+                    data=body_text or None,
+                    **self._timeout_kwargs(),
+                )
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                # Connection-level failure (timeout, refused, DNS): retry eligible
+                # idempotent methods, otherwise surface a typed error so callers
+                # see one error type whether or not the backend answered.
+                if eligible and attempt < retry.retries and retry.retry_network_errors:
+                    await asyncio.sleep(_backoff_delay(retry, attempt))
+                    attempt += 1
+                    continue
+                raise TinyPlaceError(
+                    0, str(exc), f"Request to {path} failed: {exc}"
+                ) from exc
 
-        if response.status < 200 or response.status >= 300:
-            await self._raise_error(path, response)
+            if response.status < 200 or response.status >= 300:
+                if (
+                    eligible
+                    and attempt < retry.retries
+                    and response.status in retry.retryable_statuses
+                ):
+                    delay = _retry_after_delay(response) or _backoff_delay(retry, attempt)
+                    await asyncio.sleep(delay)
+                    attempt += 1
+                    continue
+                await self._raise_error(path, response)
+            break
 
         if response.status == 204:
             return None
@@ -274,6 +355,12 @@ class HttpClient:
         if self._session is None:
             self._session = aiohttp.ClientSession()
         return self._session
+
+    def _timeout_kwargs(self) -> dict[str, Any]:
+        """Per-request timeout kwargs for ``session.request`` (empty if disabled)."""
+        if self._timeout and self._timeout > 0:
+            return {"timeout": aiohttp.ClientTimeout(total=self._timeout)}
+        return {}
 
 
 def encode(value: str) -> str:

--- a/sdk/python/src/tinyplace/safe.py
+++ b/sdk/python/src/tinyplace/safe.py
@@ -1,0 +1,64 @@
+"""Defensive response accessors.
+
+The backend owns response shapes, but the SDK should never raise a ``KeyError``
+or ``TypeError`` at a caller because a field was renamed, omitted, sent as
+``null``, or sent with the wrong type. A list selector that used to read an array
+should degrade to ``[]`` rather than blowing up. These helpers coerce untrusted
+JSON into the expected shape with a safe fallback, mirroring the TS SDK's
+``safe.ts`` and the Rust SDK's ``#[serde(default)]`` tolerance.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def as_list(value: Any) -> list[Any]:
+    """Return ``value`` if it is a list, else ``[]``."""
+    return value if isinstance(value, list) else []
+
+
+def as_dict(value: Any) -> dict[str, Any]:
+    """Return ``value`` if it is a dict, else ``{}``."""
+    return value if isinstance(value, dict) else {}
+
+
+def as_str(value: Any, fallback: str = "") -> str:
+    """Return ``value`` if it is a string, else ``fallback``."""
+    return value if isinstance(value, str) else fallback
+
+
+def as_int(value: Any, fallback: int = 0) -> int:
+    """Coerce ``value`` to an int (accepting numeric strings), else ``fallback``."""
+    if isinstance(value, bool):
+        return fallback
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return fallback
+    return fallback
+
+
+def as_bool(value: Any, fallback: bool = False) -> bool:
+    """Return ``value`` if it is a bool, else ``fallback``."""
+    return value if isinstance(value, bool) else fallback
+
+
+def list_field(response: Any, key: str) -> list[Any]:
+    """Read ``response[key]`` as a list.
+
+    Returns ``[]`` when ``response`` is not a dict, the key is absent, the value
+    is ``None``, or the value is not a list — the workhorse for list endpoints
+    whose envelope is ``{ "<key>": [...] }``.
+    """
+    return as_list(as_dict(response).get(key))
+
+
+def field(response: Any, key: str, fallback: Any = None) -> Any:
+    """Read ``response[key]``, or ``fallback`` when ``response`` isn't a dict."""
+    return as_dict(response).get(key, fallback)

--- a/sdk/python/tests/test_backward_compat.py
+++ b/sdk/python/tests/test_backward_compat.py
@@ -1,0 +1,74 @@
+"""Backward-compatibility tests: GraphQL selectors and safe accessors must
+tolerate backend shape drift (missing/null/renamed fields) instead of raising.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tinyplace import (
+    TinyPlaceClient,
+    as_int,
+    as_list,
+    field,
+    list_field,
+)
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(body: Any) -> TinyPlaceClient:
+    return TinyPlaceClient(
+        base_url="https://example.test",
+        session=FakeSession([FakeResponse(200, body)]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_graphql_bare_list_returns_empty_when_data_missing() -> None:
+    # `data` entirely absent from the GraphQL envelope.
+    client = _client({})
+    assert await client.graphql.bounties() == []
+
+
+@pytest.mark.asyncio
+async def test_graphql_bare_list_returns_empty_when_field_null() -> None:
+    client = _client({"data": {"bounties": None}})
+    assert await client.graphql.bounties() == []
+
+
+@pytest.mark.asyncio
+async def test_graphql_bare_list_returns_empty_when_renamed() -> None:
+    client = _client({"data": {"renamedField": [{"id": 1}]}})
+    assert await client.graphql.identities("crypto-1") == []
+
+
+@pytest.mark.asyncio
+async def test_graphql_object_returns_none_when_missing() -> None:
+    client = _client({"data": {}})
+    assert await client.graphql.profile("@nobody") is None
+
+
+@pytest.mark.asyncio
+async def test_graphql_envelope_returns_none_when_missing() -> None:
+    # An envelope field (`{count, jobs}`) returns None rather than raising when
+    # the backend omits it.
+    client = _client({"data": {}})
+    assert await client.graphql.jobs() is None
+
+
+def test_safe_accessors_coerce() -> None:
+    assert as_list(None) == []
+    assert as_list("x") == []
+    assert as_list([1, 2]) == [1, 2]
+    assert list_field({"a": [1]}, "a") == [1]
+    assert list_field({"a": None}, "a") == []
+    assert list_field(None, "a") == []
+    assert field({"a": 1}, "a") == 1
+    assert field(None, "a") is None
+    assert field("not-a-dict", "a", fallback=5) == 5
+    assert as_int("12") == 12
+    assert as_int("nope", fallback=-1) == -1
+    assert as_int(True) == 0

--- a/sdk/python/tests/test_resilience.py
+++ b/sdk/python/tests/test_resilience.py
@@ -1,0 +1,118 @@
+"""Transport-resilience tests: retry-with-backoff and timeout typing."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import aiohttp
+import pytest
+
+from tinyplace import RetryOptions, TinyPlaceClient, TinyPlaceError
+
+from .helpers import FakeResponse, FakeSession
+
+
+def _client(session: Any, **kw: Any) -> TinyPlaceClient:
+    return TinyPlaceClient(
+        base_url="https://example.test",
+        session=session,
+        retry=kw.pop("retry", RetryOptions(base_delay=0.001, max_delay=0.002)),
+        **kw,
+    )
+
+
+class RaisingSession:
+    """A session whose ``request`` raises, optionally succeeding after N calls."""
+
+    def __init__(self, exc: BaseException, succeed_on: int | None = None) -> None:
+        self._exc = exc
+        self._succeed_on = succeed_on
+        self.calls = 0
+        self.closed = False
+
+    async def request(self, *_a: Any, **_k: Any) -> FakeResponse:
+        self.calls += 1
+        if self._succeed_on is not None and self.calls >= self._succeed_on:
+            return FakeResponse(200, {"ok": True})
+        raise self._exc
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_retries_idempotent_get_on_503_then_succeeds() -> None:
+    session = FakeSession(
+        [
+            FakeResponse(503, "down"),
+            FakeResponse(503, "down"),
+            FakeResponse(200, {"agents": []}),
+        ]
+    )
+    client = _client(session, retry=RetryOptions(retries=3, base_delay=0.001, max_delay=0.002))
+    result = await client.directory.list_agents()
+    assert result == {"agents": []}
+    assert len(session.requests) == 3
+
+
+@pytest.mark.asyncio
+async def test_gives_up_after_configured_retries() -> None:
+    session = FakeSession([FakeResponse(500, "boom") for _ in range(5)])
+    client = _client(session, retry=RetryOptions(retries=2, base_delay=0.001, max_delay=0.002))
+    with pytest.raises(TinyPlaceError) as info:
+        await client.directory.list_agents()
+    assert info.value.status == 500
+    assert len(session.requests) == 3  # 1 initial + 2 retries
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_a_non_idempotent_write() -> None:
+    session = FakeSession([FakeResponse(503, "down")])
+    client = _client(session, retry=RetryOptions(retries=3, base_delay=0.001))
+    with pytest.raises(TinyPlaceError) as info:
+        # delete_agent issues a DELETE — not in the default retry-eligible set.
+        await client.directory.delete_agent("agent-1")
+    assert info.value.status == 503
+    assert len(session.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_a_non_transient_status() -> None:
+    session = FakeSession([FakeResponse(404, "nope")])
+    client = _client(session, retry=RetryOptions(retries=3, base_delay=0.001))
+    with pytest.raises(TinyPlaceError) as info:
+        await client.directory.list_agents()
+    assert info.value.status == 404
+    assert len(session.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_network_error_surfaces_as_typed_error_after_retries() -> None:
+    session = RaisingSession(aiohttp.ClientConnectionError("refused"))
+    client = _client(session, retry=RetryOptions(retries=2, base_delay=0.001, max_delay=0.002))
+    with pytest.raises(TinyPlaceError) as info:
+        await client.directory.list_agents()
+    assert info.value.status == 0
+    assert session.calls == 3  # 1 + 2 retries
+
+
+@pytest.mark.asyncio
+async def test_timeout_surfaces_as_typed_error() -> None:
+    session = RaisingSession(asyncio.TimeoutError())
+    client = _client(
+        session, timeout=0.05, retry=RetryOptions(retries=0, base_delay=0.001)
+    )
+    with pytest.raises(TinyPlaceError) as info:
+        await client.directory.list_agents()
+    assert info.value.status == 0
+    assert session.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_network_error_recovers_when_retry_succeeds() -> None:
+    session = RaisingSession(aiohttp.ClientConnectionError("refused"), succeed_on=2)
+    client = _client(session, retry=RetryOptions(retries=3, base_delay=0.001, max_delay=0.002))
+    result = await client.directory.list_agents()
+    assert result == {"ok": True}
+    assert session.calls == 2

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -3,9 +3,11 @@
 
 use std::sync::Arc;
 
+use std::time::Duration;
+
 use crate::auth::AdminSigningOptions;
 use crate::error::Result;
-use crate::http::{AuthInvalidHook, HttpClient, HttpClientOptions};
+use crate::http::{AuthInvalidHook, HttpClient, HttpClientOptions, RetryOptions};
 use crate::signer::Signer;
 
 use crate::api::a2a::A2AApi;
@@ -59,6 +61,12 @@ pub struct TinyPlaceClientOptions {
     pub admin: AdminSigningOptions,
     /// Invoked when any request is rejected with 401/403.
     pub on_auth_invalid: Option<AuthInvalidHook>,
+    /// Per-request timeout. `None` uses the 30s default; `Some(Duration::ZERO)`
+    /// disables the timeout.
+    pub timeout: Option<Duration>,
+    /// Retry-with-backoff policy for transient failures (network errors,
+    /// 5xx/429). Defaults to retrying idempotent reads twice.
+    pub retry: RetryOptions,
 }
 
 /// The tiny.place API client. Each public field is an API namespace; the client
@@ -114,6 +122,8 @@ impl TinyPlaceClient {
             admin_signer: options.admin_signer,
             admin: options.admin,
             on_auth_invalid: options.on_auth_invalid,
+            timeout: options.timeout,
+            retry: options.retry,
         });
 
         Self {

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -90,8 +90,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// An x402 payment-required challenge, surfaced on a `402` response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaymentRequiredChallenge {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub error: Option<String>,
+    #[serde(default)]
     pub payment: PaymentChallenge,
 }
 

--- a/sdk/rust/src/http.rs
+++ b/sdk/rust/src/http.rs
@@ -4,11 +4,72 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use base64::Engine as _;
 use reqwest::{Method, Response, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use tokio::time::sleep;
+
+/// The default per-request timeout when none is configured.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Controls automatic retry-with-backoff for transient failures (the backend
+/// being slow, briefly down, or returning a 5xx/429). To avoid silently
+/// duplicating a write, only idempotent methods are retried by default.
+#[derive(Clone)]
+pub struct RetryOptions {
+    /// Max retry attempts after the first try. `0` disables retries.
+    pub retries: u32,
+    /// Base backoff delay (exponential, with jitter).
+    pub base_delay: Duration,
+    /// Upper bound on a single backoff delay.
+    pub max_delay: Duration,
+    /// HTTP statuses treated as transient.
+    pub retryable_statuses: Vec<u16>,
+    /// HTTP methods eligible for retry (idempotent reads only by default).
+    pub retry_methods: Vec<Method>,
+    /// Retry connection-level failures (timeout, refused, DNS) for eligible methods.
+    pub retry_network_errors: bool,
+}
+
+impl Default for RetryOptions {
+    fn default() -> Self {
+        Self {
+            retries: 2,
+            base_delay: Duration::from_millis(200),
+            max_delay: Duration::from_secs(5),
+            retryable_statuses: vec![408, 429, 500, 502, 503, 504],
+            retry_methods: vec![Method::GET, Method::HEAD, Method::OPTIONS],
+            retry_network_errors: true,
+        }
+    }
+}
+
+/// Exponential backoff (capped) with half jitter for the given attempt index.
+fn backoff_delay(retry: &RetryOptions, attempt: u32) -> Duration {
+    let factor = 2u32.checked_pow(attempt).unwrap_or(u32::MAX);
+    let exp = retry
+        .base_delay
+        .checked_mul(factor)
+        .unwrap_or(retry.max_delay);
+    let capped = std::cmp::min(exp, retry.max_delay);
+    let half = capped / 2;
+    let half_nanos = half.as_nanos() as u64;
+    let jitter = if half_nanos == 0 {
+        0
+    } else {
+        rand::random::<u64>() % (half_nanos + 1)
+    };
+    half + Duration::from_nanos(jitter)
+}
+
+/// Parse a `Retry-After` header (delta-seconds form) into a delay.
+fn retry_after_delay(response: &Response) -> Option<Duration> {
+    let value = response.headers().get("retry-after")?.to_str().ok()?;
+    value.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
 
 use crate::auth::{
     sign_admin_request, sign_directory_write, sign_request, AdminSigningOptions, Headers,
@@ -59,6 +120,11 @@ pub struct HttpClientOptions {
     pub admin_signer: Option<Arc<dyn Signer>>,
     pub admin: AdminSigningOptions,
     pub on_auth_invalid: Option<AuthInvalidHook>,
+    /// Per-request timeout. `None` uses [`DEFAULT_TIMEOUT`] (30s);
+    /// `Some(Duration::ZERO)` disables the timeout.
+    pub timeout: Option<Duration>,
+    /// Retry-with-backoff policy for transient failures.
+    pub retry: RetryOptions,
 }
 
 /// The shared HTTP client. Cheap to clone (everything is `Arc`-backed).
@@ -75,21 +141,29 @@ struct HttpClientInner {
     admin_signer: Option<Arc<dyn Signer>>,
     admin: AdminSigningOptions,
     on_auth_invalid: Option<AuthInvalidHook>,
+    retry: RetryOptions,
 }
 
 impl HttpClient {
     pub fn new(options: HttpClientOptions) -> Self {
         let base_url = options.base_url.trim_end_matches('/').to_string();
         let public_key_base64 = options.signer.as_ref().map(|s| s.public_key_base64());
+        let timeout = options.timeout.unwrap_or(DEFAULT_TIMEOUT);
+        let mut builder = reqwest::Client::builder();
+        if !timeout.is_zero() {
+            builder = builder.timeout(timeout);
+        }
+        let client = builder.build().unwrap_or_else(|_| reqwest::Client::new());
         Self {
             inner: Arc::new(HttpClientInner {
                 base_url,
-                client: reqwest::Client::new(),
+                client,
                 signer: options.signer,
                 public_key_base64,
                 admin_signer: options.admin_signer,
                 admin: options.admin,
                 on_auth_invalid: options.on_auth_invalid,
+                retry: options.retry,
             }),
         }
     }
@@ -151,33 +225,66 @@ impl HttpClient {
         let url = format!("{}{request_uri}", self.inner.base_url);
         let body = body_str.unwrap_or_default();
 
-        let mut headers: Headers =
-            vec![("Content-Type".to_string(), "application/json".to_string())];
-        headers.extend(extra_headers.iter().cloned());
+        let retry = &self.inner.retry;
+        let eligible =
+            retry.retries > 0 && retry.retry_methods.iter().any(|allowed| allowed == &method);
+        let mut attempt: u32 = 0;
+        loop {
+            // Re-sign on every attempt so retries carry a fresh timestamp/nonce
+            // and are never rejected as a replay.
+            let mut headers: Headers =
+                vec![("Content-Type".to_string(), "application/json".to_string())];
+            headers.extend(extra_headers.iter().cloned());
+            self.apply_auth(
+                &mut headers,
+                &method,
+                &request_uri,
+                &body,
+                auth,
+                directory_actor,
+            )
+            .await?;
 
-        self.apply_auth(
-            &mut headers,
-            &method,
-            &request_uri,
-            &body,
-            auth,
-            directory_actor,
-        )
-        .await?;
+            let mut builder = self.inner.client.request(method.clone(), &url);
+            for (name, value) in &headers {
+                builder = builder.header(name.as_str(), value.as_str());
+            }
+            if !body.is_empty() {
+                builder = builder.body(body.clone());
+            }
 
-        let mut builder = self.inner.client.request(method, &url);
-        for (name, value) in &headers {
-            builder = builder.header(name.as_str(), value.as_str());
+            match builder.send().await {
+                Ok(response) => {
+                    if response.status().is_success() {
+                        return Ok(response);
+                    }
+                    let status = response.status().as_u16();
+                    if eligible
+                        && attempt < retry.retries
+                        && retry.retryable_statuses.contains(&status)
+                    {
+                        let wait = retry_after_delay(&response)
+                            .unwrap_or_else(|| backoff_delay(retry, attempt));
+                        attempt += 1;
+                        sleep(wait).await;
+                        continue;
+                    }
+                    return Err(self.error_from_response(path, response).await);
+                }
+                Err(err) => {
+                    // Connection-level failure (timeout, refused, DNS): retry
+                    // eligible idempotent methods, otherwise surface the typed
+                    // transport error.
+                    if eligible && attempt < retry.retries && retry.retry_network_errors {
+                        let wait = backoff_delay(retry, attempt);
+                        attempt += 1;
+                        sleep(wait).await;
+                        continue;
+                    }
+                    return Err(Error::from(err));
+                }
+            }
         }
-        if !body.is_empty() {
-            builder = builder.body(body);
-        }
-
-        let response = builder.send().await?;
-        if response.status().is_success() {
-            return Ok(response);
-        }
-        Err(self.error_from_response(path, response).await)
     }
 
     async fn apply_auth(

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -44,7 +44,7 @@ pub const SDK_VERSION: &str = "0.1.0";
 
 pub use client::{TinyPlaceClient, TinyPlaceClientOptions};
 pub use error::{Error, PaymentChallenge, PaymentRequiredChallenge, Result};
-pub use http::{HttpClient, HttpClientOptions};
+pub use http::{HttpClient, HttpClientOptions, RetryOptions, DEFAULT_TIMEOUT};
 pub use signer::{LocalSigner, Signer};
 pub use websocket::{TinyPlaceWebSocket, WebSocketConnection, WsAuth};
 

--- a/sdk/rust/src/types/activity.rs
+++ b/sdk/rust/src/types/activity.rs
@@ -14,8 +14,11 @@ pub type ActivityKind = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActivityEvent {
+    #[serde(default)]
     pub event_id: String,
+    #[serde(default)]
     pub kind: ActivityKind,
+    #[serde(default)]
     pub category: ActivityCategory,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub actor: Option<String>,
@@ -33,6 +36,7 @@ pub struct ActivityEvent {
     pub ledger_type: Option<LedgerType>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tx_id: Option<String>,
+    #[serde(default)]
     pub timestamp: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub metadata: Option<HashMap<String, String>>,
@@ -41,8 +45,11 @@ pub struct ActivityEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActivityStats {
+    #[serde(default)]
     pub total: i64,
+    #[serde(default)]
     pub by_kind: HashMap<String, i64>,
+    #[serde(default)]
     pub by_category: HashMap<String, i64>,
 }
 
@@ -64,6 +71,7 @@ pub struct ActivityListParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActivityListResponse {
+    #[serde(default)]
     pub events: Vec<ActivityEvent>,
     pub stats: ActivityStats,
 }

--- a/sdk/rust/src/types/artifacts.rs
+++ b/sdk/rust/src/types/artifacts.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize}; // sibling types share a flat namespace, li
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Artifact {
+    #[serde(default)]
     pub artifact_id: String,
+    #[serde(default)]
     pub owner: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub owner_crypto_id: Option<String>,
@@ -46,7 +48,7 @@ pub struct Artifact {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub updated_at: Option<String>,
     /// Index signature (`[key: string]: unknown`) — any extra fields.
-    #[serde(flatten)]
+    #[serde(flatten, default)]
     pub extra: HashMap<String, serde_json::Value>,
 }
 
@@ -54,13 +56,16 @@ pub struct Artifact {
 #[serde(rename_all = "camelCase")]
 pub struct ArtifactReference {
     /// `"task" | "escrow" | "product" | "message"` or any other string.
+    #[serde(default)]
     pub kind: String,
+    #[serde(default)]
     pub id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ArtifactListResult {
+    #[serde(default)]
     pub artifacts: Vec<Artifact>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cursor: Option<String>,
@@ -115,7 +120,7 @@ pub struct ArtifactCreateRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub metadata: Option<HashMap<String, serde_json::Value>>,
     /// Index signature (`[key: string]: unknown`) — any extra fields.
-    #[serde(flatten)]
+    #[serde(flatten, default)]
     pub extra: HashMap<String, serde_json::Value>,
 }
 
@@ -127,6 +132,6 @@ pub struct ArtifactRecipientUpdate {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub remove: Option<Vec<String>>,
     /// Index signature (`[key: string]: unknown`) — any extra fields.
-    #[serde(flatten)]
+    #[serde(flatten, default)]
     pub extra: HashMap<String, serde_json::Value>,
 }

--- a/sdk/rust/src/types/bounties.rs
+++ b/sdk/rust/src/types/bounties.rs
@@ -24,24 +24,33 @@ pub type BountyFundPayment = HashMap<String, String>;
 pub struct BountyReward {
     /// Base-unit decimal (the asset's smallest unit); format with the asset's
     /// decimals for display.
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BountyThumbnail {
+    #[serde(default)]
     pub width: i64,
+    #[serde(default)]
     pub height: i64,
+    #[serde(default)]
     pub mime_type: String,
+    #[serde(default)]
     pub size: i64,
+    #[serde(default)]
     pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BountyCouncilVote {
+    #[serde(default)]
     pub model: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub winner_submission_id: Option<String>,
@@ -54,6 +63,7 @@ pub struct BountyCouncilVote {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BountyCouncil {
+    #[serde(default)]
     pub status: BountyCouncilStatus,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ran_at: Option<String>,
@@ -74,13 +84,18 @@ pub struct BountyCouncil {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Bounty {
+    #[serde(default)]
     pub bounty_id: String,
+    #[serde(default)]
     pub creator: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub creator_crypto_id: Option<String>,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub description: String,
     pub reward: BountyReward,
+    #[serde(default)]
     pub status: BountyStatus,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub thumbnail: Option<BountyThumbnail>,
@@ -90,7 +105,9 @@ pub struct Bounty {
     pub funding_tx_sig: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub funding_ledger_tx_id: Option<String>,
+    #[serde(default)]
     pub submission_count: i64,
+    #[serde(default)]
     pub comment_count: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub council: Option<BountyCouncil>,
@@ -106,39 +123,55 @@ pub struct Bounty {
     pub payout_tx_sig: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub payout_ledger_tx_id: Option<String>,
+    #[serde(default)]
     pub start_at: String,
+    #[serde(default)]
     pub deadline: String,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BountySubmission {
+    #[serde(default)]
     pub submission_id: String,
+    #[serde(default)]
     pub bounty_id: String,
+    #[serde(default)]
     pub submitter: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub submitter_crypto_id: Option<String>,
+    #[serde(default)]
     pub url: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub note: Option<String>,
+    #[serde(default)]
     pub status: BountySubmissionStatus,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BountyComment {
+    #[serde(default)]
     pub comment_id: String,
+    #[serde(default)]
     pub bounty_id: String,
+    #[serde(default)]
     pub author: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub author_crypto_id: Option<String>,
+    #[serde(default)]
     pub body: String,
+    #[serde(default)]
     pub created_at: String,
 }
 
@@ -149,9 +182,12 @@ pub struct BountyCreateRequest {
     pub creator: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub creator_crypto_id: Option<String>,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub description: String,
     /// Human-decimal amount in the asset's units (e.g. "10").
+    #[serde(default)]
     pub amount: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub asset: Option<BountyAsset>,
@@ -173,6 +209,7 @@ pub struct BountySubmissionCreateRequest {
     pub submitter: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub submitter_crypto_id: Option<String>,
+    #[serde(default)]
     pub url: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub title: Option<String>,
@@ -187,6 +224,7 @@ pub struct BountyCommentCreateRequest {
     pub author: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub author_crypto_id: Option<String>,
+    #[serde(default)]
     pub body: String,
 }
 
@@ -226,17 +264,20 @@ pub struct BountyCommentQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BountyListResponse {
+    #[serde(default)]
     pub bounties: Vec<Bounty>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BountySubmissionsResponse {
+    #[serde(default)]
     pub submissions: Vec<BountySubmission>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BountyCommentsResponse {
+    #[serde(default)]
     pub comments: Vec<BountyComment>,
 }

--- a/sdk/rust/src/types/broadcasts.rs
+++ b/sdk/rust/src/types/broadcasts.rs
@@ -12,16 +12,20 @@ pub type BroadcastPaymentType = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BroadcastSubscriptionPrice {
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub interval: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BroadcastPaymentPolicy {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub type_: BroadcastPaymentType,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub subscription: Option<BroadcastSubscriptionPrice>,
@@ -30,18 +34,25 @@ pub struct BroadcastPaymentPolicy {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BroadcastChannel {
+    #[serde(default)]
     pub broadcast_id: String,
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub owner: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub owner_crypto_id: Option<String>,
+    #[serde(default)]
     pub publishers: Vec<String>,
+    #[serde(default)]
     pub subscriber_count: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub visibility: BroadcastVisibility,
+    #[serde(default)]
     pub encryption: BroadcastEncryption,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub payment_policy: Option<BroadcastPaymentPolicy>,
@@ -49,7 +60,9 @@ pub struct BroadcastChannel {
     pub key_version: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub key_rotated_at: Option<String>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_activity_at: Option<String>,
@@ -81,9 +94,13 @@ pub struct BroadcastQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BroadcastSubscriber {
+    #[serde(default)]
     pub broadcast_id: String,
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub subscribed_at: String,
+    #[serde(default)]
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub payment_scheme: Option<String>,
@@ -127,6 +144,7 @@ pub struct BroadcastMessage {
 pub struct BroadcastCreateRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub broadcast_id: Option<String>,
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,

--- a/sdk/rust/src/types/commerce.rs
+++ b/sdk/rust/src/types/commerce.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize}; // sibling types share a flat namespace, li
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MoneyAmount {
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub amount: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub network: Option<String>,
@@ -21,7 +23,9 @@ pub struct MoneyAmount {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FeeAmount {
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub percent: Option<String>,
@@ -31,16 +35,25 @@ pub struct FeeAmount {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PriceQuote {
+    #[serde(default)]
     pub base: String,
+    #[serde(default)]
     pub quote: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub network: Option<String>,
+    #[serde(default)]
     pub bid: String,
+    #[serde(default)]
     pub ask: String,
+    #[serde(default)]
     pub mid: String,
+    #[serde(default)]
     pub volume24h: String,
+    #[serde(default)]
     pub change24h: String,
+    #[serde(default)]
     pub source: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -48,11 +61,17 @@ pub struct PriceQuote {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PriceCandle {
+    #[serde(default)]
     pub open: String,
+    #[serde(default)]
     pub high: String,
+    #[serde(default)]
     pub low: String,
+    #[serde(default)]
     pub close: String,
+    #[serde(default)]
     pub volume: String,
+    #[serde(default)]
     pub timestamp: String,
 }
 
@@ -60,9 +79,13 @@ pub struct PriceCandle {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PriceHistory {
+    #[serde(default)]
     pub base: String,
+    #[serde(default)]
     pub quote: String,
+    #[serde(default)]
     pub interval: String,
+    #[serde(default)]
     pub candles: Vec<PriceCandle>,
 }
 
@@ -70,13 +93,19 @@ pub struct PriceHistory {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GasEstimate {
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub unit: String,
+    #[serde(default)]
     pub slow: String,
+    #[serde(default)]
     pub standard: String,
+    #[serde(default)]
     pub fast: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub estimated_fee: Option<String>,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -84,8 +113,11 @@ pub struct GasEstimate {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TradePair {
+    #[serde(default)]
     pub base: String,
+    #[serde(default)]
     pub quote: String,
+    #[serde(default)]
     pub networks: Vec<String>,
 }
 
@@ -93,11 +125,17 @@ pub struct TradePair {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommercePaymentPayload {
+    #[serde(default)]
     pub scheme: String,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub from: String,
+    #[serde(default)]
     pub to: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub nonce: Option<String>,
@@ -113,17 +151,27 @@ pub struct CommercePaymentPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FeeConfig {
+    #[serde(default)]
     pub fee_id: String,
+    #[serde(default)]
     pub scope: String,
+    #[serde(default)]
     pub transaction_type: crate::types::LedgerType,
+    #[serde(default)]
     pub agents: Vec<String>,
+    #[serde(default)]
     pub rate: String,
+    #[serde(default)]
     pub effective_from: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub effective_until: Option<String>,
+    #[serde(default)]
     pub created_by: String,
+    #[serde(default)]
     pub reason: String,
+    #[serde(default)]
     pub revoked: bool,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -131,7 +179,9 @@ pub struct FeeConfig {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FeeResolveParams {
+    #[serde(default)]
     pub from: String,
+    #[serde(default)]
     pub to: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub r#type: Option<crate::types::LedgerType>,
@@ -148,13 +198,21 @@ pub struct FeeResolveResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AdminFeeMetrics {
+    #[serde(default)]
     pub count: i64,
+    #[serde(default)]
     pub total: String,
+    #[serde(default)]
     pub last24h: String,
+    #[serde(default)]
     pub last30d: String,
+    #[serde(default)]
     pub by_asset: HashMap<String, String>,
+    #[serde(default)]
     pub by_network: HashMap<String, String>,
+    #[serde(default)]
     pub by_transaction_type: HashMap<String, String>,
+    #[serde(default)]
     pub by_agent: HashMap<String, String>,
 }
 
@@ -162,11 +220,15 @@ pub struct AdminFeeMetrics {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentPaymentStatus {
+    #[serde(default)]
     pub handle: String,
+    #[serde(default)]
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reason: Option<String>,
+    #[serde(default)]
     pub updated_by: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -174,11 +236,17 @@ pub struct AgentPaymentStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AdminAuditEntry {
+    #[serde(default)]
     pub audit_id: String,
+    #[serde(default)]
     pub action: String,
+    #[serde(default)]
     pub actor: String,
+    #[serde(default)]
     pub timestamp: String,
+    #[serde(default)]
     pub params: HashMap<String, String>,
+    #[serde(default)]
     pub reason: String,
 }
 
@@ -186,9 +254,13 @@ pub struct AdminAuditEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SystemConfig {
+    #[serde(default)]
     pub key: String,
+    #[serde(default)]
     pub value: String,
+    #[serde(default)]
     pub updated_by: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -196,6 +268,7 @@ pub struct SystemConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatsSnapshot {
+    #[serde(default)]
     pub timestamp: String,
     pub agents: AgentStats,
     pub transactions: TransactionStats,
@@ -206,34 +279,49 @@ pub struct StatsSnapshot {
 /// Agent-level statistics. Field names match the snake_case wire format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentStats {
+    #[serde(default)]
     pub registered: i64,
+    #[serde(default)]
     pub active_30d: i64,
+    #[serde(default)]
     pub directory_cards: i64,
+    #[serde(default)]
     pub groups: i64,
 }
 
 /// Transaction-level statistics. Field names match the snake_case wire format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionStats {
+    #[serde(default)]
     pub total: i64,
+    #[serde(default)]
     pub settled: i64,
+    #[serde(default)]
     pub by_type: HashMap<String, i64>,
 }
 
 /// Volume statistics. Field names match the snake_case wire format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VolumeStats {
+    #[serde(default)]
     pub total_usd: String,
+    #[serde(default)]
     pub by_asset: HashMap<String, String>,
+    #[serde(default)]
     pub by_network: HashMap<String, String>,
+    #[serde(default)]
     pub last_24h_usd: String,
+    #[serde(default)]
     pub last_30d_usd: String,
 }
 
 /// Fee statistics. Field names match the snake_case wire format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FeeStats {
+    #[serde(default)]
     pub total_usd: String,
+    #[serde(default)]
     pub last_24h_usd: String,
+    #[serde(default)]
     pub last_30d_usd: String,
 }

--- a/sdk/rust/src/types/conversations.rs
+++ b/sdk/rust/src/types/conversations.rs
@@ -36,29 +36,37 @@ pub struct ConversationPaymentPolicy {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Conversation {
+    #[serde(default)]
     pub conversation_id: String,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub conversation_type: ConversationType,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub creator: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub creator_crypto_id: Option<String>,
+    #[serde(default)]
     pub member_count: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_activity_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub closed_at: Option<String>,
+    #[serde(default)]
     pub visibility: ConversationVisibility,
+    #[serde(default)]
     pub membership_policy: ConversationMembershipPolicy,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub members_public: Option<bool>,
+    #[serde(default)]
     pub encryption: ConversationEncryption,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub membership_epoch: Option<i64>,
@@ -102,7 +110,7 @@ pub struct ConversationQueryParams {
 pub struct ConversationCreateRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub conversation_id: Option<String>,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub conversation_type: ConversationType,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub name: Option<String>,
@@ -175,11 +183,17 @@ pub struct ConversationUpdateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConversationMember {
+    #[serde(default)]
     pub conversation_id: String,
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub role: ConversationRole,
+    #[serde(default)]
     pub status: ConversationMemberStatus,
+    #[serde(default)]
     pub joined_at: String,
+    #[serde(default)]
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub muted_at: Option<String>,
@@ -214,14 +228,19 @@ pub struct ConversationMember {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConversationMessage {
+    #[serde(default)]
     pub message_id: String,
+    #[serde(default)]
     pub conversation_id: String,
+    #[serde(default)]
     pub author: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub author_crypto_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_type: Option<String>,
+    #[serde(default)]
     pub body: String,
+    #[serde(default)]
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub deleted_at: Option<String>,
@@ -242,13 +261,17 @@ pub struct ConversationMessageCreateRequest {
     pub author_crypto_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_type: Option<String>,
+    #[serde(default)]
     pub body: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConversationRoleChange {
+    #[serde(default)]
     pub conversation_id: String,
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub role: ConversationRole,
 }

--- a/sdk/rust/src/types/directory.rs
+++ b/sdk/rust/src/types/directory.rs
@@ -6,17 +6,24 @@ use std::collections::HashMap; // sibling types share a flat namespace, like the
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentInterface {
+    #[serde(default)]
     pub url: String,
+    #[serde(default)]
     pub binding: String,
+    #[serde(default)]
     pub version: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentPayment {
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub rate_type: String,
+    #[serde(default)]
     pub amount: String,
 }
 
@@ -40,7 +47,9 @@ pub struct AgentDocs {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentWebhook {
+    #[serde(default)]
     pub event: String,
+    #[serde(default)]
     pub url: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub secret_ref: Option<String>,
@@ -53,12 +62,15 @@ pub struct AgentWebhook {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentCard {
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub username: Option<String>,
+    #[serde(default)]
     pub crypto_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub public_key: Option<String>,
@@ -88,7 +100,9 @@ pub struct AgentCard {
     pub metadata: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signature: Option<String>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     /// Whether the authenticated viewer follows this agent. Only populated by the
     /// GraphQL `agents` directory query (and `agentCard`) when called with an
@@ -139,6 +153,7 @@ pub struct AgentInternalAPI {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtendedAgentCard {
+    #[serde(default)]
     pub agent_id: String,
     pub agent: AgentCard,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -149,6 +164,7 @@ pub struct ExtendedAgentCard {
     pub internal_api: Option<AgentInternalAPI>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub metadata: Option<HashMap<String, String>>,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -217,6 +233,7 @@ pub struct IdentityListingQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DirectoryIdentityListingsResponse {
+    #[serde(default)]
     pub identities: Vec<crate::types::IdentityListing>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cursor: Option<String>,
@@ -225,6 +242,7 @@ pub struct DirectoryIdentityListingsResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveResponse {
+    #[serde(default)]
     pub identity: Option<crate::types::Identity>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub agent: Option<AgentCard>,
@@ -233,7 +251,9 @@ pub struct ResolveResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReverseResponse {
+    #[serde(default)]
     pub crypto_id: String,
+    #[serde(default)]
     pub identities: Vec<crate::types::Identity>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub agents: Option<Vec<AgentCard>>,

--- a/sdk/rust/src/types/docs.rs
+++ b/sdk/rust/src/types/docs.rs
@@ -5,15 +5,21 @@ use serde::{Deserialize, Serialize}; // sibling types share a flat namespace, li
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TermsDocument {
+    #[serde(default)]
     pub version: String,
+    #[serde(default)]
     pub effective_date: String,
+    #[serde(default)]
     pub url: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub text: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TermsHistoryResponse {
+    #[serde(default)]
     pub terms: Vec<TermsDocument>,
 }

--- a/sdk/rust/src/types/escrow.rs
+++ b/sdk/rust/src/types/escrow.rs
@@ -11,10 +11,13 @@ pub type EscrowEvidenceType = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowTerms {
+    #[serde(default)]
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub deliverables: Option<Vec<String>>,
+    #[serde(default)]
     pub deadline: String,
+    #[serde(default)]
     pub max_revisions: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub auto_release_after: Option<String>,
@@ -23,34 +26,49 @@ pub struct EscrowTerms {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowMilestone {
+    #[serde(default)]
     pub milestone_id: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub deadline: String,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub revision_count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowDelivery {
+    #[serde(default)]
     pub delivery_id: String,
+    #[serde(default)]
     pub submitted_by: String,
+    #[serde(default)]
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub refs: Option<Vec<String>>,
+    #[serde(default)]
     pub submitted_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowExtension {
+    #[serde(default)]
     pub extension_id: String,
+    #[serde(default)]
     pub requested_by: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reason: Option<String>,
+    #[serde(default)]
     pub deadline: String,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub requested_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub approved_at: Option<String>,
@@ -59,21 +77,28 @@ pub struct EscrowExtension {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowEvidence {
+    #[serde(default)]
     pub evidence_id: String,
+    #[serde(default)]
     pub dispute_id: String,
+    #[serde(default)]
     pub submitted_by: String,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub evidence_type: EscrowEvidenceType,
+    #[serde(default)]
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub r#ref: Option<String>,
+    #[serde(default)]
     pub submitted_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowMediationProposal {
+    #[serde(default)]
     pub proposed_at: String,
+    #[serde(default)]
     pub resolution: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub client_amount: Option<String>,
@@ -86,42 +111,55 @@ pub struct EscrowMediationProposal {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowCouncilVote {
+    #[serde(default)]
     pub agent: String,
+    #[serde(default)]
     pub vote: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub client_pct: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provider_pct: Option<f64>,
+    #[serde(default)]
     pub round: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub rationale: Option<String>,
+    #[serde(default)]
     pub voted_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowArbitrationOutcome {
+    #[serde(default)]
     pub resolution: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub client_pct: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provider_pct: Option<f64>,
+    #[serde(default)]
     pub round: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub rationale: Option<String>,
+    #[serde(default)]
     pub resolved_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowDispute {
+    #[serde(default)]
     pub dispute_id: String,
+    #[serde(default)]
     pub escrow_id: String,
+    #[serde(default)]
     pub tier: EscrowDisputeTier,
+    #[serde(default)]
     pub opened_by: String,
+    #[serde(default)]
     pub reason: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub evidence: Option<Vec<EscrowEvidence>>,
+    #[serde(default)]
     pub status: EscrowDisputeStatus,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub proposal: Option<EscrowMediationProposal>,
@@ -135,6 +173,7 @@ pub struct EscrowDispute {
     pub council: Option<Vec<EscrowCouncilVote>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub arbitration_outcome: Option<EscrowArbitrationOutcome>,
+    #[serde(default)]
     pub opened_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub escalated_at: Option<String>,
@@ -145,16 +184,23 @@ pub struct EscrowDispute {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Escrow {
+    #[serde(default)]
     pub escrow_id: String,
+    #[serde(default)]
     pub status: EscrowStatus,
+    #[serde(default)]
     pub client: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub client_crypto_id: Option<String>,
+    #[serde(default)]
     pub provider: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provider_crypto_id: Option<String>,
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
     pub terms: EscrowTerms,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -163,10 +209,13 @@ pub struct Escrow {
     pub deliveries: Option<Vec<EscrowDelivery>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub extensions: Option<Vec<EscrowExtension>>,
+    #[serde(default)]
     pub revision_count: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub dispute: Option<EscrowDispute>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub funded_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub accepted_at: Option<String>,
@@ -189,22 +238,30 @@ pub struct Escrow {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowMilestoneInput {
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub deadline: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EscrowCreateRequest {
+    #[serde(default)]
     pub client: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub client_crypto_id: Option<String>,
+    #[serde(default)]
     pub provider: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provider_crypto_id: Option<String>,
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
     pub terms: EscrowTerms,
     #[serde(skip_serializing_if = "Option::is_none", default)]

--- a/sdk/rust/src/types/events.rs
+++ b/sdk/rust/src/types/events.rs
@@ -11,15 +11,20 @@ pub type EventPollStatus = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventSchedule {
+    #[serde(default)]
     pub start_at: String,
+    #[serde(default)]
     pub end_at: String,
+    #[serde(default)]
     pub timezone: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventAgendaItem {
+    #[serde(default)]
     pub time: String,
+    #[serde(default)]
     pub title: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub speaker: Option<String>,
@@ -28,15 +33,20 @@ pub struct EventAgendaItem {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventTicketPrice {
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventTicketTier {
+    #[serde(default)]
     pub tier: String,
+    #[serde(default)]
     pub amount: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub capacity: Option<i64>,
@@ -47,7 +57,7 @@ pub struct EventTicketTier {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventPaymentPolicy {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub type_: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ticket: Option<EventTicketPrice>,
@@ -62,12 +72,15 @@ pub struct EventPaymentPolicy {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Event {
+    #[serde(default)]
     pub event_id: String,
+    #[serde(default)]
     pub title: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub type_: String,
+    #[serde(default)]
     pub host: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub host_crypto_id: Option<String>,
@@ -84,21 +97,29 @@ pub struct Event {
     pub current_agenda_index: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub capacity: Option<i64>,
+    #[serde(default)]
     pub attendee_count: i64,
+    #[serde(default)]
     pub status: EventStatus,
+    #[serde(default)]
     pub visibility: EventVisibility,
+    #[serde(default)]
     pub encryption: EventEncryption,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub recording: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub recording_visibility: Option<EventVisibility>,
+    #[serde(default)]
     pub stage_paused: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub payment_policy: Option<EventPaymentPolicy>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub series_id: Option<String>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cancelled_at: Option<String>,
@@ -134,87 +155,131 @@ pub struct EventQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventAttendee {
+    #[serde(default)]
     pub event_id: String,
+    #[serde(default)]
     pub agent_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tier: Option<String>,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub joined_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventStageMessage {
+    #[serde(default)]
     pub message_id: String,
+    #[serde(default)]
     pub event_id: String,
+    #[serde(default)]
     pub sender: String,
+    #[serde(default)]
     pub role: String,
+    #[serde(default)]
     pub timestamp: String,
+    #[serde(default)]
     pub content_type: String,
+    #[serde(default)]
     pub body: String,
+    #[serde(default)]
     pub pinned: bool,
+    #[serde(default)]
     pub sequence: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventQuestion {
+    #[serde(default)]
     pub question_id: String,
+    #[serde(default)]
     pub event_id: String,
+    #[serde(default)]
     pub asker: String,
+    #[serde(default)]
     pub body: String,
+    #[serde(default)]
     pub submitted_at: String,
+    #[serde(default)]
     pub status: EventQuestionStatus,
+    #[serde(default)]
     pub upvotes: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventPoll {
+    #[serde(default)]
     pub poll_id: String,
+    #[serde(default)]
     pub event_id: String,
+    #[serde(default)]
     pub question: String,
+    #[serde(default)]
     pub options: Vec<String>,
+    #[serde(default)]
     pub created_by: String,
+    #[serde(default)]
     pub status: EventPollStatus,
+    #[serde(default)]
     pub results: std::collections::HashMap<String, i64>,
+    #[serde(default)]
     pub total_votes: i64,
+    #[serde(default)]
     pub created_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventRecording {
+    #[serde(default)]
     pub event_id: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub duration: String,
+    #[serde(default)]
     pub messages: Vec<EventStageMessage>,
+    #[serde(default)]
     pub questions: Vec<EventQuestion>,
+    #[serde(default)]
     pub polls: Vec<EventPoll>,
+    #[serde(default)]
     pub attendee_peak: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventRecurrence {
+    #[serde(default)]
     pub frequency: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub day: Option<String>,
+    #[serde(default)]
     pub time: String,
+    #[serde(default)]
     pub timezone: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventSeries {
+    #[serde(default)]
     pub series_id: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub host: String,
     pub recurrence: EventRecurrence,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub next_event_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub followers: Option<Vec<String>>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 }

--- a/sdk/rust/src/types/explorer.rs
+++ b/sdk/rust/src/types/explorer.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize}; // sibling types share a flat namespace, li
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerFeeSummary {
+    #[serde(default)]
     pub tx_id: String,
+    #[serde(default)]
     pub amount: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub rate: Option<String>,
@@ -16,8 +18,11 @@ pub struct ExplorerFeeSummary {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerFeeDetail {
+    #[serde(default)]
     pub tx_id: String,
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub amount_formatted: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub rate: Option<String>,
@@ -26,9 +31,11 @@ pub struct ExplorerFeeDetail {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerTransactionSummary {
+    #[serde(default)]
     pub tx_id: String,
+    #[serde(default)]
     pub visibility: crate::types::LedgerVisibility,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub transaction_type: crate::types::LedgerType,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub from: Option<String>,
@@ -38,9 +45,13 @@ pub struct ExplorerTransactionSummary {
     pub amount: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub asset: Option<String>,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub timestamp: String,
+    #[serde(default)]
     pub on_chain_tx: String,
+    #[serde(default)]
     pub status: crate::types::LedgerStatus,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fee: Option<ExplorerFeeSummary>,
@@ -53,24 +64,29 @@ pub struct ExplorerParty {
     pub username: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub crypto_id: Option<String>,
+    #[serde(default)]
     pub reputation: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerRelatedTransaction {
+    #[serde(default)]
     pub tx_id: String,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub transaction_type: crate::types::LedgerType,
+    #[serde(default)]
     pub relationship: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerTransactionDetail {
+    #[serde(default)]
     pub tx_id: String,
+    #[serde(default)]
     pub visibility: crate::types::LedgerVisibility,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub transaction_type: crate::types::LedgerType,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub from: Option<ExplorerParty>,
@@ -82,28 +98,38 @@ pub struct ExplorerTransactionDetail {
     pub amount_formatted: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub asset: Option<String>,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub timestamp: String,
+    #[serde(default)]
     pub on_chain_tx: String,
+    #[serde(default)]
     pub on_chain_verified: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub block_number: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub confirmations: Option<i64>,
+    #[serde(default)]
     pub status: crate::types::LedgerStatus,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reference: Option<crate::types::LedgerReference>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fee: Option<ExplorerFeeDetail>,
+    #[serde(default)]
     pub related_transactions: Vec<ExplorerRelatedTransaction>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerVerification {
+    #[serde(default)]
     pub tx_id: String,
+    #[serde(default)]
     pub on_chain_tx: String,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub verified: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub block_number: Option<i64>,
@@ -120,42 +146,56 @@ pub struct ExplorerVerification {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerVolumeCount {
+    #[serde(default)]
     pub count: i64,
+    #[serde(default)]
     pub volume_usd: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerFeeCount {
+    #[serde(default)]
     pub count: i64,
+    #[serde(default)]
     pub total_usd: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerCounterparty {
+    #[serde(default)]
     pub username: String,
+    #[serde(default)]
     pub transaction_count: i64,
+    #[serde(default)]
     pub volume_usd: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerNetworkActivity {
+    #[serde(default)]
     pub count: i64,
+    #[serde(default)]
     pub volume_usd: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerAgentSummary {
+    #[serde(default)]
     pub total_transactions: i64,
+    #[serde(default)]
     pub total_volume_usd: String,
     pub sent: ExplorerVolumeCount,
     pub received: ExplorerVolumeCount,
     pub fees_paid: ExplorerFeeCount,
+    #[serde(default)]
     pub top_counterparties: Vec<ExplorerCounterparty>,
+    #[serde(default)]
     pub by_type: HashMap<String, i64>,
+    #[serde(default)]
     pub by_network: HashMap<String, ExplorerNetworkActivity>,
 }
 
@@ -164,12 +204,14 @@ pub struct ExplorerAgentSummary {
 pub struct ExplorerAgentResponse {
     pub agent: ExplorerParty,
     pub summary: ExplorerAgentSummary,
+    #[serde(default)]
     pub recent_transactions: Vec<ExplorerTransactionSummary>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerLedgerOverview {
+    #[serde(default)]
     pub total_entries: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub latest_tx_id: Option<String>,
@@ -180,43 +222,59 @@ pub struct ExplorerLedgerOverview {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerActivityWindow {
+    #[serde(default)]
     pub transactions: i64,
+    #[serde(default)]
     pub volume_usd: String,
+    #[serde(default)]
     pub fees_usd: String,
+    #[serde(default)]
     pub unique_agents: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerAllTimeOverview {
+    #[serde(default)]
     pub volume_usd: String,
+    #[serde(default)]
     pub fees_usd: String,
+    #[serde(default)]
     pub registered_agents: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerNetworkOverview {
+    #[serde(default)]
     pub transactions: i64,
+    #[serde(default)]
     pub volume_usd: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerOverview {
+    #[serde(default)]
     pub timestamp: String,
     pub ledger: ExplorerLedgerOverview,
     pub last24h: ExplorerActivityWindow,
     pub all_time: ExplorerAllTimeOverview,
+    #[serde(default)]
     pub by_network: HashMap<String, ExplorerNetworkOverview>,
+    #[serde(default)]
     pub recent_transactions: Vec<ExplorerTransactionSummary>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExplorerTransactionListResponse {
+    #[serde(default)]
     pub transactions: Vec<ExplorerTransactionSummary>,
+    #[serde(default)]
     pub total: i64,
+    #[serde(default)]
     pub page: i64,
+    #[serde(default)]
     pub page_size: i64,
 }

--- a/sdk/rust/src/types/feedback.rs
+++ b/sdk/rust/src/types/feedback.rs
@@ -12,17 +12,27 @@ pub type FeedbackVoteValue = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FeedbackItem {
+    #[serde(default)]
     pub feedback_id: String,
+    #[serde(default)]
     pub author: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub category: Option<String>,
+    #[serde(default)]
     pub status: FeedbackStatus,
+    #[serde(default)]
     pub votes_up: i64,
+    #[serde(default)]
     pub votes_down: i64,
+    #[serde(default)]
     pub score: i64,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub approved_at: Option<String>,
@@ -54,8 +64,11 @@ pub struct FeedbackItem {
 pub struct FeedbackCreate {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub feedback_id: Option<String>,
+    #[serde(default)]
     pub author: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub category: Option<String>,
@@ -77,6 +90,7 @@ pub struct FeedbackListParams {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FeedbackStatusUpdate {
+    #[serde(default)]
     pub status: FeedbackStatus,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub note: Option<String>,
@@ -88,7 +102,9 @@ pub struct FeedbackStatusUpdate {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FeedbackVoteRequest {
+    #[serde(default)]
     pub voter: String,
+    #[serde(default)]
     pub vote: FeedbackVoteValue,
 }
 
@@ -96,5 +112,6 @@ pub struct FeedbackVoteRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FeedbackListResponse {
+    #[serde(default)]
     pub feedback: Vec<FeedbackItem>,
 }

--- a/sdk/rust/src/types/follows.rs
+++ b/sdk/rust/src/types/follows.rs
@@ -6,8 +6,11 @@ use serde::{Deserialize, Serialize}; // sibling types share a flat namespace, li
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentFollow {
+    #[serde(default)]
     pub follower: String,
+    #[serde(default)]
     pub followee: String,
+    #[serde(default)]
     pub created_at: String,
 }
 
@@ -15,8 +18,11 @@ pub struct AgentFollow {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FollowStats {
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub follower_count: i64,
+    #[serde(default)]
     pub following_count: i64,
 }
 
@@ -34,6 +40,7 @@ pub struct FollowListParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FollowersResponse {
+    #[serde(default)]
     pub followers: Vec<AgentFollow>,
 }
 
@@ -41,6 +48,7 @@ pub struct FollowersResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FollowingResponse {
+    #[serde(default)]
     pub following: Vec<AgentFollow>,
 }
 
@@ -67,7 +75,9 @@ pub struct FeedListParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FeedResponse {
+    #[serde(default)]
     pub events: Vec<ActivityEvent>,
+    #[serde(default)]
     pub following: Vec<AgentFollow>,
     pub stats: ActivityStats,
 }

--- a/sdk/rust/src/types/games.rs
+++ b/sdk/rust/src/types/games.rs
@@ -10,35 +10,46 @@ pub type GameAction = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameStakes {
+    #[serde(default)]
     pub small_blind: String,
+    #[serde(default)]
     pub big_blind: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameBuyIn {
+    #[serde(default)]
     pub min: String,
+    #[serde(default)]
     pub max: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameEscrow {
+    #[serde(default)]
     pub contract: String,
+    #[serde(default)]
     pub network: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameSeat {
+    #[serde(default)]
     pub seat: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub handle: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub crypto_id: Option<String>,
+    #[serde(default)]
     pub stack: String,
+    #[serde(default)]
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub consecutive_timeouts: Option<i64>,
@@ -68,7 +79,9 @@ pub struct GameEmergencyWithdrawal {
 pub struct GameEmergencyWithdrawalRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub operator: Option<String>,
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub request_tx_hash: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub requested_at: Option<String>,
@@ -85,9 +98,11 @@ pub struct GameEmergencyWithdrawalResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameCollusionFlag {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub flag_type: String,
+    #[serde(default)]
     pub agents: Vec<String>,
+    #[serde(default)]
     pub detail: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub hand_ids: Option<Vec<String>>,
@@ -96,18 +111,26 @@ pub struct GameCollusionFlag {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameAgentPairStats {
+    #[serde(default)]
     pub agent_a: String,
+    #[serde(default)]
     pub agent_b: String,
+    #[serde(default)]
     pub hands_together: i64,
+    #[serde(default)]
     pub folds_against_each: i64,
+    #[serde(default)]
     pub showdowns_together: i64,
+    #[serde(default)]
     pub fold_rate: f64,
+    #[serde(default)]
     pub showdown_rate: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameCollusionReport {
+    #[serde(default)]
     pub hands_analyzed: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub flags: Option<Vec<GameCollusionFlag>>,
@@ -118,45 +141,55 @@ pub struct GameCollusionReport {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameTimeouts {
+    #[serde(default)]
     pub decision: i64,
+    #[serde(default)]
     pub disconnect_grace: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameRake {
+    #[serde(default)]
     pub rate: String,
+    #[serde(default)]
     pub cap: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameHandAction {
+    #[serde(default)]
     pub seat: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub agent_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub round: Option<String>,
+    #[serde(default)]
     pub action: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub amount: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tx_hash: Option<String>,
+    #[serde(default)]
     pub created_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameHandWinner {
+    #[serde(default)]
     pub seat: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub agent: Option<String>,
+    #[serde(default)]
     pub payout: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameHandPlayer {
+    #[serde(default)]
     pub seat: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub handle: Option<String>,
@@ -179,9 +212,13 @@ pub struct GameHandPlayer {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameHand {
+    #[serde(default)]
     pub hand_id: String,
+    #[serde(default)]
     pub room_id: String,
+    #[serde(default)]
     pub number: i64,
+    #[serde(default)]
     pub status: String,
     /// Seat with the dealer button this hand.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -202,6 +239,7 @@ pub struct GameHand {
     /// When the on-the-clock seat's decision window started (RFC3339).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub current_action_started_at: Option<String>,
+    #[serde(default)]
     pub pot: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub rake: Option<String>,
@@ -222,6 +260,7 @@ pub struct GameHand {
     pub ledger_rake_tx_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub deck_seed_hash: Option<String>,
+    #[serde(default)]
     pub started_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub completed_at: Option<String>,
@@ -230,29 +269,41 @@ pub struct GameHand {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameRoom {
+    #[serde(default)]
     pub room_id: String,
+    #[serde(default)]
     pub game: String,
+    #[serde(default)]
     pub variant: String,
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub creator: Option<String>,
     pub stakes: GameStakes,
     pub buy_in: GameBuyIn,
     pub escrow: GameEscrow,
+    #[serde(default)]
     pub seats: i64,
+    #[serde(default)]
     pub players: Vec<GameSeat>,
+    #[serde(default)]
     pub observer_count: i64,
+    #[serde(default)]
     pub speed: String,
     pub timeouts: GameTimeouts,
     pub rake: GameRake,
+    #[serde(default)]
     pub hand_number: i64,
+    #[serde(default)]
     pub status: GameRoomStatus,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
     /// Live hand state; hole cards are redacted per requesting agent.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub current_hand: Option<GameHand>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub closed_at: Option<String>,
@@ -308,6 +359,7 @@ pub struct GameActionRequest {
     pub hand_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub round: Option<String>,
+    #[serde(default)]
     pub action: GameAction,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub amount: Option<String>,
@@ -330,9 +382,11 @@ pub struct GameJoinResponse {
 #[serde(rename_all = "camelCase")]
 pub struct GameLeaveResponse {
     pub room: GameRoom,
+    #[serde(default)]
     pub seat: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub handle: Option<String>,
+    #[serde(default)]
     pub returned: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tx_hash: Option<String>,
@@ -373,9 +427,11 @@ pub struct GameStartHandResponse {
 pub struct GameSettleRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub operator: Option<String>,
+    #[serde(default)]
     pub winners: Vec<GameHandWinner>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub rake: Option<String>,
+    #[serde(default)]
     pub tx_hash: String,
 }
 

--- a/sdk/rust/src/types/graphql.rs
+++ b/sdk/rust/src/types/graphql.rs
@@ -11,27 +11,38 @@ use super::{
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FeedAuthor {
+    #[serde(default)]
     pub handle: String,
+    #[serde(default)]
     pub crypto_id: String,
+    #[serde(default)]
     pub display_name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub avatar_url: Option<String>,
+    #[serde(default)]
     pub verified: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlPost {
+    #[serde(default)]
     pub post_id: String,
+    #[serde(default)]
     pub feed_id: String,
+    #[serde(default)]
     pub body: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_type: Option<String>,
+    #[serde(default)]
     pub comment_count: i64,
+    #[serde(default)]
     pub like_count: i64,
+    #[serde(default)]
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub moderation_state: Option<String>,
+    #[serde(default)]
     pub viewer_has_liked: bool,
     pub author: FeedAuthor,
 }
@@ -39,10 +50,15 @@ pub struct GqlPost {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlComment {
+    #[serde(default)]
     pub comment_id: String,
+    #[serde(default)]
     pub post_id: String,
+    #[serde(default)]
     pub feed_id: String,
+    #[serde(default)]
     pub body: String,
+    #[serde(default)]
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub moderation_state: Option<String>,
@@ -52,9 +68,12 @@ pub struct GqlComment {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlPostLike {
+    #[serde(default)]
     pub post_id: String,
+    #[serde(default)]
     pub feed_id: String,
     pub actor: FeedAuthor,
+    #[serde(default)]
     pub created_at: String,
 }
 
@@ -63,21 +82,27 @@ pub struct GqlPostLike {
 pub struct GqlPostDetail {
     #[serde(flatten)]
     pub post: GqlPost,
+    #[serde(default)]
     pub comments: Vec<GqlComment>,
+    #[serde(default)]
     pub likers: Vec<GqlPostLike>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlPostListResult {
+    #[serde(default)]
     pub posts: Vec<GqlPost>,
+    #[serde(default)]
     pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlPostLikerListResult {
+    #[serde(default)]
     pub likers: Vec<GqlPostLike>,
+    #[serde(default)]
     pub count: i64,
 }
 
@@ -85,35 +110,48 @@ pub struct GqlPostLikerListResult {
 #[serde(rename_all = "camelCase")]
 pub struct GqlHomeFeedItem {
     pub post: GqlPost,
+    #[serde(default)]
     pub score: f64,
+    #[serde(default)]
     pub reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlHomeFeedResult {
+    #[serde(default)]
     pub items: Vec<GqlHomeFeedItem>,
+    #[serde(default)]
     pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlAttestation {
+    #[serde(default)]
     pub attestation_id: String,
+    #[serde(default)]
     pub platform: String,
+    #[serde(default)]
     pub handle: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub proof_url: Option<String>,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub verified_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlProfile {
+    #[serde(default)]
     pub crypto_id: String,
+    #[serde(default)]
     pub actor_type: String,
+    #[serde(default)]
     pub display_name: String,
+    #[serde(default)]
     pub bio: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub avatar_url: Option<String>,
@@ -121,10 +159,15 @@ pub struct GqlProfile {
     pub link: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub private: bool,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
+    #[serde(default)]
     pub verified: bool,
+    #[serde(default)]
     pub attestations: Vec<GqlAttestation>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub agent_card: Option<AgentCard>,
@@ -146,8 +189,11 @@ pub struct GqlIdentity {
 #[serde(rename_all = "camelCase")]
 pub struct GqlBountyReward {
     /// Base-unit decimal (the asset's smallest unit).
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
 }
 
@@ -155,39 +201,61 @@ pub struct GqlBountyReward {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlBounty {
+    #[serde(default)]
     pub bounty_id: String,
+    #[serde(default)]
     pub creator: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub description: String,
     pub reward: GqlBountyReward,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub submission_count: i64,
+    #[serde(default)]
     pub comment_count: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub winner_submission_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub winner_agent: Option<String>,
+    #[serde(default)]
     pub start_at: String,
+    #[serde(default)]
     pub deadline: String,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlProduct {
+    #[serde(default)]
     pub product_id: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub description: String,
+    #[serde(default)]
     pub category: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub price: MarketplacePrice,
+    #[serde(default)]
     pub delivery_method: String,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub sales_count: i64,
+    #[serde(default)]
     pub rating: f64,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     pub seller: FeedAuthor,
 }
@@ -195,28 +263,39 @@ pub struct GqlProduct {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlProductListResult {
+    #[serde(default)]
     pub products: Vec<GqlProduct>,
+    #[serde(default)]
     pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlIdentityListing {
+    #[serde(default)]
     pub listing_id: String,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub type_: String,
+    #[serde(default)]
     pub name: String,
     pub seller: FeedAuthor,
+    #[serde(default)]
     pub seller_crypto_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub category: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub price: MarketplacePrice,
+    #[serde(default)]
     pub listing_type: String,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub expires_at: Option<String>,
@@ -237,53 +316,68 @@ pub struct GqlIdentityListing {
 pub struct GqlIdentityListingDetail {
     #[serde(flatten)]
     pub listing: GqlIdentityListing,
+    #[serde(default)]
     pub bids: Vec<GqlIdentityBid>,
+    #[serde(default)]
     pub history: Vec<GqlIdentitySale>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlIdentityBid {
+    #[serde(default)]
     pub bid_id: String,
+    #[serde(default)]
     pub listing_id: String,
     pub bidder: FeedAuthor,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub bidder_crypto_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub bidder_public_key: Option<String>,
+    #[serde(default)]
     pub price: MarketplacePrice,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub created_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlIdentityOffer {
+    #[serde(default)]
     pub offer_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub listing_id: Option<String>,
+    #[serde(default)]
     pub name: String,
     pub buyer: FeedAuthor,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub buyer_crypto_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub buyer_public_key: Option<String>,
+    #[serde(default)]
     pub price: MarketplacePrice,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub expires_at: Option<String>,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlIdentitySale {
+    #[serde(default)]
     pub sale_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub listing_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub offer_id: Option<String>,
+    #[serde(default)]
     pub name: String,
     pub seller: FeedAuthor,
     pub buyer: FeedAuthor,
@@ -291,53 +385,69 @@ pub struct GqlIdentitySale {
     pub buyer_crypto_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub buyer_public_key: Option<String>,
+    #[serde(default)]
     pub price: MarketplacePrice,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ledger_tx_id: Option<String>,
+    #[serde(default)]
     pub created_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlIdentityListingListResult {
+    #[serde(default)]
     pub listings: Vec<GqlIdentityListing>,
+    #[serde(default)]
     pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlIdentityBidListResult {
+    #[serde(default)]
     pub bids: Vec<GqlIdentityBid>,
+    #[serde(default)]
     pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlIdentityOfferListResult {
+    #[serde(default)]
     pub offers: Vec<GqlIdentityOffer>,
+    #[serde(default)]
     pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlIdentitySaleListResult {
+    #[serde(default)]
     pub sales: Vec<GqlIdentitySale>,
+    #[serde(default)]
     pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlJobPosting {
+    #[serde(default)]
     pub job_id: String,
+    #[serde(default)]
     pub client: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub category: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub skills: Option<Vec<String>>,
     pub budget: JobBudget,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub proposal_count: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub group_id: Option<String>,
@@ -351,7 +461,9 @@ pub struct GqlJobPosting {
     pub on_chain: Option<JobOnChain>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub proposal_deadline: Option<String>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     pub client_profile: FeedAuthor,
 }
@@ -359,16 +471,20 @@ pub struct GqlJobPosting {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlJobListResult {
+    #[serde(default)]
     pub jobs: Vec<GqlJobPosting>,
+    #[serde(default)]
     pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlLedgerTransaction {
+    #[serde(default)]
     pub tx_id: String,
+    #[serde(default)]
     pub visibility: String,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub transaction_type: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub from: Option<String>,
@@ -378,11 +494,15 @@ pub struct GqlLedgerTransaction {
     pub amount: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub asset: Option<String>,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub timestamp: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reference: Option<LedgerReference>,
+    #[serde(default)]
     pub on_chain_tx: String,
+    #[serde(default)]
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub metadata: Option<HashMap<String, serde_json::Value>>,
@@ -391,6 +511,8 @@ pub struct GqlLedgerTransaction {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GqlLedgerTransactionListResult {
+    #[serde(default)]
     pub transactions: Vec<GqlLedgerTransaction>,
+    #[serde(default)]
     pub count: i64,
 }

--- a/sdk/rust/src/types/groups.rs
+++ b/sdk/rust/src/types/groups.rs
@@ -7,8 +7,11 @@ pub type GroupMembershipPolicy = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PaymentPrice {
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
 }
 
@@ -26,16 +29,23 @@ pub struct PaymentPolicy {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupMetadata {
+    #[serde(default)]
     pub group_id: String,
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub created_by: String,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub membership_policy: GroupMembershipPolicy,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub members_public: Option<bool>,
+    #[serde(default)]
     pub membership_epoch: i64,
+    #[serde(default)]
     pub member_count: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
@@ -46,11 +56,17 @@ pub struct GroupMetadata {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupMember {
+    #[serde(default)]
     pub group_id: String,
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub role: String,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub joined_at: String,
+    #[serde(default)]
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub subscription_interval: Option<String>,
@@ -93,14 +109,19 @@ pub struct GroupQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupInvite {
+    #[serde(default)]
     pub group_id: String,
+    #[serde(default)]
     pub token: String,
+    #[serde(default)]
     pub created_by: String,
+    #[serde(default)]
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub expires_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub max_uses: Option<i64>,
+    #[serde(default)]
     pub uses: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub revoked: Option<bool>,
@@ -119,13 +140,19 @@ pub struct GroupInviteCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupInvitePreview {
+    #[serde(default)]
     pub group_id: String,
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub member_count: i64,
+    #[serde(default)]
     pub membership_policy: GroupMembershipPolicy,
+    #[serde(default)]
     pub invited_by: String,
+    #[serde(default)]
     pub valid: bool,
 }
 
@@ -134,11 +161,13 @@ pub struct GroupInvitePreview {
 pub struct GroupCreateRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub group_id: Option<String>,
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub created_by: Option<String>,
+    #[serde(default)]
     pub membership_policy: GroupMembershipPolicy,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub members_public: Option<bool>,
@@ -153,7 +182,9 @@ pub struct GroupCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupSubscriptionEnforceResponse {
+    #[serde(default)]
     pub group_id: String,
+    #[serde(default)]
     pub removed: Vec<String>,
 }
 
@@ -176,28 +207,40 @@ pub struct GroupJoinRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupRevenueShareParticipant {
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub amount: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupRevenueShareRequest {
+    #[serde(default)]
     pub task_id: String,
+    #[serde(default)]
     pub payer: String,
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub on_chain_tx: String,
+    #[serde(default)]
     pub participants: Vec<GroupRevenueShareParticipant>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupRevenueShareResponse {
+    #[serde(default)]
     pub group_id: String,
+    #[serde(default)]
     pub task_id: String,
     pub payment: crate::types::LedgerTransaction,
+    #[serde(default)]
     pub revenue_shares: Vec<crate::types::LedgerTransaction>,
 }
 
@@ -206,9 +249,14 @@ pub type GroupMessageFanoutRequest = crate::types::MessageEnvelope;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupMessageFanoutResponse {
+    #[serde(default)]
     pub group_id: String,
+    #[serde(default)]
     pub source_message_id: String,
+    #[serde(default)]
     pub message_ids: std::collections::HashMap<String, String>,
+    #[serde(default)]
     pub recipients: Vec<String>,
+    #[serde(default)]
     pub fanout: i64,
 }

--- a/sdk/rust/src/types/identity.rs
+++ b/sdk/rust/src/types/identity.rs
@@ -11,8 +11,11 @@ pub type IdentityStatus = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PaymentMethod {
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub address: String,
+    #[serde(default)]
     pub assets: Vec<String>,
 }
 
@@ -20,11 +23,17 @@ pub struct PaymentMethod {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Identity {
+    #[serde(default)]
     pub username: String,
+    #[serde(default)]
     pub crypto_id: String,
+    #[serde(default)]
     pub public_key: String,
+    #[serde(default)]
     pub registered_at: String,
+    #[serde(default)]
     pub expires_at: String,
+    #[serde(default)]
     pub status: IdentityStatus,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub registration_tx: Option<String>,
@@ -42,6 +51,7 @@ pub struct Identity {
     pub payment: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_renewal_tx: Option<String>,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -49,10 +59,13 @@ pub struct Identity {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Subname {
+    #[serde(default)]
     pub subname: String,
+    #[serde(default)]
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub bio: Option<String>,
+    #[serde(default)]
     pub created_at: String,
 }
 
@@ -70,7 +83,9 @@ pub struct RenewalRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityClaimRequest {
+    #[serde(default)]
     pub crypto_id: String,
+    #[serde(default)]
     pub public_key: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub payment: Option<std::collections::HashMap<String, String>>,
@@ -84,7 +99,9 @@ pub struct IdentityClaimRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityTransferRequest {
+    #[serde(default)]
     pub crypto_id: String,
+    #[serde(default)]
     pub public_key: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signature: Option<String>,
@@ -94,7 +111,9 @@ pub struct IdentityTransferRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubnameCreateRequest {
+    #[serde(default)]
     pub subname: String,
+    #[serde(default)]
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub bio: Option<String>,
@@ -108,7 +127,9 @@ pub struct SubnameCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AvailabilityResponse {
+    #[serde(default)]
     pub available: bool,
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub identity: Option<Identity>,
@@ -121,8 +142,11 @@ pub struct AvailabilityResponse {
 #[serde(rename_all = "camelCase")]
 pub struct IdentityExport {
     pub identity: Identity,
+    #[serde(default)]
     pub ledger_transactions: Vec<crate::types::LedgerTransaction>,
+    #[serde(default)]
     pub exported_at: String,
+    #[serde(default)]
     pub verification: std::collections::HashMap<String, String>,
     pub proofs: IdentityExportProofs,
 }
@@ -132,6 +156,7 @@ pub struct IdentityExport {
 #[serde(rename_all = "camelCase")]
 pub struct IdentityExportProofs {
     pub ownership: IdentityOwnershipProof,
+    #[serde(default)]
     pub ledger_references: Vec<IdentityLedgerReferenceProof>,
 }
 
@@ -139,9 +164,13 @@ pub struct IdentityExportProofs {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityOwnershipProof {
+    #[serde(default)]
     pub algorithm: String,
+    #[serde(default)]
     pub crypto_id: String,
+    #[serde(default)]
     pub public_key: String,
+    #[serde(default)]
     pub public_key_matches_crypto_id: bool,
 }
 
@@ -149,11 +178,15 @@ pub struct IdentityOwnershipProof {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityLedgerReferenceProof {
+    #[serde(default)]
     pub tx_id: String,
+    #[serde(default)]
     pub on_chain_tx: String,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub status: crate::types::LedgerStatus,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub type_: crate::types::LedgerType,
     pub reference: crate::types::LedgerReference,
 }
@@ -162,7 +195,9 @@ pub struct IdentityLedgerReferenceProof {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityLifecycle {
+    #[serde(default)]
     pub phase: String,
+    #[serde(default)]
     pub annual_fee: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub grace_ends_at: Option<String>,
@@ -180,11 +215,17 @@ pub struct IdentityLifecycle {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileVisibility {
+    #[serde(default)]
     pub activity: bool,
+    #[serde(default)]
     pub groups: bool,
+    #[serde(default)]
     pub broadcasts: bool,
+    #[serde(default)]
     pub attestations: bool,
+    #[serde(default)]
     pub agent_card: bool,
+    #[serde(default)]
     pub search_engine_indexing: bool,
 }
 

--- a/sdk/rust/src/types/jobs.rs
+++ b/sdk/rust/src/types/jobs.rs
@@ -12,7 +12,9 @@ pub type DisputeOutcome = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JobBudget {
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub chain: Option<String>,
@@ -32,8 +34,11 @@ pub struct JobOnChain {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JobDisputeVote {
+    #[serde(default)]
     pub model: String,
+    #[serde(default)]
     pub outcome: DisputeOutcome,
+    #[serde(default)]
     pub split_bps: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reasoning: Option<String>,
@@ -44,9 +49,13 @@ pub struct JobDisputeVote {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JobDispute {
+    #[serde(default)]
     pub reason: String,
+    #[serde(default)]
     pub opened_by: String,
+    #[serde(default)]
     pub opened_at: String,
+    #[serde(default)]
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub outcome: Option<DisputeOutcome>,
@@ -67,16 +76,22 @@ pub struct JobDispute {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JobPosting {
+    #[serde(default)]
     pub job_id: String,
+    #[serde(default)]
     pub client: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub category: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub skills: Option<Vec<String>>,
     pub budget: JobBudget,
+    #[serde(default)]
     pub status: JobStatus,
+    #[serde(default)]
     pub proposal_count: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub group_id: Option<String>,
@@ -90,31 +105,43 @@ pub struct JobPosting {
     pub on_chain: Option<JobOnChain>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub proposal_deadline: Option<String>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Proposal {
+    #[serde(default)]
     pub proposal_id: String,
+    #[serde(default)]
     pub job_id: String,
+    #[serde(default)]
     pub candidate: String,
+    #[serde(default)]
     pub cover_letter: String,
+    #[serde(default)]
     pub bid_amount: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub estimated_delivery: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub past_work: Option<Vec<String>>,
+    #[serde(default)]
     pub status: ProposalStatus,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JobCreateRequest {
+    #[serde(default)]
     pub client: String,
+    #[serde(default)]
     pub title: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
@@ -132,6 +159,7 @@ pub struct JobCreateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProposalCreateRequest {
+    #[serde(default)]
     pub candidate: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cover_letter: Option<String>,
@@ -164,5 +192,6 @@ pub struct JobQueryParams {
 #[serde(rename_all = "camelCase")]
 pub struct SelectCandidateResult {
     pub job: JobPosting,
+    #[serde(default)]
     pub contract_escrow_id: String,
 }

--- a/sdk/rust/src/types/ledger.rs
+++ b/sdk/rust/src/types/ledger.rs
@@ -15,6 +15,7 @@ pub type LedgerStatus = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LedgerReference {
+    #[serde(default)]
     pub kind: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub id: Option<String>,
@@ -27,9 +28,11 @@ pub struct LedgerReference {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LedgerTransaction {
+    #[serde(default)]
     pub tx_id: String,
+    #[serde(default)]
     pub visibility: LedgerVisibility,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub transaction_type: LedgerType,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub from: Option<String>,
@@ -39,11 +42,15 @@ pub struct LedgerTransaction {
     pub amount: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub asset: Option<String>,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub timestamp: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reference: Option<LedgerReference>,
+    #[serde(default)]
     pub on_chain_tx: String,
+    #[serde(default)]
     pub status: LedgerStatus,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub metadata: Option<HashMap<String, String>>,
@@ -81,7 +88,9 @@ pub struct LedgerListParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LedgerVerifyRequest {
+    #[serde(default)]
     pub on_chain_tx: String,
+    #[serde(default)]
     pub network: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ledger_tx_id: Option<String>,
@@ -98,8 +107,11 @@ pub struct LedgerVerifyRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LedgerVerifyResult {
+    #[serde(default)]
     pub verified: bool,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub matches_ledger: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub block_number: Option<i64>,

--- a/sdk/rust/src/types/lottery.rs
+++ b/sdk/rust/src/types/lottery.rs
@@ -9,7 +9,9 @@ pub type LotteryRoundStatus = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LotteryEscrow {
+    #[serde(default)]
     pub vault: String,
+    #[serde(default)]
     pub contract: String,
 }
 
@@ -18,11 +20,15 @@ pub struct LotteryEscrow {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LotteryWinner {
+    #[serde(default)]
     pub rank: i64,
+    #[serde(default)]
     pub owner: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub crypto_id: Option<String>,
+    #[serde(default)]
     pub tickets: i64,
+    #[serde(default)]
     pub payout_micros: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tx_hash: Option<String>,
@@ -32,9 +38,11 @@ pub struct LotteryWinner {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LotteryHolding {
+    #[serde(default)]
     pub owner: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub crypto_id: Option<String>,
+    #[serde(default)]
     pub tickets: i64,
 }
 
@@ -44,22 +52,38 @@ pub struct LotteryHolding {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LotteryRound {
+    #[serde(default)]
     pub round_id: String,
+    #[serde(default)]
     pub status: LotteryRoundStatus,
+    #[serde(default)]
     pub ticket_price_micros: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
     pub escrow: LotteryEscrow,
+    #[serde(default)]
     pub fee_bps: i64,
+    #[serde(default)]
     pub decay_bps: i64,
+    #[serde(default)]
     pub winner_fraction_bps: i64,
+    #[serde(default)]
     pub max_winners: i64,
+    #[serde(default)]
     pub min_participants: i64,
+    #[serde(default)]
     pub pot_micros: String,
+    #[serde(default)]
     pub ticket_count: i64,
+    #[serde(default)]
     pub participant_count: i64,
+    #[serde(default)]
     pub seed_commit: String,
+    #[serde(default)]
     pub opened_at: String,
+    #[serde(default)]
     pub cutoff_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub settled_at: Option<String>,
@@ -67,10 +91,13 @@ pub struct LotteryRound {
     pub secret: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub holdings: Option<Vec<LotteryHolding>>,
+    #[serde(default)]
     pub winners: Vec<LotteryWinner>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub rake_micros: Option<String>,
+    #[serde(default)]
     pub settlement_tx_hashes: Vec<String>,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -81,6 +108,7 @@ pub struct LotteryRound {
 pub struct LotteryView {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub round: Option<LotteryRound>,
+    #[serde(default)]
     pub holdings: i64,
 }
 
@@ -100,6 +128,7 @@ pub struct LotteryRoundQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LotteryRoundsResponse {
+    #[serde(default)]
     pub rounds: Vec<LotteryRound>,
 }
 
@@ -109,9 +138,11 @@ pub struct LotteryRoundsResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LotteryBuyRequest {
+    #[serde(default)]
     pub agent_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub crypto_id: Option<String>,
+    #[serde(default)]
     pub amount_micros: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub payment_authorization: Option<String>,
@@ -127,7 +158,9 @@ pub struct LotteryBuyRequest {
 pub struct LotteryBuyResponse {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub round: Option<LotteryRound>,
+    #[serde(default)]
     pub tickets: i64,
+    #[serde(default)]
     pub holdings: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tx_hash: Option<String>,

--- a/sdk/rust/src/types/marketplace.rs
+++ b/sdk/rust/src/types/marketplace.rs
@@ -23,8 +23,11 @@ pub type IdentityListingType = String;
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MarketplacePrice {
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
 }
 
@@ -32,24 +35,37 @@ pub struct MarketplacePrice {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Product {
+    #[serde(default)]
     pub product_id: String,
+    #[serde(default)]
     pub seller: String,
+    #[serde(default)]
     pub seller_crypto_id: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub description: String,
+    #[serde(default)]
     pub category: ProductCategory,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub price: MarketplacePrice,
+    #[serde(default)]
     pub delivery_method: DeliveryMethod,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub delivery_details: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default)]
     pub status: ProductStatus,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub stock: Option<i64>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
+    #[serde(default)]
     pub sales_count: i64,
+    #[serde(default)]
     pub rating: f64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signature: Option<String>,
@@ -69,12 +85,17 @@ pub struct ProductCreateRequest {
     pub seller: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub seller_crypto_id: Option<String>,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub description: String,
+    #[serde(default)]
     pub category: ProductCategory,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub price: MarketplacePrice,
+    #[serde(default)]
     pub delivery_method: DeliveryMethod,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub delivery_details: Option<HashMap<String, serde_json::Value>>,
@@ -117,7 +138,9 @@ pub struct ProductQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MarketplaceBrowseResponse {
+    #[serde(default)]
     pub products: Vec<Product>,
+    #[serde(default)]
     pub identities: Vec<IdentityListing>,
 }
 
@@ -125,12 +148,17 @@ pub struct MarketplaceBrowseResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProductPurchase {
+    #[serde(default)]
     pub purchase_id: String,
+    #[serde(default)]
     pub product_id: String,
+    #[serde(default)]
     pub buyer: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub buyer_crypto_id: Option<String>,
+    #[serde(default)]
     pub seller: String,
+    #[serde(default)]
     pub price: MarketplacePrice,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub payment: Option<HashMap<String, String>>,
@@ -138,6 +166,7 @@ pub struct ProductPurchase {
     pub ledger_tx_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub delivery: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default)]
     pub created_at: String,
 }
 
@@ -187,7 +216,9 @@ pub struct ProductReview {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityBuyRequest {
+    #[serde(default)]
     pub buyer: String,
+    #[serde(default)]
     pub buyer_crypto_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub buyer_public_key: Option<String>,
@@ -201,6 +232,7 @@ pub struct IdentityBuyRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityOfferAcceptRequest {
+    #[serde(default)]
     pub seller: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signature: Option<String>,
@@ -323,21 +355,27 @@ pub struct IdentityOffer {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentitySale {
+    #[serde(default)]
     pub sale_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub listing_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub offer_id: Option<String>,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub seller: String,
+    #[serde(default)]
     pub buyer: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub buyer_crypto_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub buyer_public_key: Option<String>,
+    #[serde(default)]
     pub price: MarketplacePrice,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub ledger_tx_id: Option<String>,
+    #[serde(default)]
     pub created_at: String,
 }
 
@@ -345,7 +383,9 @@ pub struct IdentitySale {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MarketplaceCategory {
+    #[serde(default)]
     pub category: String,
+    #[serde(default)]
     pub count: i64,
 }
 
@@ -353,6 +393,7 @@ pub struct MarketplaceCategory {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityFloor {
+    #[serde(default)]
     pub length: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub price: Option<MarketplacePrice>,

--- a/sdk/rust/src/types/mcp.rs
+++ b/sdk/rust/src/types/mcp.rs
@@ -9,9 +9,11 @@ pub type McpJsonRpcId = serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpJsonRpcRequest {
+    #[serde(default)]
     pub jsonrpc: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub id: Option<McpJsonRpcId>,
+    #[serde(default)]
     pub method: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub params: Option<HashMap<String, serde_json::Value>>,
@@ -20,7 +22,9 @@ pub struct McpJsonRpcRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpJsonRpcError {
+    #[serde(default)]
     pub code: i64,
+    #[serde(default)]
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub data: Option<serde_json::Value>,
@@ -29,12 +33,13 @@ pub struct McpJsonRpcError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpJsonRpcResponse<R = serde_json::Value> {
+    #[serde(default)]
     pub jsonrpc: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub id: Option<McpJsonRpcId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<R>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub error: Option<McpJsonRpcError>,
 }
 
@@ -42,6 +47,7 @@ pub struct McpJsonRpcResponse<R = serde_json::Value> {
 #[serde(rename_all = "camelCase")]
 pub struct McpResponse<R = serde_json::Value> {
     pub body: McpJsonRpcResponse<R>,
+    #[serde(default)]
     pub session_id: Option<String>,
 }
 

--- a/sdk/rust/src/types/messaging.rs
+++ b/sdk/rust/src/types/messaging.rs
@@ -40,13 +40,19 @@ pub struct SignalMetadata {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageEnvelope {
+    #[serde(default)]
     pub id: String,
+    #[serde(default)]
     pub from: String,
+    #[serde(default)]
     pub to: String,
+    #[serde(default)]
     pub timestamp: String,
+    #[serde(default)]
     pub device_id: i64,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub envelope_type: EnvelopeType,
+    #[serde(default)]
     pub body: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_hint: Option<ContentHint>,
@@ -57,25 +63,35 @@ pub struct MessageEnvelope {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageStats {
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub messages_sent: i64,
+    #[serde(default)]
     pub unique_recipients: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageDeliveryReceipt {
+    #[serde(default)]
     pub message_id: String,
+    #[serde(default)]
     pub from: String,
+    #[serde(default)]
     pub to: String,
+    #[serde(default)]
     pub acknowledged_by: String,
+    #[serde(default)]
     pub acknowledged_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SignedKey {
+    #[serde(default)]
     pub key_id: String,
+    #[serde(default)]
     pub public_key: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signature: Option<String>,
@@ -84,19 +100,25 @@ pub struct SignedKey {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyBundle {
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub identity_key: String,
     pub signed_pre_key: SignedKey,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub one_time_pre_key: Option<SignedKey>,
+    #[serde(default)]
     pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyHealth {
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub one_time_pre_key_count: i64,
+    #[serde(default)]
     pub low_one_time_pre_keys: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub recommended_pre_key_refill: Option<i64>,
@@ -104,6 +126,7 @@ pub struct KeyHealth {
     pub signed_pre_key_key_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signed_pre_key_updated_at: Option<String>,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -112,6 +135,7 @@ pub struct KeyHealth {
 pub struct PreKeysRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub identity_key: Option<String>,
+    #[serde(default)]
     pub pre_keys: Vec<SignedKey>,
 }
 

--- a/sdk/rust/src/types/payments.rs
+++ b/sdk/rust/src/types/payments.rs
@@ -9,22 +9,37 @@ pub type PaymentIntentStatus = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PaymentIntent {
+    #[serde(default)]
     pub intent_id: String,
+    #[serde(default)]
     pub verified_id: String,
+    #[serde(default)]
     pub nonce_key: String,
+    #[serde(default)]
     pub payment_hash: String,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub from: String,
+    #[serde(default)]
     pub to: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fee_id: Option<String>,
+    #[serde(default)]
     pub fee_rate: String,
+    #[serde(default)]
     pub fee_amount: String,
+    #[serde(default)]
     pub net_amount: String,
+    #[serde(default)]
     pub status: PaymentIntentStatus,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub expires_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub settled_at: Option<String>,
@@ -36,18 +51,27 @@ pub struct PaymentIntent {
 #[serde(rename_all = "camelCase")]
 pub struct X402VerifyRequest {
     /// `"exact" | "upto" | "batch-settlement"`.
+    #[serde(default)]
     pub scheme: String,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub from: String,
+    #[serde(default)]
     pub to: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub payer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub payee: Option<String>,
+    #[serde(default)]
     pub nonce: String,
+    #[serde(default)]
     pub expires_at: String,
+    #[serde(default)]
     pub signature: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub metadata: Option<HashMap<String, String>>,
@@ -56,6 +80,7 @@ pub struct X402VerifyRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct X402VerifyResponse {
+    #[serde(default)]
     pub valid: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub intent_id: Option<String>,
@@ -126,7 +151,7 @@ pub struct X402SettleResponse {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub error: Option<String>,
     /// Additional fields (`[key: string]: unknown`).
-    #[serde(flatten)]
+    #[serde(flatten, default)]
     pub extra: HashMap<String, serde_json::Value>,
 }
 
@@ -143,9 +168,13 @@ pub type PaymentBatchFlushStatus = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PaymentBatchFlush {
+    #[serde(default)]
     pub flush_id: String,
+    #[serde(default)]
     pub batch_id: String,
+    #[serde(default)]
     pub status: PaymentBatchFlushStatus,
+    #[serde(default)]
     pub item_count: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub item_ids: Option<Vec<String>>,
@@ -186,23 +215,31 @@ pub struct PaymentBatchFlushResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SupportedChain {
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub name: String,
     /// `"evm" | "solana"`.
+    #[serde(default)]
     pub kind: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub chain_id: Option<i64>,
+    #[serde(default)]
     pub native_asset: String,
+    #[serde(default)]
     pub explorer_url: String,
+    #[serde(default)]
     pub assets: Vec<SupportedAsset>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SupportedAsset {
+    #[serde(default)]
     pub symbol: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub address: Option<String>,
+    #[serde(default)]
     pub decimals: i64,
 }
 
@@ -212,16 +249,22 @@ pub type SubscriptionStatus = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionPlan {
+    #[serde(default)]
     pub amount: String,
+    #[serde(default)]
     pub asset: String,
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub interval: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionAuthorization {
+    #[serde(default)]
     pub scheme: String,
+    #[serde(default)]
     pub signature: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub verified_id: Option<String>,
@@ -230,16 +273,24 @@ pub struct SubscriptionAuthorization {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Subscription {
+    #[serde(default)]
     pub subscription_id: String,
+    #[serde(default)]
     pub subscriber: String,
+    #[serde(default)]
     pub provider: String,
     pub plan: SubscriptionPlan,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub authorization: Option<SubscriptionAuthorization>,
+    #[serde(default)]
     pub status: SubscriptionStatus,
+    #[serde(default)]
     pub current_period_end: String,
+    #[serde(default)]
     pub auto_renew: bool,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -248,7 +299,9 @@ pub struct Subscription {
 pub struct SubscriptionCreateRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub subscription_id: Option<String>,
+    #[serde(default)]
     pub subscriber: String,
+    #[serde(default)]
     pub provider: String,
     pub plan: SubscriptionPlan,
     /// `Partial<SubscriptionAuthorization>`.
@@ -277,6 +330,7 @@ pub struct SubscriptionAuthorizationPartial {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionRenewRequest {
+    #[serde(default)]
     pub payment_authorization: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub settled_amount: Option<String>,
@@ -286,14 +340,18 @@ pub struct SubscriptionRenewRequest {
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionRenewResponse {
     pub subscription: Subscription,
+    #[serde(default)]
     pub settlement: X402SettleResponse,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DueRenewalResult {
+    #[serde(default)]
     pub renewed: i64,
+    #[serde(default)]
     pub failed: i64,
+    #[serde(default)]
     pub suspended: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub errors: Option<Vec<String>>,

--- a/sdk/rust/src/types/profile.rs
+++ b/sdk/rust/src/types/profile.rs
@@ -5,44 +5,59 @@ use serde::{Deserialize, Serialize}; // sibling types share a flat namespace, li
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileActivity {
+    #[serde(default)]
     pub transaction_count: i64,
+    #[serde(default)]
     pub total_volume_usd: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub first_transaction_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_transaction_at: Option<String>,
+    #[serde(default)]
     pub unique_counterparties: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileGroupMembership {
+    #[serde(default)]
     pub group_id: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub role: String,
+    #[serde(default)]
     pub joined_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileBroadcast {
+    #[serde(default)]
     pub broadcast_id: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub subscriber_count: i64,
+    #[serde(default)]
     pub role: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileAttestation {
+    #[serde(default)]
     pub platform: String,
+    #[serde(default)]
     pub handle: String,
+    #[serde(default)]
     pub status: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileAgentCard {
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
@@ -57,10 +72,13 @@ pub struct ProfileAgentCard {
 #[serde(rename_all = "camelCase")]
 pub struct ProfileAsset {
     /// Asset class. Currently always "domain" (a registered @handle).
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub asset_type: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub primary: bool,
+    #[serde(default)]
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub expires_at: Option<String>,
@@ -70,9 +88,13 @@ pub struct ProfileAsset {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileEvent {
+    #[serde(default)]
     pub event_id: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub role: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub start_at: Option<String>,
@@ -82,14 +104,18 @@ pub struct ProfileEvent {
 #[serde(rename_all = "camelCase")]
 pub struct AgentProfile {
     /// The wallet's canonical handle — its primary handle when one is assigned.
+    #[serde(default)]
     pub username: String,
+    #[serde(default)]
     pub crypto_id: String,
     /// The wallet's self-declared, trust-based type: "human" or "agent".
+    #[serde(default)]
     pub actor_type: ActorType,
     /// displayName/bio/avatarEmail/link/tags are sourced from the wallet's User
     /// record (keyed by cryptoId), not from any single handle.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub display_name: Option<String>,
+    #[serde(default)]
     pub bio: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub avatar_email: Option<String>,
@@ -97,11 +123,14 @@ pub struct AgentProfile {
     pub link: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub registered_at: String,
+    #[serde(default)]
     pub status: String,
     pub reputation: crate::types::ReputationScore,
     pub profile_visibility: crate::types::ProfileVisibility,
     /// The wallet's owned domains/handles.
+    #[serde(default)]
     pub assets: Vec<ProfileAsset>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub activity: Option<ProfileActivity>,

--- a/sdk/rust/src/types/reputation.rs
+++ b/sdk/rust/src/types/reputation.rs
@@ -7,28 +7,38 @@ use serde::{Deserialize, Serialize}; // sibling types share a flat namespace, li
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReputationScore {
+    #[serde(default)]
     pub agent_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub username: Option<String>,
+    #[serde(default)]
     pub score: f64,
+    #[serde(default)]
     pub breakdown: HashMap<String, f64>,
+    #[serde(default)]
     pub updated_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReputationReview {
+    #[serde(default)]
     pub review_id: String,
+    #[serde(default)]
     pub reviewer: String,
+    #[serde(default)]
     pub subject: String,
+    #[serde(default)]
     pub rating: f64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub context: Option<String>,
+    #[serde(default)]
     pub transaction_ref: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signature: Option<String>,
+    #[serde(default)]
     pub created_at: String,
 }
 
@@ -37,13 +47,17 @@ pub struct ReputationReview {
 pub struct ReputationReviewCreate {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub review_id: Option<String>,
+    #[serde(default)]
     pub reviewer: String,
+    #[serde(default)]
     pub subject: String,
+    #[serde(default)]
     pub rating: f64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub context: Option<String>,
+    #[serde(default)]
     pub transaction_ref: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signature: Option<String>,
@@ -56,18 +70,25 @@ pub struct ReputationReviewCreate {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReputationVouch {
+    #[serde(default)]
     pub vouch_id: String,
+    #[serde(default)]
     pub voucher: String,
+    #[serde(default)]
     pub subject: String,
+    #[serde(default)]
     pub weight: f64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub context: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(default)]
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signature: Option<String>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub expires_at: Option<String>,
@@ -80,8 +101,11 @@ pub struct ReputationVouch {
 pub struct ReputationVouchCreate {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub vouch_id: Option<String>,
+    #[serde(default)]
     pub voucher: String,
+    #[serde(default)]
     pub subject: String,
+    #[serde(default)]
     pub weight: f64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub context: Option<String>,
@@ -99,14 +123,21 @@ pub struct ReputationVouchCreate {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Attestation {
+    #[serde(default)]
     pub attestation_id: String,
+    #[serde(default)]
     pub agent: String,
+    #[serde(default)]
     pub agent_crypto_id: String,
+    #[serde(default)]
     pub platform: String,
+    #[serde(default)]
     pub handle: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub proof_url: Option<String>,
+    #[serde(default)]
     pub verified_at: String,
+    #[serde(default)]
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub signature: Option<String>,
@@ -117,9 +148,13 @@ pub struct Attestation {
 pub struct AttestationCreate {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub attestation_id: Option<String>,
+    #[serde(default)]
     pub agent: String,
+    #[serde(default)]
     pub agent_crypto_id: String,
+    #[serde(default)]
     pub platform: String,
+    #[serde(default)]
     pub handle: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub proof_url: Option<String>,
@@ -133,6 +168,7 @@ pub struct AttestationCreate {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AttestationVerification {
+    #[serde(default)]
     pub verified: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub status: Option<String>,
@@ -145,7 +181,9 @@ pub struct AttestationVerification {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReputationHistoryPoint {
+    #[serde(default)]
     pub timestamp: String,
+    #[serde(default)]
     pub score: f64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub breakdown: Option<HashMap<String, f64>>,
@@ -155,8 +193,11 @@ pub struct ReputationHistoryPoint {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrustContributor {
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub weight: f64,
+    #[serde(default)]
     pub contribution: f64,
 }
 
@@ -164,9 +205,13 @@ pub struct TrustContributor {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrustScore {
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub trust: f64,
+    #[serde(default)]
     pub contributors: Vec<TrustContributor>,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -174,8 +219,11 @@ pub struct TrustScore {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrustGraphNode {
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub score: f64,
+    #[serde(default)]
     pub trust: f64,
 }
 
@@ -183,9 +231,13 @@ pub struct TrustGraphNode {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrustGraphEdge {
+    #[serde(default)]
     pub vouch_id: String,
+    #[serde(default)]
     pub from: String,
+    #[serde(default)]
     pub to: String,
+    #[serde(default)]
     pub weight: f64,
 }
 
@@ -193,8 +245,11 @@ pub struct TrustGraphEdge {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrustGraph {
+    #[serde(default)]
     pub nodes: Vec<TrustGraphNode>,
+    #[serde(default)]
     pub edges: Vec<TrustGraphEdge>,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -208,6 +263,7 @@ pub struct TrustGraphQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LeaderboardEntry {
+    #[serde(default)]
     pub rank: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub username: Option<String>,
@@ -272,12 +328,15 @@ pub struct LeaderboardEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LeaderboardResponse {
+    #[serde(default)]
     pub leaderboard: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub period: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub sort: Option<String>,
+    #[serde(default)]
     pub entries: Vec<LeaderboardEntry>,
+    #[serde(default)]
     pub updated_at: String,
 }
 

--- a/sdk/rust/src/types/search.rs
+++ b/sdk/rust/src/types/search.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize}; // sibling types share a flat namespace, li
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchResult {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub result_type: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub id: Option<String>,
@@ -33,6 +33,7 @@ pub struct SearchResult {
     pub price: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub score: f64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reputation: Option<f64>,
@@ -49,25 +50,33 @@ pub struct SearchResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchResponse {
+    #[serde(default)]
     pub query: String,
+    #[serde(default)]
     pub results: Vec<SearchResult>,
+    #[serde(default)]
     pub total: i64,
+    #[serde(default)]
     pub page: i64,
+    #[serde(default)]
     pub page_size: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchSuggestion {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub suggestion_type: String,
+    #[serde(default)]
     pub value: String,
+    #[serde(default)]
     pub label: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SuggestResponse {
+    #[serde(default)]
     pub suggestions: Vec<SearchSuggestion>,
 }
 
@@ -93,14 +102,20 @@ pub struct DiscoverResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiscoveryCategory {
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub source_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub pinned: Option<bool>,
+    #[serde(default)]
     pub agent_count: i64,
+    #[serde(default)]
     pub group_count: i64,
+    #[serde(default)]
     pub channel_count: i64,
+    #[serde(default)]
     pub broadcast_count: i64,
+    #[serde(default)]
     pub product_count: i64,
 }

--- a/sdk/rust/src/types/social.rs
+++ b/sdk/rust/src/types/social.rs
@@ -13,13 +13,16 @@ pub type InboxType = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxReference {
+    #[serde(default)]
     pub kind: String,
+    #[serde(default)]
     pub id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxPayload {
+    #[serde(default)]
     pub encrypted: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub body: Option<HashMap<String, serde_json::Value>>,
@@ -28,18 +31,23 @@ pub struct InboxPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxItem {
+    #[serde(default)]
     pub item_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub owner: Option<String>,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     pub type_: InboxType,
+    #[serde(default)]
     pub status: InboxStatus,
+    #[serde(default)]
     pub priority: InboxPriority,
+    #[serde(default)]
     pub timestamp: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub from: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub from_crypto_id: Option<String>,
+    #[serde(default)]
     pub subject: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub summary: Option<String>,
@@ -54,27 +62,37 @@ pub struct InboxItem {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxListResult {
+    #[serde(default)]
     pub items: Vec<InboxItem>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cursor: Option<String>,
+    #[serde(default)]
     pub unread_count: i64,
+    #[serde(default)]
     pub total_count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxCounts {
+    #[serde(default)]
     pub unread: i64,
+    #[serde(default)]
     pub read: i64,
+    #[serde(default)]
     pub archived: i64,
+    #[serde(default)]
     pub by_type: HashMap<String, i64>,
+    #[serde(default)]
     pub urgent: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxMarkResult {
+    #[serde(default)]
     pub item_ids: Vec<String>,
+    #[serde(default)]
     pub status: InboxStatus,
 }
 
@@ -117,26 +135,33 @@ pub struct InboxClearParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxReadAllResult {
+    #[serde(default)]
     pub updated: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxClearResult {
+    #[serde(default)]
     pub deleted: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Channel {
+    #[serde(default)]
     pub channel_id: String,
+    #[serde(default)]
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub creator: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub creator_crypto_id: Option<String>,
+    #[serde(default)]
     pub member_count: i64,
+    #[serde(default)]
     pub is_public: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
@@ -146,7 +171,9 @@ pub struct Channel {
     pub category: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub nsfw: Option<bool>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_activity_at: Option<String>,
@@ -176,12 +203,17 @@ pub struct ChannelQueryParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChannelMessage {
+    #[serde(default)]
     pub message_id: String,
+    #[serde(default)]
     pub channel_id: String,
+    #[serde(default)]
     pub author: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub author_crypto_id: Option<String>,
+    #[serde(default)]
     pub body: String,
+    #[serde(default)]
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub deleted_at: Option<String>,
@@ -192,11 +224,15 @@ pub struct ChannelMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChannelMember {
+    #[serde(default)]
     pub channel_id: String,
+    #[serde(default)]
     pub agent_id: String,
+    #[serde(default)]
     pub role: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub status: Option<String>,
+    #[serde(default)]
     pub joined_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub muted_at: Option<String>,
@@ -209,23 +245,31 @@ pub struct ChannelMember {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChannelCategory {
+    #[serde(default)]
     pub category: String,
+    #[serde(default)]
     pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Constitution {
+    #[serde(default)]
     pub version: String,
+    #[serde(default)]
     pub effective_date: String,
+    #[serde(default)]
     pub rules: Vec<ConstitutionRule>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConstitutionRule {
+    #[serde(default)]
     pub id: String,
+    #[serde(default)]
     pub title: String,
+    #[serde(default)]
     pub description: String,
 }
 
@@ -237,16 +281,23 @@ pub type ModerationReportContentType = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ModerationReport {
+    #[serde(default)]
     pub report_id: String,
+    #[serde(default)]
     pub reporter: String,
+    #[serde(default)]
     pub content_type: ModerationReportContentType,
+    #[serde(default)]
     pub content_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub channel_id: Option<String>,
+    #[serde(default)]
     pub rule_violated: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reviewed_by: Option<String>,
@@ -261,11 +312,15 @@ pub struct ModerationReport {
 pub struct ModerationReportCreate {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub report_id: Option<String>,
+    #[serde(default)]
     pub reporter: String,
+    #[serde(default)]
     pub content_type: ModerationReportContentType,
+    #[serde(default)]
     pub content_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub channel_id: Option<String>,
+    #[serde(default)]
     pub rule_violated: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
@@ -274,10 +329,13 @@ pub struct ModerationReportCreate {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ModerationAction {
+    #[serde(default)]
     pub action_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub report_id: Option<String>,
+    #[serde(default)]
     pub action: String,
+    #[serde(default)]
     pub target: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_type: Option<String>,
@@ -285,7 +343,9 @@ pub struct ModerationAction {
     pub content_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub channel_id: Option<String>,
+    #[serde(default)]
     pub rule_violated: String,
+    #[serde(default)]
     pub constitution_version: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reason: Option<String>,
@@ -293,18 +353,24 @@ pub struct ModerationAction {
     pub duration_seconds: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub expires_at: Option<String>,
+    #[serde(default)]
     pub created_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ModerationAppeal {
+    #[serde(default)]
     pub appeal_id: String,
+    #[serde(default)]
     pub action_id: String,
+    #[serde(default)]
     pub appellant: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment: Option<String>,
+    #[serde(default)]
     pub status: String,
+    #[serde(default)]
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reviewed_by: Option<String>,
@@ -323,10 +389,15 @@ pub struct ModerationAppeal {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Feed {
+    #[serde(default)]
     pub feed_id: String,
+    #[serde(default)]
     pub owner: String,
+    #[serde(default)]
     pub owner_crypto_id: String,
+    #[serde(default)]
     pub post_count: i64,
+    #[serde(default)]
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub updated_at: Option<String>,
@@ -338,21 +409,28 @@ pub struct Feed {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Post {
+    #[serde(default)]
     pub post_id: String,
+    #[serde(default)]
     pub feed_id: String,
+    #[serde(default)]
     pub author: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub author_crypto_id: Option<String>,
+    #[serde(default)]
     pub body: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub sequence: Option<i64>,
+    #[serde(default)]
     pub comment_count: i64,
+    #[serde(default)]
     pub like_count: i64,
     /// Whether the requesting viewer has liked this post (hydrated per-request).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub liked_by_me: Option<bool>,
+    #[serde(default)]
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub deleted_at: Option<String>,
@@ -364,10 +442,15 @@ pub struct Post {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PostLike {
+    #[serde(default)]
     pub post_id: String,
+    #[serde(default)]
     pub feed_id: String,
+    #[serde(default)]
     pub actor: String,
+    #[serde(default)]
     pub actor_crypto_id: String,
+    #[serde(default)]
     pub created_at: String,
 }
 
@@ -375,14 +458,18 @@ pub struct PostLike {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LikeResult {
+    #[serde(default)]
     pub post_id: String,
+    #[serde(default)]
     pub liked: bool,
+    #[serde(default)]
     pub like_count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PostLikersResult {
+    #[serde(default)]
     pub likers: Vec<PostLike>,
 }
 
@@ -390,15 +477,21 @@ pub struct PostLikersResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Comment {
+    #[serde(default)]
     pub comment_id: String,
+    #[serde(default)]
     pub post_id: String,
+    #[serde(default)]
     pub feed_id: String,
+    #[serde(default)]
     pub author: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub author_crypto_id: Option<String>,
+    #[serde(default)]
     pub body: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub sequence: Option<i64>,
+    #[serde(default)]
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub deleted_at: Option<String>,
@@ -412,26 +505,32 @@ pub struct Comment {
 #[serde(rename_all = "camelCase")]
 pub struct HomeFeedItem {
     pub post: Post,
+    #[serde(default)]
     pub score: f64,
+    #[serde(default)]
     pub reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HomeFeedResult {
+    #[serde(default)]
     pub items: Vec<HomeFeedItem>,
+    #[serde(default)]
     pub count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PostListResult {
+    #[serde(default)]
     pub posts: Vec<Post>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommentListResult {
+    #[serde(default)]
     pub comments: Vec<Comment>,
 }
 
@@ -460,6 +559,7 @@ pub struct HomeFeedParams {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PostCreate {
+    #[serde(default)]
     pub body: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_type: Option<String>,
@@ -471,6 +571,7 @@ pub struct PostCreate {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommentCreate {
+    #[serde(default)]
     pub body: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub comment_id: Option<String>,

--- a/sdk/rust/src/types/solana.rs
+++ b/sdk/rust/src/types/solana.rs
@@ -6,8 +6,11 @@ use serde::{Deserialize, Serialize}; // sibling types share a flat namespace, li
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SolanaRpcInfo {
+    #[serde(default)]
     pub url: String,
+    #[serde(default)]
     pub rate_limit_per_min: i64,
+    #[serde(default)]
     pub fallbacks: bool,
 }
 
@@ -15,12 +18,19 @@ pub struct SolanaRpcInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SolanaChainInfo {
+    #[serde(default)]
     pub network: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub kind: String,
+    #[serde(default)]
     pub native_asset: String,
+    #[serde(default)]
     pub explorer_url: String,
+    #[serde(default)]
     pub confirmations: i64,
+    #[serde(default)]
     pub assets: Vec<SupportedAsset>,
     pub rpc: SolanaRpcInfo,
 }
@@ -33,9 +43,11 @@ pub type SolanaRpcId = serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SolanaRpcRequest {
+    #[serde(default)]
     pub jsonrpc: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub id: Option<SolanaRpcId>,
+    #[serde(default)]
     pub method: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub params: Option<serde_json::Value>,
@@ -45,7 +57,9 @@ pub struct SolanaRpcRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SolanaRpcError {
+    #[serde(default)]
     pub code: i64,
+    #[serde(default)]
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub data: Option<serde_json::Value>,
@@ -55,12 +69,13 @@ pub struct SolanaRpcError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SolanaRpcResponse<T = serde_json::Value> {
+    #[serde(default)]
     pub jsonrpc: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub id: Option<SolanaRpcId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<T>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub error: Option<SolanaRpcError>,
 }
 

--- a/sdk/rust/src/types/user.rs
+++ b/sdk/rust/src/types/user.rs
@@ -14,14 +14,19 @@ pub type ActorType = String;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct User {
+    #[serde(default)]
     pub crypto_id: String,
+    #[serde(default)]
     pub actor_type: ActorType,
+    #[serde(default)]
     pub display_name: String,
+    #[serde(default)]
     pub bio: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub avatar_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub email: Option<String>,
+    #[serde(default)]
     pub email_verified: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub email_verified_at: Option<String>,
@@ -33,7 +38,9 @@ pub struct User {
     pub link: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub created_at: String,
+    #[serde(default)]
     pub updated_at: String,
 }
 
@@ -69,6 +76,7 @@ pub struct UserProfileUpdate {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UserEmailVerificationRequest {
+    #[serde(default)]
     pub email: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub harness_key: Option<String>,
@@ -81,7 +89,9 @@ pub struct UserEmailVerificationRequest {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UserEmailVerificationConfirmRequest {
+    #[serde(default)]
     pub email: String,
+    #[serde(default)]
     pub code: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub harness_key: Option<String>,

--- a/sdk/rust/tests/common/mod.rs
+++ b/sdk/rust/tests/common/mod.rs
@@ -28,6 +28,7 @@ pub fn client_for(server: &MockServer) -> TinyPlaceClient {
         admin_signer: Some(signer),
         admin: Default::default(),
         on_auth_invalid: None,
+        ..Default::default()
     })
 }
 

--- a/sdk/rust/tests/resilience.rs
+++ b/sdk/rust/tests/resilience.rs
@@ -1,0 +1,114 @@
+//! Transport-resilience tests: retry-with-backoff for transient failures and a
+//! timeout that surfaces a typed error when the backend is unreachable. These
+//! drive the `HttpClient` directly (like `http_pipeline.rs`) so they do not
+//! depend on any namespace method names.
+
+use std::time::Duration;
+
+use tinyplace::{Error, HttpClient, HttpClientOptions, RetryOptions};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A client with near-zero backoff so retry tests run fast.
+fn fast_retry(server_uri: String, retries: u32) -> HttpClient {
+    HttpClient::new(HttpClientOptions {
+        base_url: server_uri,
+        retry: RetryOptions {
+            retries,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(2),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+
+#[tokio::test]
+async fn retries_idempotent_get_on_503_then_succeeds() {
+    let server = MockServer::start().await;
+    // The first two attempts get a 503; wiremock then falls through to the 200.
+    Mock::given(method("GET"))
+        .and(path("/thing"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(2)
+        .expect(2)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/thing"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let http = fast_retry(server.uri(), 2);
+    let value: serde_json::Value = http.get("/thing", &[]).await.unwrap();
+    assert_eq!(value["ok"], serde_json::json!(true));
+}
+
+#[tokio::test]
+async fn gives_up_after_configured_retries() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/thing"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(3) // 1 initial attempt + 2 retries
+        .mount(&server)
+        .await;
+
+    let http = fast_retry(server.uri(), 2);
+    let result: Result<serde_json::Value, Error> = http.get("/thing", &[]).await;
+    assert_eq!(result.unwrap_err().status(), Some(500));
+}
+
+#[tokio::test]
+async fn does_not_retry_a_non_idempotent_write() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/thing"))
+        .respond_with(ResponseTemplate::new(503))
+        .expect(1) // a POST must not be auto-retried
+        .mount(&server)
+        .await;
+
+    let http = fast_retry(server.uri(), 3);
+    let result: Result<serde_json::Value, Error> =
+        http.post("/thing", None::<&serde_json::Value>).await;
+    assert_eq!(result.unwrap_err().status(), Some(503));
+}
+
+#[tokio::test]
+async fn does_not_retry_a_non_transient_status() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/thing"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let http = fast_retry(server.uri(), 3);
+    let result: Result<serde_json::Value, Error> = http.get("/thing", &[]).await;
+    assert_eq!(result.unwrap_err().status(), Some(404));
+}
+
+#[tokio::test]
+async fn unreachable_backend_times_out_as_transport_error() {
+    // Reserved TEST-NET-1 address that does not route — the connect attempt
+    // hangs until the timeout fires.
+    let http = HttpClient::new(HttpClientOptions {
+        base_url: "http://192.0.2.1:9".to_string(),
+        timeout: Some(Duration::from_millis(150)),
+        retry: RetryOptions {
+            retries: 0,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let result: Result<serde_json::Value, Error> = http.get("/thing", &[]).await;
+    let err = result.unwrap_err();
+    // A connection-level failure is a typed transport error, not a panic.
+    assert!(matches!(err, Error::Transport(_)), "got {err:?}");
+}

--- a/sdk/rust/tests/serde_tolerance.rs
+++ b/sdk/rust/tests/serde_tolerance.rs
@@ -1,0 +1,63 @@
+//! Backward-compatibility tests for response deserialization.
+//!
+//! The backend may omit or rename fields over time. With `#[serde(default)]`
+//! applied to every primitive/collection/`Option` field on response types, a
+//! missing field must fall back to its type default instead of failing the
+//! entire `serde_json::from_str`. These tests prove that by deserializing
+//! representative public response types from an EMPTY JSON object `{}`.
+
+use tinyplace::types::{
+    ActivityEvent, AgentCard, Channel, Conversation, Identity, LedgerTransaction, MessageEnvelope,
+    Product,
+};
+
+#[test]
+fn agent_card_from_empty_object() {
+    serde_json::from_str::<AgentCard>("{}").expect("AgentCard should deserialize from {}");
+}
+
+#[test]
+fn identity_from_empty_object() {
+    serde_json::from_str::<Identity>("{}").expect("Identity should deserialize from {}");
+}
+
+#[test]
+fn message_envelope_from_empty_object() {
+    serde_json::from_str::<MessageEnvelope>("{}")
+        .expect("MessageEnvelope should deserialize from {}");
+}
+
+#[test]
+fn conversation_from_empty_object() {
+    serde_json::from_str::<Conversation>("{}").expect("Conversation should deserialize from {}");
+}
+
+#[test]
+fn channel_from_empty_object() {
+    serde_json::from_str::<Channel>("{}").expect("Channel should deserialize from {}");
+}
+
+#[test]
+fn product_from_empty_object() {
+    serde_json::from_str::<Product>("{}").expect("Product should deserialize from {}");
+}
+
+#[test]
+fn ledger_transaction_from_empty_object() {
+    serde_json::from_str::<LedgerTransaction>("{}")
+        .expect("LedgerTransaction should deserialize from {}");
+}
+
+#[test]
+fn activity_event_from_empty_object() {
+    serde_json::from_str::<ActivityEvent>("{}").expect("ActivityEvent should deserialize from {}");
+}
+
+/// Unknown/renamed-to-new fields must still be ignored (no `deny_unknown_fields`),
+/// and known-but-renamed-away fields fall back to defaults.
+#[test]
+fn tolerates_unknown_fields() {
+    let json = r#"{"thisFieldDoesNotExist": 123, "anotherBogusField": "x"}"#;
+    serde_json::from_str::<AgentCard>(json)
+        .expect("AgentCard should ignore unknown fields and default the rest");
+}

--- a/sdk/typescript/src/api/activity.ts
+++ b/sdk/typescript/src/api/activity.ts
@@ -3,7 +3,10 @@ import type { TinyPlaceWebSocket } from "../websocket.js";
 import type {
   ActivityListParams,
   ActivityListResponse,
+  ActivityEvent,
+  ActivityStats,
 } from "../types/index.js";
+import { field, listField } from "../safe.js";
 
 /**
  * ActivityApi reads the global activity livestream — a public, normalized
@@ -18,10 +21,12 @@ export class ActivityApi {
   ) {}
 
   list(params?: ActivityListParams): Promise<ActivityListResponse> {
-    return this.http.get<ActivityListResponse>(
-      "/activity",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<ActivityListResponse>("/activity", params as Record<string, unknown>)
+      .then((result) => ({
+        events: listField<ActivityEvent>(result, "events"),
+        stats: field<ActivityStats>(result, "stats") as ActivityStats,
+      }));
   }
 
   stream(params?: ActivityListParams): TinyPlaceWebSocket | undefined {

--- a/sdk/typescript/src/api/admin.ts
+++ b/sdk/typescript/src/api/admin.ts
@@ -8,6 +8,7 @@ import type {
   FeeResolveResponse,
   SystemConfig,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export class AdminApi {
   constructor(private readonly http: HttpClient) {}
@@ -15,7 +16,9 @@ export class AdminApi {
   // --- Fee Configuration ---
 
   listFees(): Promise<{ fees: Array<FeeConfig> }> {
-    return this.http.getAdmin<{ fees: Array<FeeConfig> }>("/admin/fees");
+    return this.http
+      .getAdmin<{ fees: Array<FeeConfig> | null }>("/admin/fees")
+      .then((result) => ({ fees: listField<FeeConfig>(result, "fees") }));
   }
 
   createFee(fee: Partial<FeeConfig>): Promise<FeeConfig> {
@@ -109,10 +112,12 @@ export class AdminApi {
     limit?: number;
     offset?: number;
   }): Promise<{ audit: Array<AdminAuditEntry> }> {
-    return this.http.getAdmin<{ audit: Array<AdminAuditEntry> }>(
-      "/admin/audit",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .getAdmin<{ audit: Array<AdminAuditEntry> | null }>(
+        "/admin/audit",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({ audit: listField<AdminAuditEntry>(result, "audit") }));
   }
 
   // --- Metrics ---

--- a/sdk/typescript/src/api/artifacts.ts
+++ b/sdk/typescript/src/api/artifacts.ts
@@ -6,6 +6,7 @@ import type {
   ArtifactQueryParams,
   ArtifactRecipientUpdate,
 } from "../types/index.js";
+import { asString, listField } from "../safe.js";
 
 export class ArtifactsApi {
   constructor(private readonly http: HttpClient) {}
@@ -14,17 +15,20 @@ export class ArtifactsApi {
     params?: ArtifactQueryParams,
     actorId?: string,
   ): Promise<ArtifactListResult> {
-    if (actorId) {
-      return this.http.getDirectoryAuthAs<ArtifactListResult>(
-        "/artifacts",
-        actorId,
-        params as Record<string, unknown>,
-      );
-    }
-    return this.http.getDirectoryAuth<ArtifactListResult>(
-      "/artifacts",
-      params as Record<string, unknown>,
-    );
+    const request = actorId
+      ? this.http.getDirectoryAuthAs<ArtifactListResult>(
+          "/artifacts",
+          actorId,
+          params as Record<string, unknown>,
+        )
+      : this.http.getDirectoryAuth<ArtifactListResult>(
+          "/artifacts",
+          params as Record<string, unknown>,
+        );
+    return request.then((result) => ({
+      artifacts: listField<Artifact>(result, "artifacts"),
+      cursor: asString((result as { cursor?: unknown })?.cursor) || undefined,
+    }));
   }
 
   create(request: ArtifactCreateRequest, ownerId?: string): Promise<Artifact> {

--- a/sdk/typescript/src/api/bounties.ts
+++ b/sdk/typescript/src/api/bounties.ts
@@ -8,6 +8,7 @@ import type {
   BountySubmission,
   BountySubmissionCreateRequest,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 // BountiesApi covers the bounty platform: create + fund in one x402 flow (the
 // reward into escrow), browse, submit a URL, comment for free, run the
@@ -18,10 +19,12 @@ export class BountiesApi {
   // --- Bounties ---
 
   list(params?: BountyQueryParams): Promise<{ bounties: Array<Bounty> }> {
-    return this.http.get<{ bounties: Array<Bounty> }>(
-      "/bounties",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ bounties: Array<Bounty> | null }>(
+        "/bounties",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({ bounties: listField<Bounty>(result, "bounties") }));
   }
 
   get(bountyId: string): Promise<Bounty> {
@@ -61,10 +64,14 @@ export class BountiesApi {
     bountyId: string,
     params?: { status?: string; submitter?: string; limit?: number },
   ): Promise<{ submissions: Array<BountySubmission> }> {
-    return this.http.get<{ submissions: Array<BountySubmission> }>(
-      `/bounties/${encodeURIComponent(bountyId)}/submissions`,
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ submissions: Array<BountySubmission> | null }>(
+        `/bounties/${encodeURIComponent(bountyId)}/submissions`,
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        submissions: listField<BountySubmission>(result, "submissions"),
+      }));
   }
 
   // --- Comments (free) ---
@@ -84,10 +91,14 @@ export class BountiesApi {
     bountyId: string,
     params?: { limit?: number; offset?: number },
   ): Promise<{ comments: Array<BountyComment> }> {
-    return this.http.get<{ comments: Array<BountyComment> }>(
-      `/bounties/${encodeURIComponent(bountyId)}/comments`,
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ comments: Array<BountyComment> | null }>(
+        `/bounties/${encodeURIComponent(bountyId)}/comments`,
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        comments: listField<BountyComment>(result, "comments"),
+      }));
   }
 
   // --- Council + approval ---

--- a/sdk/typescript/src/api/broadcasts.ts
+++ b/sdk/typescript/src/api/broadcasts.ts
@@ -8,6 +8,7 @@ import type {
   BroadcastSubscribeRequest,
   BroadcastSubscriber,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export class BroadcastsApi {
   constructor(
@@ -26,7 +27,9 @@ export class BroadcastsApi {
         "/broadcasts",
         params as Record<string, unknown>,
       )
-      .then((result) => ({ broadcasts: result.broadcasts ?? [] }));
+      .then((result) => ({
+        broadcasts: listField<BroadcastChannel>(result, "broadcasts"),
+      }));
   }
 
   create(request: BroadcastCreateRequest): Promise<BroadcastChannel> {
@@ -149,14 +152,16 @@ export class BroadcastsApi {
     broadcastId: string,
     actor?: string,
   ): Promise<{ subscribers: Array<BroadcastSubscriber> }> {
-    if (actor) {
-      return this.http.getDirectoryAuthAs<{
-        subscribers: Array<BroadcastSubscriber>;
-      }>(`/broadcasts/${encodeURIComponent(broadcastId)}/subscribers`, actor);
-    }
-    return this.http.getDirectoryAuth<{
-      subscribers: Array<BroadcastSubscriber>;
-    }>(`/broadcasts/${encodeURIComponent(broadcastId)}/subscribers`);
+    const request = actor
+      ? this.http.getDirectoryAuthAs<{
+          subscribers: Array<BroadcastSubscriber> | null;
+        }>(`/broadcasts/${encodeURIComponent(broadcastId)}/subscribers`, actor)
+      : this.http.getDirectoryAuth<{
+          subscribers: Array<BroadcastSubscriber> | null;
+        }>(`/broadcasts/${encodeURIComponent(broadcastId)}/subscribers`);
+    return request.then((result) => ({
+      subscribers: listField<BroadcastSubscriber>(result, "subscribers"),
+    }));
   }
 
   removeSubscriber(
@@ -198,7 +203,9 @@ export class BroadcastsApi {
           query as Record<string, unknown>,
           headers,
         )
-        .then((result) => ({ messages: result.messages ?? [] }));
+        .then((result) => ({
+          messages: listField<BroadcastMessage>(result, "messages"),
+        }));
     }
     return this.http
       .getDirectoryAuth<{

--- a/sdk/typescript/src/api/contacts.ts
+++ b/sdk/typescript/src/api/contacts.ts
@@ -6,7 +6,9 @@ import type {
   ContactsResponse,
   ContactStats,
   ContactStatusResponse,
+  ContactView,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 /**
  * ContactsApi manages the mutual first-level contact graph: send/accept/decline
@@ -60,18 +62,27 @@ export class ContactsApi {
 
   /** List the acting agent's accepted contacts. */
   list(params?: ContactListParams): Promise<ContactsResponse> {
-    return this.http.getAgentAuth<ContactsResponse>(
-      "/contacts",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .getAgentAuth<ContactsResponse>(
+        "/contacts",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        contacts: listField<ContactView>(result, "contacts"),
+      }));
   }
 
   /** List pending incoming and outgoing requests. */
   requests(params?: ContactListParams): Promise<ContactRequestsResponse> {
-    return this.http.getAgentAuth<ContactRequestsResponse>(
-      "/contacts/requests",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .getAgentAuth<ContactRequestsResponse>(
+        "/contacts/requests",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        incoming: listField<ContactView>(result, "incoming"),
+        outgoing: listField<ContactView>(result, "outgoing"),
+      }));
   }
 
   /** Get the relationship status with agentId. */

--- a/sdk/typescript/src/api/conversations.ts
+++ b/sdk/typescript/src/api/conversations.ts
@@ -10,6 +10,7 @@ import type {
   ConversationRoleChange,
   ConversationUpdateRequest,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export class ConversationsApi {
   constructor(
@@ -27,7 +28,9 @@ export class ConversationsApi {
       .get<{
         conversations: Array<Conversation> | null;
       }>("/conversations", params as Record<string, unknown>)
-      .then((result) => ({ conversations: result.conversations ?? [] }));
+      .then((result) => ({
+        conversations: listField<Conversation>(result, "conversations"),
+      }));
   }
 
   create(request: ConversationCreateRequest): Promise<Conversation> {
@@ -114,7 +117,9 @@ export class ConversationsApi {
       .get<{
         members: Array<ConversationMember> | null;
       }>(`/conversations/${encodeURIComponent(conversationId)}/members`)
-      .then((result) => ({ members: result.members ?? [] }));
+      .then((result) => ({
+        members: listField<ConversationMember>(result, "members"),
+      }));
   }
 
   addMember(
@@ -196,7 +201,9 @@ export class ConversationsApi {
       .get<{
         messages: Array<ConversationMessage> | null;
       }>(`/conversations/${encodeURIComponent(conversationId)}/messages`, params as Record<string, unknown>)
-      .then((result) => ({ messages: result.messages ?? [] }));
+      .then((result) => ({
+        messages: listField<ConversationMessage>(result, "messages"),
+      }));
   }
 
   postMessage(

--- a/sdk/typescript/src/api/directory.ts
+++ b/sdk/typescript/src/api/directory.ts
@@ -15,16 +15,19 @@ import {
   validateExtendedAgentCard,
   validateIdentityListingQueryParams,
 } from "../validation.js";
+import { listField } from "../safe.js";
 
 export class DirectoryApi {
   constructor(private readonly http: HttpClient) {}
 
   listAgents(params?: AgentQueryParams): Promise<{ agents: Array<AgentCard> }> {
     validateAgentQueryParams(params);
-    return this.http.get<{ agents: Array<AgentCard> }>(
-      "/directory/agents",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ agents: Array<AgentCard> | null }>(
+        "/directory/agents",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({ agents: listField<AgentCard>(result, "agents") }));
   }
 
   getAgent(agentId: string): Promise<AgentCard> {

--- a/sdk/typescript/src/api/docs.ts
+++ b/sdk/typescript/src/api/docs.ts
@@ -4,6 +4,7 @@ import type {
   TermsDocument,
   TermsHistoryResponse,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export class DocsApi {
   constructor(private readonly http: HttpClient) {}
@@ -45,7 +46,11 @@ export class DocsApi {
   }
 
   termsHistory(): Promise<TermsHistoryResponse> {
-    return this.http.get<TermsHistoryResponse>("/terms/history");
+    return this.http
+      .get<TermsHistoryResponse>("/terms/history")
+      .then((result) => ({
+        terms: listField<TermsDocument>(result, "terms"),
+      }));
   }
 
   llms(): Promise<string> {

--- a/sdk/typescript/src/api/escrow.ts
+++ b/sdk/typescript/src/api/escrow.ts
@@ -8,6 +8,7 @@ import type {
   EscrowMilestone,
   EscrowQueryParams,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export class EscrowApi {
   constructor(
@@ -21,10 +22,12 @@ export class EscrowApi {
   list(params?: EscrowQueryParams): Promise<{ escrows: Array<Escrow> }> {
     // Escrow reads expose private bilateral contracts; the backend requires the
     // freshness-bound (directory) signature and scopes results to the caller.
-    return this.http.getDirectoryAuth<{ escrows: Array<Escrow> }>(
-      "/escrow",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .getDirectoryAuth<{ escrows: Array<Escrow> | null }>(
+        "/escrow",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({ escrows: listField<Escrow>(result, "escrows") }));
   }
 
   create(request: EscrowCreateRequest): Promise<Escrow> {

--- a/sdk/typescript/src/api/events.ts
+++ b/sdk/typescript/src/api/events.ts
@@ -12,6 +12,7 @@ import type {
   EventVisibility,
 } from "../types/index.js";
 import type { X402PaymentMap } from "../x402.js";
+import { listField } from "../safe.js";
 
 export interface EventRsvpRequest {
   agentId?: string;
@@ -30,10 +31,12 @@ export class EventsApi {
   ) {}
 
   list(params?: EventQueryParams): Promise<{ events: Array<Event> }> {
-    return this.http.get<{ events: Array<Event> }>(
-      "/events",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ events: Array<Event> | null }>(
+        "/events",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({ events: listField<Event>(result, "events") }));
   }
 
   create(event: Partial<Event>, hostId = event.host): Promise<Event> {
@@ -122,14 +125,22 @@ export class EventsApi {
     actorId?: string,
   ): Promise<{ attendees: Array<EventAttendee> }> {
     if (actorId) {
-      return this.http.getDirectoryAuthAs<{ attendees: Array<EventAttendee> }>(
-        `/events/${encodeURIComponent(eventId)}/attendees`,
-        actorId,
-      );
+      return this.http
+        .getDirectoryAuthAs<{ attendees: Array<EventAttendee> | null }>(
+          `/events/${encodeURIComponent(eventId)}/attendees`,
+          actorId,
+        )
+        .then((result) => ({
+          attendees: listField<EventAttendee>(result, "attendees"),
+        }));
     }
-    return this.http.getDirectoryAuth<{ attendees: Array<EventAttendee> }>(
-      `/events/${encodeURIComponent(eventId)}/attendees`,
-    );
+    return this.http
+      .getDirectoryAuth<{ attendees: Array<EventAttendee> | null }>(
+        `/events/${encodeURIComponent(eventId)}/attendees`,
+      )
+      .then((result) => ({
+        attendees: listField<EventAttendee>(result, "attendees"),
+      }));
   }
 
   removeAttendee(
@@ -197,9 +208,13 @@ export class EventsApi {
   }
 
   getStage(eventId: string): Promise<{ messages: Array<EventStageMessage> }> {
-    return this.http.get<{ messages: Array<EventStageMessage> }>(
-      `/events/${encodeURIComponent(eventId)}/stage`,
-    );
+    return this.http
+      .get<{ messages: Array<EventStageMessage> | null }>(
+        `/events/${encodeURIComponent(eventId)}/stage`,
+      )
+      .then((result) => ({
+        messages: listField<EventStageMessage>(result, "messages"),
+      }));
   }
 
   postToStage(
@@ -364,9 +379,13 @@ export class EventsApi {
   }
 
   questions(eventId: string): Promise<{ questions: Array<EventQuestion> }> {
-    return this.http.get<{ questions: Array<EventQuestion> }>(
-      `/events/${encodeURIComponent(eventId)}/questions`,
-    );
+    return this.http
+      .get<{ questions: Array<EventQuestion> | null }>(
+        `/events/${encodeURIComponent(eventId)}/questions`,
+      )
+      .then((result) => ({
+        questions: listField<EventQuestion>(result, "questions"),
+      }));
   }
 
   postQuestion(
@@ -464,9 +483,11 @@ export class EventsApi {
   }
 
   polls(eventId: string): Promise<{ polls: Array<EventPoll> }> {
-    return this.http.get<{ polls: Array<EventPoll> }>(
-      `/events/${encodeURIComponent(eventId)}/polls`,
-    );
+    return this.http
+      .get<{ polls: Array<EventPoll> | null }>(
+        `/events/${encodeURIComponent(eventId)}/polls`,
+      )
+      .then((result) => ({ polls: listField<EventPoll>(result, "polls") }));
   }
 
   createPoll(
@@ -543,7 +564,9 @@ export class EventsApi {
   }
 
   listSeries(): Promise<{ series: Array<EventSeries> }> {
-    return this.http.get<{ series: Array<EventSeries> }>("/events/series");
+    return this.http
+      .get<{ series: Array<EventSeries> | null }>("/events/series")
+      .then((result) => ({ series: listField<EventSeries>(result, "series") }));
   }
 
   createSeries(

--- a/sdk/typescript/src/api/explorer.ts
+++ b/sdk/typescript/src/api/explorer.ts
@@ -6,7 +6,9 @@ import type {
   ExplorerTransactionDetail,
   ExplorerTransactionListResponse,
   ExplorerVerification,
+  ExplorerTransactionSummary,
 } from "../types/index.js";
+import { asObject, asNumber, field, listField } from "../safe.js";
 
 export class ExplorerApi {
   constructor(
@@ -15,11 +17,15 @@ export class ExplorerApi {
   ) {}
 
   root(): Promise<ExplorerOverview> {
-    return this.http.get<ExplorerOverview>("/explorer");
+    return this.http
+      .get<ExplorerOverview>("/explorer")
+      .then(coalesceOverview);
   }
 
   overview(): Promise<ExplorerOverview> {
-    return this.http.get<ExplorerOverview>("/explorer/overview");
+    return this.http
+      .get<ExplorerOverview>("/explorer/overview")
+      .then(coalesceOverview);
   }
 
   listTransactions(params?: {
@@ -29,10 +35,22 @@ export class ExplorerApi {
     status?: string;
     type?: string;
   }): Promise<ExplorerTransactionListResponse> {
-    return this.http.get<ExplorerTransactionListResponse>(
-      "/explorer/transactions",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<ExplorerTransactionListResponse>(
+        "/explorer/transactions",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        ...(asObject<ExplorerTransactionListResponse>(result) ??
+          ({} as ExplorerTransactionListResponse)),
+        transactions: listField<ExplorerTransactionSummary>(
+          result,
+          "transactions",
+        ),
+        total: asNumber(field(result, "total")),
+        page: asNumber(field(result, "page")),
+        pageSize: asNumber(field(result, "pageSize")),
+      }));
   }
 
   getTransaction(txId: string): Promise<ExplorerTransactionDetail> {
@@ -48,12 +66,31 @@ export class ExplorerApi {
   }
 
   getAgent(agentId: string): Promise<ExplorerAgentResponse> {
-    return this.http.get<ExplorerAgentResponse>(
-      `/explorer/agents/${encodeURIComponent(agentId)}`,
-    );
+    return this.http
+      .get<ExplorerAgentResponse>(
+        `/explorer/agents/${encodeURIComponent(agentId)}`,
+      )
+      .then((result) => ({
+        ...(asObject<ExplorerAgentResponse>(result) ??
+          ({} as ExplorerAgentResponse)),
+        recentTransactions: listField<ExplorerTransactionSummary>(
+          result,
+          "recentTransactions",
+        ),
+      }));
   }
 
   live(): TinyPlaceWebSocket | undefined {
     return this.wsFactory?.("/explorer/live");
   }
+}
+
+function coalesceOverview(result: ExplorerOverview): ExplorerOverview {
+  return {
+    ...(asObject<ExplorerOverview>(result) ?? ({} as ExplorerOverview)),
+    recentTransactions: listField<ExplorerTransactionSummary>(
+      result,
+      "recentTransactions",
+    ),
+  };
 }

--- a/sdk/typescript/src/api/feedback.ts
+++ b/sdk/typescript/src/api/feedback.ts
@@ -6,6 +6,7 @@ import type {
   FeedbackStatusUpdate,
   FeedbackVoteRequest,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export class FeedbackApi {
   constructor(private readonly http: HttpClient) {}
@@ -13,19 +14,27 @@ export class FeedbackApi {
   list(
     params?: FeedbackListParams,
   ): Promise<{ feedback: Array<FeedbackItem> }> {
-    return this.http.get<{ feedback: Array<FeedbackItem> }>(
-      "/feedback",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ feedback: Array<FeedbackItem> | null }>(
+        "/feedback",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        feedback: listField<FeedbackItem>(result, "feedback"),
+      }));
   }
 
   listAdmin(
     params?: FeedbackListParams,
   ): Promise<{ feedback: Array<FeedbackItem> }> {
-    return this.http.getAdmin<{ feedback: Array<FeedbackItem> }>(
-      "/feedback",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .getAdmin<{ feedback: Array<FeedbackItem> | null }>(
+        "/feedback",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        feedback: listField<FeedbackItem>(result, "feedback"),
+      }));
   }
 
   get(feedbackId: string): Promise<FeedbackItem> {

--- a/sdk/typescript/src/api/follows.ts
+++ b/sdk/typescript/src/api/follows.ts
@@ -8,6 +8,8 @@ import type {
   FollowListParams,
   FollowStats,
 } from "../types/index.js";
+import type { ActivityEvent, ActivityStats } from "../types/index.js";
+import { asObject, field, listField } from "../safe.js";
 
 /**
  * FollowsApi manages the agent-only social graph and personalized activity
@@ -32,20 +34,28 @@ export class FollowsApi {
     agentId: string,
     params?: FollowListParams,
   ): Promise<FollowersResponse> {
-    return this.http.get<FollowersResponse>(
-      `/follows/${encodeURIComponent(agentId)}/followers`,
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<FollowersResponse>(
+        `/follows/${encodeURIComponent(agentId)}/followers`,
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        followers: listField<AgentFollow>(result, "followers"),
+      }));
   }
 
   following(
     agentId: string,
     params?: FollowListParams,
   ): Promise<FollowingResponse> {
-    return this.http.get<FollowingResponse>(
-      `/follows/${encodeURIComponent(agentId)}/following`,
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<FollowingResponse>(
+        `/follows/${encodeURIComponent(agentId)}/following`,
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        following: listField<AgentFollow>(result, "following"),
+      }));
   }
 
   stats(agentId: string): Promise<FollowStats> {
@@ -55,9 +65,13 @@ export class FollowsApi {
   }
 
   feed(params?: FeedListParams): Promise<FeedResponse> {
-    return this.http.getAgentAuth<FeedResponse>(
-      "/feed",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .getAgentAuth<FeedResponse>("/feed", params as Record<string, unknown>)
+      .then((result) => ({
+        events: listField<ActivityEvent>(result, "events"),
+        following: listField<AgentFollow>(result, "following"),
+        stats: (asObject<ActivityStats>(field(result, "stats")) ??
+          {}) as ActivityStats,
+      }));
   }
 }

--- a/sdk/typescript/src/api/graphql.ts
+++ b/sdk/typescript/src/api/graphql.ts
@@ -53,13 +53,20 @@ import type {
   GqlJobPosting,
   GqlLedgerTransaction,
   GqlLedgerTransactionListResult,
+  GqlIdentityBid,
+  GqlIdentityOffer,
+  GqlIdentitySale,
   GqlPostDetail,
+  GqlPostLiker,
   GqlPostLikerListResult,
   GqlPostListResult,
   GqlProduct,
   GqlProductListResult,
   GqlProfile,
 } from "../types/graphql.js";
+import type { GqlHomeFeedItem, GqlPost } from "../types/social.js";
+import type { Attestation } from "../types/reputation.js";
+import { asArray, asNumber, field, listField } from "../safe.js";
 
 export interface BountyGraphQLParams {
   status?: string;
@@ -137,7 +144,10 @@ export class GraphQLApi {
         },
         { auth: "agent" },
       )
-      .then((data) => data.homeFeed);
+      .then((data) => ({
+        items: listField<GqlHomeFeedItem>(data.homeFeed, "items"),
+        count: asNumber(field(data.homeFeed, "count")),
+      }));
   }
 
   /** Comments on a post, with authors (and verified status) embedded. Public. */
@@ -152,7 +162,7 @@ export class GraphQLApi {
         limit: params?.limit,
         after: params?.after,
       })
-      .then((data) => data.comments);
+      .then((data) => asArray<GqlComment>(data.comments));
   }
 
   /** Posts on a wallet/profile feed, with authors and viewer-like state embedded. Public. */
@@ -164,7 +174,10 @@ export class GraphQLApi {
         before: params?.before,
         viewer: params?.viewer,
       })
-      .then((data) => data.posts);
+      .then((data) => ({
+        posts: listField<GqlPost>(data.posts, "posts"),
+        count: asNumber(field(data.posts, "count")),
+      }));
   }
 
   /** A single post with paginated comments and likers embedded. Public. */
@@ -183,7 +196,15 @@ export class GraphQLApi {
         likerLimit: params?.likerLimit,
         likerOffset: params?.likerOffset,
       })
-      .then((data) => data.post);
+      .then((data) =>
+        data.post
+          ? {
+              ...data.post,
+              comments: listField<GqlComment>(data.post, "comments"),
+              likers: listField<GqlPostLiker>(data.post, "likers"),
+            }
+          : data.post,
+      );
   }
 
   /** Likers on a post, with actor details embedded. Public. */
@@ -197,21 +218,24 @@ export class GraphQLApi {
         limit: params?.limit,
         offset: params?.offset,
       })
-      .then((data) => data.postLikers);
+      .then((data) => ({
+        likers: listField<GqlPostLiker>(data.postLikers, "likers"),
+        count: asNumber(field(data.postLikers, "count")),
+      }));
   }
 
   /** A wallet profile resolved from an @handle, attestations embedded. Public. */
   profile(username: string): Promise<GqlProfile | null> {
     return this.http
       .graphql<{ profile: GqlProfile | null }>(USER_PROFILE_QUERY, { username })
-      .then((data) => data.profile);
+      .then((data) => coalesceProfile(data.profile));
   }
 
   /** A wallet profile by raw crypto ID, including owned identities. Public. */
   user(cryptoId: string): Promise<GqlProfile | null> {
     return this.http
       .graphql<{ user: GqlProfile | null }>(USER_BY_CRYPTO_ID_QUERY, { cryptoId })
-      .then((data) => data.user);
+      .then((data) => coalesceProfile(data.user));
   }
 
   /** A single @handle identity record, optionally with owner details. Public. */
@@ -225,7 +249,7 @@ export class GraphQLApi {
   identities(cryptoId: string): Promise<Array<Identity>> {
     return this.http
       .graphql<{ identities: Array<Identity> }>(IDENTITIES_QUERY, { cryptoId })
-      .then((data) => data.identities);
+      .then((data) => asArray<Identity>(data.identities));
   }
 
   /** A single agent directory card. Public. */
@@ -263,7 +287,10 @@ export class GraphQLApi {
         },
         { auth: "agent" },
       )
-      .then((data) => data.agents);
+      .then((data) => ({
+        agents: listField<GqlAgentCard>(data.agents, "agents"),
+        count: asNumber(field(data.agents, "count")),
+      }));
   }
 
   /** Marketplace products with sellers embedded. Public. */
@@ -280,7 +307,7 @@ export class GraphQLApi {
         limit: params?.limit,
         offset: params?.offset,
       })
-      .then((data) => data.products.products);
+      .then((data) => listField<GqlProduct>(data.products, "products"));
   }
 
   /** A single marketplace product with seller embedded. Public. */
@@ -311,7 +338,13 @@ export class GraphQLApi {
           offset: params?.offset,
         },
       )
-      .then((data) => data.identityListings);
+      .then((data) => ({
+        listings: listField<GqlIdentityListing>(
+          data.identityListings,
+          "listings",
+        ),
+        count: asNumber(field(data.identityListings, "count")),
+      }));
   }
 
   /** One identity marketplace listing, with paginated bids/history embedded. Public. */
@@ -330,7 +363,18 @@ export class GraphQLApi {
           historyOffset: params?.historyOffset,
         },
       )
-      .then((data) => data.identityListing);
+      .then((data) =>
+        data.identityListing
+          ? {
+              ...data.identityListing,
+              bids: listField<GqlIdentityBid>(data.identityListing, "bids"),
+              history: listField<GqlIdentitySale>(
+                data.identityListing,
+                "history",
+              ),
+            }
+          : data.identityListing,
+      );
   }
 
   /** Bids for an identity auction listing, with bidder details embedded. Public. */
@@ -344,7 +388,10 @@ export class GraphQLApi {
         limit: params?.limit,
         offset: params?.offset,
       })
-      .then((data) => data.identityBids);
+      .then((data) => ({
+        bids: listField<GqlIdentityBid>(data.identityBids, "bids"),
+        count: asNumber(field(data.identityBids, "count")),
+      }));
   }
 
   /** Identity offers, with buyer details embedded. Public. */
@@ -363,7 +410,10 @@ export class GraphQLApi {
           offset: params?.offset,
         },
       )
-      .then((data) => data.identityOffers);
+      .then((data) => ({
+        offers: listField<GqlIdentityOffer>(data.identityOffers, "offers"),
+        count: asNumber(field(data.identityOffers, "count")),
+      }));
   }
 
   /** Sale history for one @handle, with seller/buyer details embedded. Public. */
@@ -380,7 +430,10 @@ export class GraphQLApi {
           offset: params?.offset,
         },
       )
-      .then((data) => data.identitySales);
+      .then((data) => ({
+        sales: listField<GqlIdentitySale>(data.identitySales, "sales"),
+        count: asNumber(field(data.identitySales, "count")),
+      }));
   }
 
   /** Bounties/jobs with client profiles embedded. Public. */
@@ -394,7 +447,10 @@ export class GraphQLApi {
         limit: params?.limit,
         offset: params?.offset,
       })
-      .then((data) => data.jobs);
+      .then((data) => ({
+        jobs: listField<GqlJobPosting>(data.jobs, "jobs"),
+        count: asNumber(field(data.jobs, "count")),
+      }));
   }
 
   /** A single bounty/job with client profile embedded. Public. */
@@ -426,7 +482,13 @@ export class GraphQLApi {
           offset: params?.offset,
         },
       )
-      .then((data) => data.ledgerTransactions);
+      .then((data) => ({
+        transactions: listField<GqlLedgerTransaction>(
+          data.ledgerTransactions,
+          "transactions",
+        ),
+        count: asNumber(field(data.ledgerTransactions, "count")),
+      }));
   }
 
   /** A single ledger transaction. Public. */
@@ -448,7 +510,7 @@ export class GraphQLApi {
         limit: params?.limit,
         offset: params?.offset,
       })
-      .then((data) => data.bounties);
+      .then((data) => asArray<GqlBounty>(data.bounties));
   }
 
   /** A single bounty by id. Public. */
@@ -457,4 +519,21 @@ export class GraphQLApi {
       .graphql<{ bounty: GqlBounty | null }>(BOUNTY_QUERY, { id })
       .then((data) => data.bounty);
   }
+}
+
+/**
+ * Coalesce the array-valued fields of a GraphQL profile so a renamed/missing
+ * `attestations`/`tags`/`identities` never breaks a caller that `.map`s them.
+ * Preserves `null` (no profile) and every scalar/object field.
+ */
+function coalesceProfile(profile: GqlProfile | null): GqlProfile | null {
+  if (!profile) {
+    return profile;
+  }
+  return {
+    ...profile,
+    attestations: listField<Attestation>(profile, "attestations"),
+    tags: listField<string>(profile, "tags"),
+    identities: listField<GqlIdentity>(profile, "identities"),
+  };
 }

--- a/sdk/typescript/src/api/groups.ts
+++ b/sdk/typescript/src/api/groups.ts
@@ -16,6 +16,7 @@ import type {
   GroupSubscriptionEnforceResponse,
   GroupSubscriptionRenewRequest,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export class GroupsApi {
   constructor(private readonly http: HttpClient) {}
@@ -53,9 +54,13 @@ export class GroupsApi {
   }
 
   members(groupId: string): Promise<{ members: Array<GroupMember> }> {
-    return this.http.get<{ members: Array<GroupMember> }>(
-      `/directory/groups/${encodeURIComponent(groupId)}/members`,
-    );
+    return this.http
+      .get<{ members: Array<GroupMember> | null }>(
+        `/directory/groups/${encodeURIComponent(groupId)}/members`,
+      )
+      .then((result) => ({
+        members: listField<GroupMember>(result, "members"),
+      }));
   }
 
   addMember(

--- a/sdk/typescript/src/api/inbox.ts
+++ b/sdk/typescript/src/api/inbox.ts
@@ -10,6 +10,7 @@ import type {
   InboxQueryParams,
   InboxReadAllResult,
 } from "../types/index.js";
+import { asNumber, asString, field, listField } from "../safe.js";
 
 export class InboxApi {
   constructor(
@@ -19,16 +20,17 @@ export class InboxApi {
 
   list(params?: InboxQueryParams, owner?: string): Promise<InboxListResult> {
     if (owner) {
-      return this.http.getDirectoryAuthAs<InboxListResult>(
-        "/inbox",
-        owner,
-        params as Record<string, unknown>,
-      );
+      return this.http
+        .getDirectoryAuthAs<InboxListResult>(
+          "/inbox",
+          owner,
+          params as Record<string, unknown>,
+        )
+        .then(coalesceInboxList);
     }
-    return this.http.getAgentAuth<InboxListResult>(
-      "/inbox",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .getAgentAuth<InboxListResult>("/inbox", params as Record<string, unknown>)
+      .then(coalesceInboxList);
   }
 
   get(itemId: string, owner?: string): Promise<InboxItem> {
@@ -45,15 +47,19 @@ export class InboxApi {
 
   search(query: string, owner?: string): Promise<{ items: Array<InboxItem> }> {
     if (owner) {
-      return this.http.getDirectoryAuthAs<{ items: Array<InboxItem> }>(
-        "/inbox/search",
-        owner,
-        { q: query },
-      );
+      return this.http
+        .getDirectoryAuthAs<{ items: Array<InboxItem> | null }>(
+          "/inbox/search",
+          owner,
+          { q: query },
+        )
+        .then((result) => ({ items: listField<InboxItem>(result, "items") }));
     }
-    return this.http.getAgentAuth<{ items: Array<InboxItem> }>("/inbox/search", {
-      q: query,
-    });
+    return this.http
+      .getAgentAuth<{ items: Array<InboxItem> | null }>("/inbox/search", {
+        q: query,
+      })
+      .then((result) => ({ items: listField<InboxItem>(result, "items") }));
   }
 
   counts(owner?: string): Promise<InboxCounts> {
@@ -190,4 +196,14 @@ export class InboxApi {
   stream(): TinyPlaceWebSocket | undefined {
     return this.wsFactory?.("/inbox/stream");
   }
+}
+
+function coalesceInboxList(result: InboxListResult): InboxListResult {
+  const cursor = field(result, "cursor");
+  return {
+    items: listField<InboxItem>(result, "items"),
+    ...(typeof cursor === "string" ? { cursor: asString(cursor) } : {}),
+    unreadCount: asNumber(field(result, "unreadCount")),
+    totalCount: asNumber(field(result, "totalCount")),
+  };
 }

--- a/sdk/typescript/src/api/jobs.ts
+++ b/sdk/typescript/src/api/jobs.ts
@@ -7,6 +7,7 @@ import type {
   ProposalCreateRequest,
   SelectCandidateResult,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 // Backend POST /jobs requires an RFC3339 timestamp; a bare `YYYY-MM-DD` date
 // (e.g. from an `<input type="date">`) must be expanded or it fails with
@@ -23,10 +24,12 @@ export class JobsApi {
   // --- Postings ---
 
   list(params?: JobQueryParams): Promise<{ jobs: Array<JobPosting> }> {
-    return this.http.get<{ jobs: Array<JobPosting> }>(
-      "/jobs",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ jobs: Array<JobPosting> | null }>(
+        "/jobs",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({ jobs: listField<JobPosting>(result, "jobs") }));
   }
 
   get(jobId: string): Promise<JobPosting> {
@@ -71,11 +74,15 @@ export class JobsApi {
     client: string,
     params?: { status?: string; limit?: number; offset?: number },
   ): Promise<{ proposals: Array<Proposal> }> {
-    return this.http.getDirectoryAuthAs<{ proposals: Array<Proposal> }>(
-      `/jobs/${encodeURIComponent(jobId)}/proposals`,
-      client,
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .getDirectoryAuthAs<{ proposals: Array<Proposal> | null }>(
+        `/jobs/${encodeURIComponent(jobId)}/proposals`,
+        client,
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        proposals: listField<Proposal>(result, "proposals"),
+      }));
   }
 
   getProposal(

--- a/sdk/typescript/src/api/ledger.ts
+++ b/sdk/typescript/src/api/ledger.ts
@@ -6,6 +6,7 @@ import type {
   LedgerVerifyRequest,
   LedgerVerifyResult,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export class LedgerApi {
   constructor(
@@ -14,10 +15,14 @@ export class LedgerApi {
   ) {}
 
   list(params?: LedgerListParams): Promise<{ transactions: Array<LedgerTransaction> }> {
-    return this.http.get<{ transactions: Array<LedgerTransaction> }>(
-      "/ledger/transactions",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ transactions: Array<LedgerTransaction> | null }>(
+        "/ledger/transactions",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        transactions: listField<LedgerTransaction>(result, "transactions"),
+      }));
   }
 
   get(txId: string): Promise<LedgerTransaction> {

--- a/sdk/typescript/src/api/lottery.ts
+++ b/sdk/typescript/src/api/lottery.ts
@@ -10,6 +10,7 @@ import type {
   LotteryRoundsResponse,
   LotteryView,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 /**
  * Lottery (`/lottery`). A rolling 24h pooled USDC pot held in on-chain escrow,
@@ -43,10 +44,12 @@ export class LotteryApi {
    * @returns The matching rounds.
    */
   listRounds(query?: LotteryRoundQueryParams): Promise<LotteryRoundsResponse> {
-    return this.http.get<LotteryRoundsResponse>(
-      "/lottery/rounds",
-      query as Record<string, unknown>,
-    );
+    return this.http
+      .get<LotteryRoundsResponse>(
+        "/lottery/rounds",
+        query as Record<string, unknown>,
+      )
+      .then((result) => ({ rounds: listField<LotteryRound>(result, "rounds") }));
   }
 
   /**

--- a/sdk/typescript/src/api/marketplace.ts
+++ b/sdk/typescript/src/api/marketplace.ts
@@ -31,6 +31,7 @@ import type {
   ProductQueryParams,
   ProductReview,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export interface ProductSolanaPurchaseOptions
   extends Omit<SolanaX402PaymentExecutionOptions, "payment" | "signer"> {
@@ -101,10 +102,12 @@ export class MarketplaceApi {
   listProducts(
     params?: ProductQueryParams,
   ): Promise<{ products: Array<Product> }> {
-    return this.http.get<{ products: Array<Product> }>(
-      "/marketplace/products",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ products: Array<Product> | null }>(
+        "/marketplace/products",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({ products: listField<Product>(result, "products") }));
   }
 
   async createProduct(product: ProductCreateRequest): Promise<Product> {
@@ -296,9 +299,11 @@ export class MarketplaceApi {
   listProductReviews(
     productId: string,
   ): Promise<{ reviews: Array<ProductReview> }> {
-    return this.http.get<{ reviews: Array<ProductReview> }>(
-      `/marketplace/products/${encodeURIComponent(productId)}/reviews`,
-    );
+    return this.http
+      .get<{ reviews: Array<ProductReview> | null }>(
+        `/marketplace/products/${encodeURIComponent(productId)}/reviews`,
+      )
+      .then((result) => ({ reviews: listField<ProductReview>(result, "reviews") }));
   }
 
   async createProductReview(
@@ -338,10 +343,14 @@ export class MarketplaceApi {
     limit?: number;
     status?: string;
   }): Promise<{ identities: Array<IdentityListing> }> {
-    return this.http.get<{ identities: Array<IdentityListing> }>(
-      "/marketplace/identities",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ identities: Array<IdentityListing> | null }>(
+        "/marketplace/identities",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        identities: listField<IdentityListing>(result, "identities"),
+      }));
   }
 
   async createIdentityListing(
@@ -465,9 +474,11 @@ export class MarketplaceApi {
   }
 
   listBids(listingId: string): Promise<{ bids: Array<IdentityBid> }> {
-    return this.http.get<{ bids: Array<IdentityBid> }>(
-      `/marketplace/identities/${encodeURIComponent(listingId)}/bids`,
-    );
+    return this.http
+      .get<{ bids: Array<IdentityBid> | null }>(
+        `/marketplace/identities/${encodeURIComponent(listingId)}/bids`,
+      )
+      .then((result) => ({ bids: listField<IdentityBid>(result, "bids") }));
   }
 
   async placeBid(
@@ -585,9 +596,11 @@ export class MarketplaceApi {
   identitySaleHistory(
     name: string,
   ): Promise<{ history: Array<IdentitySale> | null }> {
-    return this.http.get<{ history: Array<IdentitySale> | null }>(
-      `/marketplace/identities/history/${encodeURIComponent(name)}`,
-    );
+    return this.http
+      .get<{ history: Array<IdentitySale> | null }>(
+        `/marketplace/identities/history/${encodeURIComponent(name)}`,
+      )
+      .then((result) => ({ history: listField<IdentitySale>(result, "history") }));
   }
 
   identityFloor(length?: number): Promise<IdentityFloor> {
@@ -613,10 +626,12 @@ export class MarketplaceApi {
     limit?: number;
     offset?: number;
   }): Promise<{ offers: Array<IdentityOffer> }> {
-    return this.http.get<{ offers: Array<IdentityOffer> }>(
-      "/marketplace/offers",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ offers: Array<IdentityOffer> | null }>(
+        "/marketplace/offers",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({ offers: listField<IdentityOffer>(result, "offers") }));
   }
 
   async createOffer(offer: Partial<IdentityOffer>): Promise<IdentityOffer> {
@@ -739,24 +754,37 @@ export class MarketplaceApi {
   browseMarketplace(
     params?: ProductQueryParams,
   ): Promise<MarketplaceBrowseResponse> {
-    return this.http.get<MarketplaceBrowseResponse>(
-      "/marketplace",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<MarketplaceBrowseResponse>(
+        "/marketplace",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        products: listField<Product>(result, "products"),
+        identities: listField<IdentityListing>(result, "identities"),
+      }));
   }
 
   categories(): Promise<{ categories: Array<MarketplaceCategory> }> {
-    return this.http.get<{ categories: Array<MarketplaceCategory> }>(
-      "/marketplace/categories",
-    );
+    return this.http
+      .get<{ categories: Array<MarketplaceCategory> | null }>(
+        "/marketplace/categories",
+      )
+      .then((result) => ({
+        categories: listField<MarketplaceCategory>(result, "categories"),
+      }));
   }
 
   featured(): Promise<{ items: Array<unknown> }> {
-    return this.http.get<{ items: Array<unknown> }>("/marketplace/featured");
+    return this.http
+      .get<{ items: Array<unknown> | null }>("/marketplace/featured")
+      .then((result) => ({ items: listField<unknown>(result, "items") }));
   }
 
   recent(): Promise<{ sales: Array<IdentitySale> }> {
-    return this.http.get<{ sales: Array<IdentitySale> }>("/marketplace/recent");
+    return this.http
+      .get<{ sales: Array<IdentitySale> | null }>("/marketplace/recent")
+      .then((result) => ({ sales: listField<IdentitySale>(result, "sales") }));
   }
 
   stream(

--- a/sdk/typescript/src/api/moderation.ts
+++ b/sdk/typescript/src/api/moderation.ts
@@ -6,6 +6,7 @@ import type {
   ModerationReport,
   ModerationReportCreate,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export class ModerationApi {
   constructor(private readonly http: HttpClient) {}
@@ -47,10 +48,14 @@ export class ModerationApi {
     limit?: number;
     offset?: number;
   }): Promise<{ actions: Array<ModerationAction> }> {
-    return this.http.get<{ actions: Array<ModerationAction> }>(
-      "/moderation/actions",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ actions: Array<ModerationAction> | null }>(
+        "/moderation/actions",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        actions: listField<ModerationAction>(result, "actions"),
+      }));
   }
 
   createAction(action: Partial<ModerationAction>): Promise<ModerationAction> {

--- a/sdk/typescript/src/api/payments.ts
+++ b/sdk/typescript/src/api/payments.ts
@@ -20,6 +20,7 @@ import type {
   X402VerifyResponse,
   X402VerifyUntilValidOptions,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 const DEFAULT_VERIFY_ATTEMPTS = 10;
 const DEFAULT_VERIFY_INTERVAL_MS = 2000;
@@ -215,9 +216,11 @@ export class PaymentsApi {
   }
 
   supported(): Promise<{ chains: Array<SupportedChain> }> {
-    return this.http.get<{ chains: Array<SupportedChain> }>(
-      "/payments/supported",
-    );
+    return this.http
+      .get<{ chains: Array<SupportedChain> }>("/payments/supported")
+      .then((result) => ({
+        chains: listField<SupportedChain>(result, "chains"),
+      }));
   }
 
   createSubscription(subscription: SubscriptionCreateRequest): Promise<Subscription> {

--- a/sdk/typescript/src/api/pricing.ts
+++ b/sdk/typescript/src/api/pricing.ts
@@ -1,11 +1,13 @@
 import type { HttpClient } from "../http.js";
 import type {
   GasEstimate,
+  PriceCandle,
   PriceHistory,
   PriceQuote,
   SupportedChain,
   TradePair,
 } from "../types/index.js";
+import { asString, listField } from "../safe.js";
 
 export class PricingApi {
   constructor(
@@ -32,28 +34,47 @@ export class PricingApi {
     from?: string;
     to?: string;
   }): Promise<PriceHistory> {
-    return this.http.get<PriceHistory>(
-      "/pricing/history",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<PriceHistory>(
+        "/pricing/history",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        base: asString((result as PriceHistory | undefined)?.base),
+        quote: asString((result as PriceHistory | undefined)?.quote),
+        interval: asString((result as PriceHistory | undefined)?.interval),
+        candles: listField<PriceCandle>(result, "candles"),
+      }));
   }
 
   assets(): Promise<{
     assets: Array<{ symbol: string; address?: string; decimals: number }>;
   }> {
-    return this.http.get<{
-      assets: Array<{ symbol: string; address?: string; decimals: number }>;
-    }>("/pricing/assets");
+    return this.http
+      .get<{
+        assets: Array<{ symbol: string; address?: string; decimals: number }>;
+      }>("/pricing/assets")
+      .then((result) => ({
+        assets: listField<{
+          symbol: string;
+          address?: string;
+          decimals: number;
+        }>(result, "assets"),
+      }));
   }
 
   pairs(): Promise<{ pairs: Array<TradePair> }> {
-    return this.http.get<{ pairs: Array<TradePair> }>("/pricing/pairs");
+    return this.http
+      .get<{ pairs: Array<TradePair> }>("/pricing/pairs")
+      .then((result) => ({ pairs: listField<TradePair>(result, "pairs") }));
   }
 
   networks(): Promise<{ networks: Array<SupportedChain> }> {
-    return this.http.get<{ networks: Array<SupportedChain> }>(
-      "/pricing/networks",
-    );
+    return this.http
+      .get<{ networks: Array<SupportedChain> }>("/pricing/networks")
+      .then((result) => ({
+        networks: listField<SupportedChain>(result, "networks"),
+      }));
   }
 
   gas(network: string): Promise<GasEstimate> {

--- a/sdk/typescript/src/api/profiles.ts
+++ b/sdk/typescript/src/api/profiles.ts
@@ -7,6 +7,7 @@ import type {
   ProfileBroadcast,
   ProfileGroupMembership,
 } from "../types/index.js";
+import { listField } from "../safe.js";
 
 export class ProfilesApi {
   constructor(private readonly http: HttpClient) {}
@@ -20,21 +21,33 @@ export class ProfilesApi {
   }
 
   groups(username: string): Promise<{ groups: Array<ProfileGroupMembership> }> {
-    return this.http.get<{ groups: Array<ProfileGroupMembership> }>(
-      `/profiles/${encodeURIComponent(username)}/groups`,
-    );
+    return this.http
+      .get<{ groups: Array<ProfileGroupMembership> }>(
+        `/profiles/${encodeURIComponent(username)}/groups`,
+      )
+      .then((result) => ({
+        groups: listField<ProfileGroupMembership>(result, "groups"),
+      }));
   }
 
   broadcasts(username: string): Promise<{ broadcasts: Array<ProfileBroadcast> }> {
-    return this.http.get<{ broadcasts: Array<ProfileBroadcast> }>(
-      `/profiles/${encodeURIComponent(username)}/broadcasts`,
-    );
+    return this.http
+      .get<{ broadcasts: Array<ProfileBroadcast> }>(
+        `/profiles/${encodeURIComponent(username)}/broadcasts`,
+      )
+      .then((result) => ({
+        broadcasts: listField<ProfileBroadcast>(result, "broadcasts"),
+      }));
   }
 
   attestations(username: string): Promise<{ attestations: Array<ProfileAttestation> }> {
-    return this.http.get<{ attestations: Array<ProfileAttestation> }>(
-      `/profiles/${encodeURIComponent(username)}/attestations`,
-    );
+    return this.http
+      .get<{ attestations: Array<ProfileAttestation> }>(
+        `/profiles/${encodeURIComponent(username)}/attestations`,
+      )
+      .then((result) => ({
+        attestations: listField<ProfileAttestation>(result, "attestations"),
+      }));
   }
 
   agentCard(username: string): Promise<AgentCard> {

--- a/sdk/typescript/src/api/reputation.ts
+++ b/sdk/typescript/src/api/reputation.ts
@@ -2,12 +2,14 @@ import type { HttpClient } from "../http.js";
 import type { SigningKey } from "../auth.js";
 import { signCanonicalPayload } from "../auth.js";
 import { canonicalPayload } from "../crypto.js";
+import { asString, listField } from "../safe.js";
 import type {
   Attestation,
   AttestationCreate,
   GameLeaderboardQueryParams,
   GroupLeaderboardQueryParams,
   LeaderboardCategory,
+  LeaderboardEntry,
   LeaderboardQueryParams,
   LeaderboardResponse,
   ReputationHistoryPoint,
@@ -19,6 +21,8 @@ import type {
   ReputationVouchCreate,
   SellerLeaderboardQueryParams,
   TrustGraph,
+  TrustGraphEdge,
+  TrustGraphNode,
   TrustGraphQueryParams,
   TrustScore,
   TwitterChallengeRequest,
@@ -41,23 +45,35 @@ export class ReputationApi {
   getHistory(
     agentId: string,
   ): Promise<{ history: Array<ReputationHistoryPoint> }> {
-    return this.http.get<{ history: Array<ReputationHistoryPoint> }>(
-      `/reputation/${encodeURIComponent(agentId)}/history`,
-    );
+    return this.http
+      .get<{ history: Array<ReputationHistoryPoint> }>(
+        `/reputation/${encodeURIComponent(agentId)}/history`,
+      )
+      .then((result) => ({
+        history: listField<ReputationHistoryPoint>(result, "history"),
+      }));
   }
 
   getReviews(agentId: string): Promise<{ reviews: Array<ReputationReview> }> {
-    return this.http.get<{ reviews: Array<ReputationReview> }>(
-      `/reputation/${encodeURIComponent(agentId)}/reviews`,
-    );
+    return this.http
+      .get<{ reviews: Array<ReputationReview> }>(
+        `/reputation/${encodeURIComponent(agentId)}/reviews`,
+      )
+      .then((result) => ({
+        reviews: listField<ReputationReview>(result, "reviews"),
+      }));
   }
 
   getAttestations(
     agentId: string,
   ): Promise<{ attestations: Array<Attestation> }> {
-    return this.http.get<{ attestations: Array<Attestation> }>(
-      `/reputation/${encodeURIComponent(agentId)}/attestations`,
-    );
+    return this.http
+      .get<{ attestations: Array<Attestation> }>(
+        `/reputation/${encodeURIComponent(agentId)}/attestations`,
+      )
+      .then((result) => ({
+        attestations: listField<Attestation>(result, "attestations"),
+      }));
   }
 
   async createReview(
@@ -170,10 +186,16 @@ export class ReputationApi {
   }
 
   trustGraph(params?: TrustGraphQueryParams): Promise<TrustGraph> {
-    return this.http.get<TrustGraph>(
-      "/reputation/trust/graph",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<TrustGraph>(
+        "/reputation/trust/graph",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({
+        nodes: listField<TrustGraphNode>(result, "nodes"),
+        edges: listField<TrustGraphEdge>(result, "edges"),
+        updatedAt: asString((result as TrustGraph | undefined)?.updatedAt),
+      }));
   }
 
   getTrust(agentId: string): Promise<TrustScore> {
@@ -183,17 +205,25 @@ export class ReputationApi {
   }
 
   getVouches(agentId: string): Promise<{ vouches: Array<ReputationVouch> }> {
-    return this.http.get<{ vouches: Array<ReputationVouch> }>(
-      `/reputation/${encodeURIComponent(agentId)}/vouches`,
-    );
+    return this.http
+      .get<{ vouches: Array<ReputationVouch> }>(
+        `/reputation/${encodeURIComponent(agentId)}/vouches`,
+      )
+      .then((result) => ({
+        vouches: listField<ReputationVouch>(result, "vouches"),
+      }));
   }
 
   getGivenVouches(
     agentId: string,
   ): Promise<{ vouches: Array<ReputationVouch> }> {
-    return this.http.get<{ vouches: Array<ReputationVouch> }>(
-      `/reputation/${encodeURIComponent(agentId)}/vouches/given`,
-    );
+    return this.http
+      .get<{ vouches: Array<ReputationVouch> }>(
+        `/reputation/${encodeURIComponent(agentId)}/vouches/given`,
+      )
+      .then((result) => ({
+        vouches: listField<ReputationVouch>(result, "vouches"),
+      }));
   }
 
   async createVouch(vouch: ReputationVouchCreate): Promise<ReputationVouch> {
@@ -237,76 +267,103 @@ export class ReputationApi {
       | GameLeaderboardQueryParams
       | LeaderboardQueryParams,
   ): Promise<LeaderboardResponse> {
-    return this.http.get<LeaderboardResponse>(
-      category
-        ? `/leaderboards/${encodeURIComponent(category)}`
-        : "/leaderboards/reputation",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<LeaderboardResponse>(
+        category
+          ? `/leaderboards/${encodeURIComponent(category)}`
+          : "/leaderboards/reputation",
+        params as Record<string, unknown>,
+      )
+      .then(coalesceLeaderboardResponse);
   }
 
   reputationLeaderboard(
     params?: ReputationLeaderboardQueryParams,
   ): Promise<LeaderboardResponse> {
-    return this.http.get<LeaderboardResponse>(
-      "/reputation/leaderboard",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<LeaderboardResponse>(
+        "/reputation/leaderboard",
+        params as Record<string, unknown>,
+      )
+      .then(coalesceLeaderboardResponse);
   }
 
   risingLeaderboard(
     params?: LeaderboardQueryParams,
   ): Promise<LeaderboardResponse> {
-    return this.http.get<LeaderboardResponse>(
-      "/leaderboards/rising",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<LeaderboardResponse>(
+        "/leaderboards/rising",
+        params as Record<string, unknown>,
+      )
+      .then(coalesceLeaderboardResponse);
   }
 
   sellersLeaderboard(
     params?: SellerLeaderboardQueryParams,
   ): Promise<LeaderboardResponse> {
-    return this.http.get<LeaderboardResponse>(
-      "/leaderboards/sellers",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<LeaderboardResponse>(
+        "/leaderboards/sellers",
+        params as Record<string, unknown>,
+      )
+      .then(coalesceLeaderboardResponse);
   }
 
   gamesLeaderboard(
     params?: GameLeaderboardQueryParams,
   ): Promise<LeaderboardResponse> {
-    return this.http.get<LeaderboardResponse>(
-      "/leaderboards/games",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<LeaderboardResponse>(
+        "/leaderboards/games",
+        params as Record<string, unknown>,
+      )
+      .then(coalesceLeaderboardResponse);
   }
 
   groupsLeaderboard(
     params?: GroupLeaderboardQueryParams,
   ): Promise<LeaderboardResponse> {
-    return this.http.get<LeaderboardResponse>(
-      "/leaderboards/groups",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<LeaderboardResponse>(
+        "/leaderboards/groups",
+        params as Record<string, unknown>,
+      )
+      .then(coalesceLeaderboardResponse);
   }
 
   messagesLeaderboard(
     params?: LeaderboardQueryParams,
   ): Promise<LeaderboardResponse> {
-    return this.http.get<LeaderboardResponse>(
-      "/leaderboards/messages",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<LeaderboardResponse>(
+        "/leaderboards/messages",
+        params as Record<string, unknown>,
+      )
+      .then(coalesceLeaderboardResponse);
   }
 
   volumeLeaderboard(
     params?: LeaderboardQueryParams,
   ): Promise<LeaderboardResponse> {
-    return this.http.get<LeaderboardResponse>(
-      "/leaderboards/volume",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<LeaderboardResponse>(
+        "/leaderboards/volume",
+        params as Record<string, unknown>,
+      )
+      .then(coalesceLeaderboardResponse);
   }
+}
+
+function coalesceLeaderboardResponse(result: unknown): LeaderboardResponse {
+  const source = result as LeaderboardResponse | undefined;
+  return {
+    leaderboard: asString(source?.leaderboard),
+    period: source?.period,
+    sort: source?.sort,
+    entries: listField<LeaderboardEntry>(result, "entries"),
+    updatedAt: asString(source?.updatedAt),
+  };
 }
 
 function reputationReviewSignaturePayload(

--- a/sdk/typescript/src/api/rooms.ts
+++ b/sdk/typescript/src/api/rooms.ts
@@ -1,5 +1,6 @@
 import type { HttpClient } from "../http.js";
 import type { TinyPlaceWebSocket } from "../websocket.js";
+import { listField } from "../safe.js";
 import type {
   GameActionRequest,
   GameActionResponse,
@@ -37,10 +38,12 @@ export class RoomsApi {
    * @returns The matching rooms.
    */
   list(params?: GameRoomQueryParams): Promise<{ rooms: Array<GameRoom> }> {
-    return this.http.get<{ rooms: Array<GameRoom> }>(
-      "/rooms",
-      params as Record<string, unknown>,
-    );
+    return this.http
+      .get<{ rooms: Array<GameRoom> }>(
+        "/rooms",
+        params as Record<string, unknown>,
+      )
+      .then((result) => ({ rooms: listField<GameRoom>(result, "rooms") }));
   }
 
   /**
@@ -224,15 +227,22 @@ export class RoomsApi {
     roomId: string,
     actorId?: string,
   ): Promise<{ hands: Array<GameHand> }> {
+    const coalesce = (result: unknown): { hands: Array<GameHand> } => ({
+      hands: listField<GameHand>(result, "hands"),
+    });
     if (actorId) {
-      return this.http.getDirectoryAuthAs<{ hands: Array<GameHand> }>(
-        `/rooms/${encodeURIComponent(roomId)}/hands`,
-        actorId,
-      );
+      return this.http
+        .getDirectoryAuthAs<{ hands: Array<GameHand> }>(
+          `/rooms/${encodeURIComponent(roomId)}/hands`,
+          actorId,
+        )
+        .then(coalesce);
     }
-    return this.http.get<{ hands: Array<GameHand> }>(
-      `/rooms/${encodeURIComponent(roomId)}/hands`,
-    );
+    return this.http
+      .get<{ hands: Array<GameHand> }>(
+        `/rooms/${encodeURIComponent(roomId)}/hands`,
+      )
+      .then(coalesce);
   }
 
   /**

--- a/sdk/typescript/src/api/search.ts
+++ b/sdk/typescript/src/api/search.ts
@@ -3,57 +3,111 @@ import type {
   DiscoverResponse,
   DiscoveryCategory,
   SearchResponse,
+  SearchResult,
+  SearchSuggestion,
   SuggestResponse,
 } from "../types/index.js";
+import { asNumber, asString, listField } from "../safe.js";
 
 export class SearchApi {
   constructor(private readonly http: HttpClient) {}
 
   unified(query: string): Promise<SearchResponse> {
-    return this.http.get<SearchResponse>("/search", { q: query });
+    return this.http
+      .get<SearchResponse>("/search", { q: query })
+      .then(coalesceSearchResponse);
   }
 
   agents(params: { q?: string; skill?: string; tag?: string; limit?: number; cursor?: string }): Promise<SearchResponse> {
-    return this.http.get<SearchResponse>("/search/agents", params as Record<string, unknown>);
+    return this.http
+      .get<SearchResponse>("/search/agents", params as Record<string, unknown>)
+      .then(coalesceSearchResponse);
   }
 
   groups(params: { q?: string; tag?: string; limit?: number }): Promise<SearchResponse> {
-    return this.http.get<SearchResponse>("/search/groups", params as Record<string, unknown>);
+    return this.http
+      .get<SearchResponse>("/search/groups", params as Record<string, unknown>)
+      .then(coalesceSearchResponse);
   }
 
   channels(params: { q?: string; tag?: string; limit?: number }): Promise<SearchResponse> {
-    return this.http.get<SearchResponse>("/search/channels", params as Record<string, unknown>);
+    return this.http
+      .get<SearchResponse>("/search/channels", params as Record<string, unknown>)
+      .then(coalesceSearchResponse);
   }
 
   broadcasts(params: { q?: string; tag?: string; limit?: number }): Promise<SearchResponse> {
-    return this.http.get<SearchResponse>("/search/broadcasts", params as Record<string, unknown>);
+    return this.http
+      .get<SearchResponse>("/search/broadcasts", params as Record<string, unknown>)
+      .then(coalesceSearchResponse);
   }
 
   events(params: { q?: string; tag?: string; limit?: number }): Promise<SearchResponse> {
-    return this.http.get<SearchResponse>("/search/events", params as Record<string, unknown>);
+    return this.http
+      .get<SearchResponse>("/search/events", params as Record<string, unknown>)
+      .then(coalesceSearchResponse);
   }
 
   products(params: { q?: string; category?: string; limit?: number }): Promise<SearchResponse> {
-    return this.http.get<SearchResponse>("/search/products", params as Record<string, unknown>);
+    return this.http
+      .get<SearchResponse>("/search/products", params as Record<string, unknown>)
+      .then(coalesceSearchResponse);
   }
 
   suggest(query: string): Promise<SuggestResponse> {
-    return this.http.get<SuggestResponse>("/search/suggest", { q: query });
+    return this.http
+      .get<SuggestResponse>("/search/suggest", { q: query })
+      .then((result) => ({
+        suggestions: listField<SearchSuggestion>(result, "suggestions"),
+      }));
   }
 
   trending(limit?: number): Promise<DiscoverResponse> {
-    return this.http.get<DiscoverResponse>("/discover/trending", { limit });
+    return this.http
+      .get<DiscoverResponse>("/discover/trending", { limit })
+      .then(coalesceDiscoverResponse);
   }
 
   newest(limit?: number): Promise<DiscoverResponse> {
-    return this.http.get<DiscoverResponse>("/discover/new", { limit });
+    return this.http
+      .get<DiscoverResponse>("/discover/new", { limit })
+      .then(coalesceDiscoverResponse);
   }
 
   recommended(limit?: number): Promise<DiscoverResponse> {
-    return this.http.getAgentAuth<DiscoverResponse>("/discover/recommended", { limit });
+    return this.http
+      .getAgentAuth<DiscoverResponse>("/discover/recommended", { limit })
+      .then(coalesceDiscoverResponse);
   }
 
   categories(): Promise<{ categories: Array<DiscoveryCategory> }> {
-    return this.http.get<{ categories: Array<DiscoveryCategory> }>("/discover/categories");
+    return this.http
+      .get<{ categories: Array<DiscoveryCategory> }>("/discover/categories")
+      .then((result) => ({
+        categories: listField<DiscoveryCategory>(result, "categories"),
+      }));
   }
+}
+
+function coalesceSearchResponse(result: unknown): SearchResponse {
+  return {
+    query: asString((result as SearchResponse | undefined)?.query),
+    results: listField<SearchResult>(result, "results"),
+    total: asNumber((result as SearchResponse | undefined)?.total),
+    page: asNumber((result as SearchResponse | undefined)?.page),
+    pageSize: asNumber((result as SearchResponse | undefined)?.pageSize),
+  };
+}
+
+function coalesceDiscoverResponse(result: unknown): DiscoverResponse {
+  const source = result as DiscoverResponse | undefined;
+  return {
+    agents: listField<SearchResult>(result, "agents"),
+    groups: listField<SearchResult>(result, "groups"),
+    channels: listField<SearchResult>(result, "channels"),
+    broadcasts: listField<SearchResult>(result, "broadcasts"),
+    products: listField<SearchResult>(result, "products"),
+    reason: source?.reason,
+    updatedAt: source?.updatedAt,
+  };
 }

--- a/sdk/typescript/src/api/solana.ts
+++ b/sdk/typescript/src/api/solana.ts
@@ -1,6 +1,7 @@
 import type { HttpClient } from "../http.js";
 import type { SupportedAsset } from "../types/index.js";
 import { SOLANA_NATIVE_ASSET, SOLANA_NATIVE_DECIMALS } from "../solana.js";
+import { asArray } from "../safe.js";
 
 export interface SolanaRPCInfo {
   url: string;
@@ -112,7 +113,12 @@ export class SolanaApi {
   constructor(private readonly http: HttpClient) {}
 
   info(): Promise<SolanaChainInfo> {
-    return this.http.get<SolanaChainInfo>("/solana");
+    return this.http.get<SolanaChainInfo>("/solana").then((result) => ({
+      ...result,
+      // `assets` is `.filter`-ed/`.map`-ed in balances(); degrade a
+      // missing/null/non-array value to [] so it never throws.
+      assets: asArray<SupportedAsset>(result?.assets),
+    }));
   }
 
   rpc<T = unknown>(

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -4,6 +4,7 @@ import { Signer } from "./signer.js";
 import { EncryptionContext } from "./messaging/encryption.js";
 import type { SessionStore } from "./signal/index.js";
 import { HttpClient } from "./http.js";
+import type { RetryOptions } from "./http.js";
 import { TinyPlaceWebSocket } from "./websocket.js";
 import { A2AApi } from "./api/a2a.js";
 import { AdminApi } from "./api/admin.js";
@@ -76,6 +77,17 @@ export interface TinyPlaceClientOptions {
    * invalidated session and re-auth.
    */
   onAuthInvalid?: (status: number, body: unknown) => Promise<void> | void;
+  /**
+   * Per-request timeout in milliseconds before a slow/hung backend is aborted
+   * (and retried when eligible). Default `30000`; `0` disables it.
+   */
+  timeoutMs?: number;
+  /**
+   * Automatic retry-with-backoff for transient failures (network errors,
+   * 5xx/429). Defaults to retrying idempotent reads twice; pass `{ retries: 0 }`
+   * to disable.
+   */
+  retry?: RetryOptions;
 }
 
 export class TinyPlaceClient {
@@ -142,6 +154,8 @@ export class TinyPlaceClient {
       onboardGrant: options.onboardGrant,
       fetch: options.fetch,
       onAuthInvalid: options.onAuthInvalid,
+      timeoutMs: options.timeoutMs,
+      retry: options.retry,
     });
 
     const wsFactory = (

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -8,6 +8,19 @@ import {
 
 export type BodySigner<TBody = any> = (body: TBody) => Promise<TBody> | TBody;
 
+interface RequestOptions {
+  body?: unknown;
+  query?: Record<string, unknown>;
+  signed?: boolean;
+  directoryAuth?: boolean;
+  directoryActor?: string;
+  agentAuth?: boolean;
+  adminAuth?: boolean;
+  headers?: Record<string, string>;
+  responseType?: "json" | "text" | "raw";
+  signBody?: BodySigner;
+}
+
 export class TinyPlaceError extends Error {
   public readonly paymentRequired?: PaymentRequiredChallenge;
   public readonly headers: Record<string, string>;
@@ -49,6 +62,60 @@ interface TinyPlaceErrorOptions {
   paymentRequired?: PaymentRequiredChallenge;
 }
 
+/**
+ * Controls automatic retry-with-backoff for transient failures (the backend
+ * being slow, briefly down, or returning a 5xx/429). Retries are only attempted
+ * for idempotent methods by default so a write is never silently duplicated.
+ */
+export interface RetryOptions {
+  /** Max retry attempts after the first try. `0` disables retries. Default `2`. */
+  retries?: number;
+  /** Base backoff delay in ms (exponential, with jitter). Default `200`. */
+  baseDelayMs?: number;
+  /** Upper bound on a single backoff delay in ms. Default `5000`. */
+  maxDelayMs?: number;
+  /** HTTP statuses treated as transient. Default `[408, 429, 500, 502, 503, 504]`. */
+  retryableStatuses?: Array<number>;
+  /**
+   * HTTP methods eligible for retry. Default `["GET", "HEAD", "OPTIONS"]`
+   * (idempotent reads only — writes are never auto-retried unless added here).
+   */
+  retryMethods?: Array<string>;
+  /**
+   * Retry connection-level failures (network unreachable, DNS, timeout) for the
+   * eligible methods. Default `true`.
+   */
+  retryNetworkErrors?: boolean;
+}
+
+interface ResolvedRetryOptions {
+  retries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  retryableStatuses: Set<number>;
+  retryMethods: Set<string>;
+  retryNetworkErrors: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function resolveRetryOptions(options?: RetryOptions): ResolvedRetryOptions {
+  return {
+    retries: options?.retries ?? 2,
+    baseDelayMs: options?.baseDelayMs ?? 200,
+    maxDelayMs: options?.maxDelayMs ?? 5_000,
+    retryableStatuses: new Set(
+      options?.retryableStatuses ?? [408, 429, 500, 502, 503, 504],
+    ),
+    retryMethods: new Set(
+      (options?.retryMethods ?? ["GET", "HEAD", "OPTIONS"]).map((method) =>
+        method.toUpperCase(),
+      ),
+    ),
+    retryNetworkErrors: options?.retryNetworkErrors ?? true,
+  };
+}
+
 export interface HttpClientOptions {
   baseUrl: string;
   signingKey?: SigningKey;
@@ -69,6 +136,19 @@ export interface HttpClientOptions {
    * re-authenticating. Must not throw.
    */
   onAuthInvalid?: (status: number, body: unknown) => Promise<void> | void;
+  /**
+   * Per-request timeout in milliseconds. A request that does not produce a
+   * response within this window is aborted and surfaces as a `TinyPlaceError`
+   * with `status: 0` (and is retried when the method is eligible). Default
+   * `30000`. Pass `0` to disable the timeout.
+   */
+  timeoutMs?: number;
+  /**
+   * Automatic retry-with-backoff for transient failures. Defaults retry
+   * idempotent reads (GET/HEAD/OPTIONS) twice on network errors and 5xx/429
+   * responses. See {@link RetryOptions}. Pass `{ retries: 0 }` to disable.
+   */
+  retry?: RetryOptions;
 }
 
 function buildQuery(params: Record<string, unknown>): string {
@@ -99,6 +179,8 @@ export class HttpClient {
   private readonly onboardGrant?: OnboardGrantCredential;
   private readonly _fetch: typeof globalThis.fetch;
   private readonly onAuthInvalid?: (status: number, body: unknown) => Promise<void> | void;
+  private readonly timeoutMs: number;
+  private readonly retryOptions: ResolvedRetryOptions;
 
   constructor(options: HttpClientOptions) {
     this.baseUrl = options.baseUrl.replace(/\/+$/, "");
@@ -109,6 +191,8 @@ export class HttpClient {
     this.onboardGrant = options.onboardGrant;
     this._fetch = options.fetch ?? globalThis.fetch.bind(globalThis);
     this.onAuthInvalid = options.onAuthInvalid;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.retryOptions = resolveRetryOptions(options.retry);
   }
 
   /**
@@ -124,18 +208,7 @@ export class HttpClient {
   private async request<T>(
     method: string,
     path: string,
-    options?: {
-      body?: unknown;
-      query?: Record<string, unknown>;
-      signed?: boolean;
-      directoryAuth?: boolean;
-      directoryActor?: string;
-      agentAuth?: boolean;
-      adminAuth?: boolean;
-      headers?: Record<string, string>;
-      responseType?: "json" | "text" | "raw";
-      signBody?: BodySigner;
-    },
+    options?: RequestOptions,
   ): Promise<T> {
     const queryString = options?.query ? buildQuery(options.query) : "";
     const url = `${this.baseUrl}${path}${queryString}`;
@@ -145,7 +218,7 @@ export class HttpClient {
     }
 
     try {
-      return await this.sendRequest<T>(method, path, queryString, url, {
+      return await this.sendWithRetry<T>(method, path, queryString, url, {
         ...options,
         body,
       });
@@ -157,10 +230,51 @@ export class HttpClient {
       if (bodySignature(nextBody) === bodySignature(body)) {
         throw error;
       }
-      return this.sendRequest<T>(method, path, queryString, url, {
+      return this.sendWithRetry<T>(method, path, queryString, url, {
         ...options,
         body: nextBody,
       });
+    }
+  }
+
+  /**
+   * Wrap {@link sendRequest} with retry-with-backoff for transient failures.
+   * Each attempt re-enters `sendRequest`, which re-signs the request, so retries
+   * carry a fresh timestamp/nonce and are never rejected as a replay. Network
+   * errors and configured retryable statuses are retried for eligible
+   * (idempotent) methods only; a `Retry-After` header is honoured when present.
+   */
+  private async sendWithRetry<T>(
+    method: string,
+    path: string,
+    queryString: string,
+    url: string,
+    options?: RequestOptions,
+  ): Promise<T> {
+    const retry = this.retryOptions;
+    const eligible =
+      retry.retries > 0 && retry.retryMethods.has(method.toUpperCase());
+    let attempt = 0;
+    for (;;) {
+      try {
+        return await this.sendRequest<T>(
+          method,
+          path,
+          queryString,
+          url,
+          options,
+        );
+      } catch (error) {
+        if (!eligible || attempt >= retry.retries) {
+          throw error;
+        }
+        const wait = retryDelayMs(error, attempt, retry);
+        if (wait === undefined) {
+          throw error;
+        }
+        attempt += 1;
+        await sleep(wait);
+      }
     }
   }
 
@@ -169,18 +283,7 @@ export class HttpClient {
     path: string,
     queryString: string,
     url: string,
-    options?: {
-      body?: unknown;
-      query?: Record<string, unknown>;
-      signed?: boolean;
-      directoryAuth?: boolean;
-      directoryActor?: string;
-      agentAuth?: boolean;
-      adminAuth?: boolean;
-      headers?: Record<string, string>;
-      responseType?: "json" | "text" | "raw";
-      signBody?: BodySigner;
-    },
+    options?: RequestOptions,
   ): Promise<T> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -228,11 +331,29 @@ export class HttpClient {
       Object.assign(headers, authHeaders);
     }
 
-    const response = await this._fetch(url, {
-      method,
-      headers,
-      body: bodyStr || undefined,
-    });
+    const controller =
+      this.timeoutMs > 0 && typeof AbortController !== "undefined"
+        ? new AbortController()
+        : undefined;
+    const timer =
+      controller !== undefined
+        ? setTimeout(() => controller.abort(), this.timeoutMs)
+        : undefined;
+    let response: Response;
+    try {
+      response = await this._fetch(url, {
+        method,
+        headers,
+        body: bodyStr || undefined,
+        signal: controller?.signal,
+      });
+    } catch (error) {
+      throw asTransportError(error, path, controller?.signal.aborted ?? false);
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    }
 
     if (!response.ok) {
       const errorBody = await response.text().catch(() => "");
@@ -555,6 +676,88 @@ export class HttpClient {
       signBody,
     });
   }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Normalize a connection-level failure (network unreachable, DNS, refused
+ * connection, or an abort from the request timeout) into a `TinyPlaceError`
+ * with `status: 0`, so callers see one error type regardless of whether the
+ * backend answered. The original error is preserved as the `cause`.
+ */
+function asTransportError(
+  error: unknown,
+  path: string,
+  timedOut: boolean,
+): TinyPlaceError {
+  if (error instanceof TinyPlaceError) {
+    return error;
+  }
+  const aborted =
+    timedOut ||
+    (typeof error === "object" &&
+      error !== null &&
+      (error as { name?: string }).name === "AbortError");
+  const detail = error instanceof Error ? error.message : String(error);
+  const message = aborted
+    ? `Request to ${path} timed out`
+    : `Request to ${path} failed: ${detail}`;
+  const wrapped = new TinyPlaceError(0, detail, message);
+  (wrapped as { cause?: unknown }).cause = error;
+  return wrapped;
+}
+
+/**
+ * Decide how long to wait before retrying `error`, or `undefined` when it is not
+ * a transient failure. Transport errors (`status: 0`) retry when network retries
+ * are enabled; configured retryable statuses retry and honour a `Retry-After`
+ * header; everything else is non-retryable.
+ */
+function retryDelayMs(
+  error: unknown,
+  attempt: number,
+  retry: ResolvedRetryOptions,
+): number | undefined {
+  const backoff = (): number => {
+    const ceiling = Math.min(
+      retry.maxDelayMs,
+      retry.baseDelayMs * 2 ** attempt,
+    );
+    // Half jitter: a guaranteed floor plus a random spread, to avoid retry
+    // storms when many clients fail at once.
+    return Math.round(ceiling / 2 + Math.random() * (ceiling / 2));
+  };
+
+  if (!(error instanceof TinyPlaceError)) {
+    return retry.retryNetworkErrors ? backoff() : undefined;
+  }
+  if (error.status === 0) {
+    return retry.retryNetworkErrors ? backoff() : undefined;
+  }
+  if (!retry.retryableStatuses.has(error.status)) {
+    return undefined;
+  }
+  const retryAfter = retryAfterMs(error.headers["retry-after"]);
+  return retryAfter ?? backoff();
+}
+
+/** Parse a `Retry-After` header (delta-seconds or HTTP date) into ms. */
+function retryAfterMs(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1000);
+  }
+  const date = Date.parse(value);
+  if (Number.isFinite(date)) {
+    return Math.max(0, date - Date.now());
+  }
+  return undefined;
 }
 
 function shouldRetryInvalidSignature(error: unknown): boolean {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -4,7 +4,20 @@ export { TinyPlaceClient } from "./client.js";
 export type { TinyPlaceClientOptions } from "./client.js";
 
 export { TinyPlaceError } from "./http.js";
-export type { PaymentChallenge, PaymentRequiredChallenge } from "./http.js";
+export type {
+  PaymentChallenge,
+  PaymentRequiredChallenge,
+  RetryOptions,
+} from "./http.js";
+export {
+  asArray,
+  asBool,
+  asNumber,
+  asObject,
+  asString,
+  field,
+  listField,
+} from "./safe.js";
 export { TinyPlaceValidationError } from "./validation.js";
 export { TinyPlaceWebSocket } from "./websocket.js";
 export type {

--- a/sdk/typescript/src/safe.ts
+++ b/sdk/typescript/src/safe.ts
@@ -1,0 +1,83 @@
+/**
+ * Defensive response accessors.
+ *
+ * The backend is the source of truth for response shapes, but the SDK should
+ * never crash a caller when a field is renamed, missing, null, or the wrong
+ * type — a selector that used to read an array should degrade to `[]`, not throw
+ * a `TypeError: x.map is not a function`. These helpers coerce untrusted JSON
+ * into the shape the caller expects, falling back to a safe default.
+ *
+ * Use them at the boundary where a namespace method hands a parsed response back
+ * to application code (especially anything that is then `.map`-ed, destructured,
+ * or indexed). They are intentionally tiny and dependency-free so every SDK
+ * surface can lean on them without a runtime-validation library.
+ */
+
+/** Coerce a value to an array; anything non-array becomes `[]`. */
+export function asArray<T>(value: unknown): Array<T> {
+  return Array.isArray(value) ? (value as Array<T>) : [];
+}
+
+/**
+ * Coerce a value to a plain object, or `undefined` when it is null, an array, or
+ * a primitive. Lets callers safely reach for a nested field without a `typeof`
+ * dance at every site.
+ */
+export function asObject<T extends object = Record<string, unknown>>(
+  value: unknown,
+): T | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as T)
+    : undefined;
+}
+
+/** Coerce a value to a string, falling back to `fallback` (default `""`). */
+export function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+/**
+ * Coerce a value to a finite number, falling back to `fallback` (default `0`).
+ * Numeric strings (a common JSON-shape drift) are parsed when finite.
+ */
+export function asNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+/** Coerce a value to a boolean, falling back to `fallback` (default `false`). */
+export function asBool(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+/**
+ * Read `key` off a possibly-malformed response object as an array. Returns `[]`
+ * when the response is not an object, the field is absent, or the field is not
+ * an array. This is the workhorse for list endpoints whose envelope is
+ * `{ <key>: T[] }` — it is robust to the field being `null`, missing, or the
+ * whole envelope being a non-object.
+ */
+export function listField<T>(response: unknown, key: string): Array<T> {
+  const object = asObject(response);
+  return object ? asArray<T>(object[key]) : [];
+}
+
+/**
+ * Read `key` off a possibly-malformed response object, returning `undefined`
+ * when the response is not an object or the field is absent. A type-narrowing
+ * convenience over manual `asObject(...)?.[key]`.
+ */
+export function field<T = unknown>(
+  response: unknown,
+  key: string,
+): T | undefined {
+  return asObject(response)?.[key] as T | undefined;
+}

--- a/sdk/typescript/tests/backward-compat.test.ts
+++ b/sdk/typescript/tests/backward-compat.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { TinyPlaceClient } from "../src/index.js";
+
+/**
+ * Backward-compatibility tests: when the backend changes shape, omits a field,
+ * sends `null`, or sends the wrong type, list selectors must degrade to `[]`
+ * rather than throwing `TypeError: x.map is not a function`. Each case feeds a
+ * deliberately malformed response and asserts the SDK still returns a usable,
+ * empty result.
+ */
+function clientReturning(body: unknown): TinyPlaceClient {
+  return new TinyPlaceClient({
+    baseUrl: "https://example.test",
+    fetch: async () => Response.json(body),
+  });
+}
+
+describe("response selectors tolerate backend shape drift", () => {
+  it("directory.listAgents → [] when the field is missing", async () => {
+    const client = clientReturning({});
+    await expect(client.directory.listAgents()).resolves.toEqual({
+      agents: [],
+    });
+  });
+
+  it("directory.listAgents → [] when the field is null", async () => {
+    const client = clientReturning({ agents: null });
+    await expect(client.directory.listAgents()).resolves.toEqual({
+      agents: [],
+    });
+  });
+
+  it("directory.listAgents → [] when the field is the wrong type", async () => {
+    const client = clientReturning({ agents: "oops-renamed" });
+    await expect(client.directory.listAgents()).resolves.toEqual({
+      agents: [],
+    });
+  });
+
+  it("directory.listAgents → [] when the whole body is null", async () => {
+    const client = clientReturning(null);
+    await expect(client.directory.listAgents()).resolves.toEqual({
+      agents: [],
+    });
+  });
+
+  it("findAgentByEncryptionKey does not throw on an empty body", async () => {
+    const client = clientReturning({});
+    await expect(
+      client.directory.findAgentByEncryptionKey("k"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("feedback.list → [] on an empty body", async () => {
+    const client = clientReturning({});
+    await expect(client.feedback.list()).resolves.toEqual({ feedback: [] });
+  });
+
+  it("jobs.list → [] on a renamed envelope", async () => {
+    const client = clientReturning({ results: [{ id: 1 }] });
+    const result = await client.jobs.list();
+    expect(Array.isArray(result.jobs)).toBe(true);
+    expect(result.jobs).toEqual([]);
+  });
+
+  it("moderation.listActions → [] when actions is null", async () => {
+    const client = clientReturning({ actions: null });
+    const result = await client.moderation.listActions();
+    expect(result.actions).toEqual([]);
+  });
+
+  it("ledger.list → [] on an empty body", async () => {
+    const client = clientReturning({});
+    const result = await client.ledger.list();
+    expect(Array.isArray(result.transactions)).toBe(true);
+    expect(result.transactions).toEqual([]);
+  });
+
+  it("marketplace.listProducts does not throw on an empty body", async () => {
+    const client = clientReturning({});
+    const result = await client.marketplace.listProducts();
+    expect(Array.isArray(result.products)).toBe(true);
+  });
+});

--- a/sdk/typescript/tests/resilience.test.ts
+++ b/sdk/typescript/tests/resilience.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { TinyPlaceClient, TinyPlaceError } from "../src/index.js";
+
+/**
+ * Transport-resilience tests: timeouts and retry-with-backoff. These exercise
+ * the central HttpClient via a public read (`directory.listAgents`, a GET) and a
+ * write (`feedback.submit`-style POST) so the method-eligibility rules are
+ * covered end-to-end.
+ */
+describe("HttpClient transport resilience", () => {
+  it("retries an idempotent GET on a 503 and then succeeds", async () => {
+    let calls = 0;
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      retry: { retries: 3, baseDelayMs: 1, maxDelayMs: 2 },
+      fetch: async () => {
+        calls += 1;
+        if (calls < 3) {
+          return new Response("upstream down", { status: 503 });
+        }
+        return Response.json({ agents: [] });
+      },
+    });
+
+    const result = await client.directory.listAgents();
+    expect(result).toEqual({ agents: [] });
+    expect(calls).toBe(3);
+  });
+
+  it("gives up after the configured number of retries", async () => {
+    let calls = 0;
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      retry: { retries: 2, baseDelayMs: 1, maxDelayMs: 2 },
+      fetch: async () => {
+        calls += 1;
+        return new Response("nope", { status: 500 });
+      },
+    });
+
+    await expect(client.directory.listAgents()).rejects.toMatchObject({
+      status: 500,
+    });
+    // 1 initial attempt + 2 retries.
+    expect(calls).toBe(3);
+  });
+
+  it("does not retry a non-idempotent write by default", async () => {
+    let calls = 0;
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      retry: { retries: 3, baseDelayMs: 1 },
+      fetch: async () => {
+        calls += 1;
+        return new Response("server error", { status: 500 });
+      },
+    });
+
+    // DELETE is not in the default retry-eligible method set, so a 5xx is
+    // surfaced immediately rather than risking a duplicated write.
+    await expect(
+      client.directory.deleteAgent("agent-1"),
+    ).rejects.toBeInstanceOf(TinyPlaceError);
+    expect(calls).toBe(1);
+  });
+
+  it("does not retry a non-transient status (404)", async () => {
+    let calls = 0;
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      retry: { retries: 3, baseDelayMs: 1 },
+      fetch: async () => {
+        calls += 1;
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    await expect(client.directory.listAgents()).rejects.toMatchObject({
+      status: 404,
+    });
+    expect(calls).toBe(1);
+  });
+
+  it("honours a Retry-After header on 429", async () => {
+    let calls = 0;
+    const started = Date.now();
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      retry: { retries: 1, baseDelayMs: 10_000, maxDelayMs: 20_000 },
+      fetch: async () => {
+        calls += 1;
+        if (calls === 1) {
+          return new Response("slow down", {
+            status: 429,
+            headers: { "retry-after": "0" },
+          });
+        }
+        return Response.json({ agents: [] });
+      },
+    });
+
+    await client.directory.listAgents();
+    // Retry-After: 0 overrides the (huge) backoff, so the retry is near-instant.
+    expect(Date.now() - started).toBeLessThan(1_000);
+    expect(calls).toBe(2);
+  });
+
+  it("times out a hung request as a TinyPlaceError(status 0)", async () => {
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      timeoutMs: 10,
+      retry: { retries: 0 },
+      fetch: (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    });
+
+    const error = await client.directory.listAgents().catch((cause) => cause);
+    expect(error).toBeInstanceOf(TinyPlaceError);
+    expect((error as TinyPlaceError).status).toBe(0);
+    expect((error as TinyPlaceError).message).toContain("timed out");
+  });
+
+  it("retries connection-level failures for GETs", async () => {
+    let calls = 0;
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      retry: { retries: 2, baseDelayMs: 1, maxDelayMs: 2 },
+      fetch: async () => {
+        calls += 1;
+        if (calls < 2) {
+          throw new TypeError("fetch failed");
+        }
+        return Response.json({ agents: [] });
+      },
+    });
+
+    await client.directory.listAgents();
+    expect(calls).toBe(2);
+  });
+});


### PR DESCRIPTION
## What & why

Make all three SDKs **backward-compatible** so that a backend response-shape change (a renamed/missing/`null`/wrong-type field) or the backend going down **never breaks the SDK** — selectors degrade gracefully and failures surface as typed errors instead of crashes/hangs.

Two layers per SDK, plus regression tests:

### 1. Tolerant parsing / safe selectors (shape drift)
- **TypeScript** — new `src/safe.ts` (`asArray`/`asObject`/`asString`/`asNumber`/`asBool`/`listField`/`field`). Every list-returning method across **all 38 namespaces** coalesces, so a missing/renamed/`null`/wrong-type field yields `[]`/`undefined` instead of `TypeError: x.map is not a function`.
- **Rust** — `#[serde(default)]` swept across every `src/types/*.rs` response struct, so an omitted/renamed field falls back to the type default instead of failing the whole deserialize. Unknown fields are still ignored (no `deny_unknown_fields`).
- **Python** — already dict-lenient; added `safe.py` and hardened `graphql.py`'s `data["x"]` accesses (bare lists → `[]`, `{count, …}` envelopes/objects → `None`).

### 2. Transport resilience (backend slow/down)
All three central HTTP clients gained a per-request **timeout** (default 30s) and **retry-with-backoff** on transient failures (network errors, 5xx/429, honoring `Retry-After`). Retries are **idempotent-methods-only by default** and **re-sign each attempt** (fresh nonce/timestamp) — so a write is never silently duplicated and a retry is never rejected as a replay. A dead/slow backend now surfaces a **typed error** (`TinyPlaceError(status 0)` / `Error::Transport`) rather than a raw crash or an indefinite hang. All knobs are configurable via `RetryOptions` / `timeout`.

## Tests
- **TS:** existing 271 unit tests green + 17 new (`resilience.test.ts`, `backward-compat.test.ts`); `tsc` clean.
- **Rust:** full suite green incl. 5 new resilience (`tests/resilience.rs`) + 9 serde-tolerance (`tests/serde_tolerance.rs`); 0 warnings, `cargo fmt` clean.
- **Python:** 283 passed incl. 13 new (`test_resilience.py`, `test_backward_compat.py`).

A companion live e2e ("every namespace reachable + a dead backend returns a typed error") was added in the umbrella repo (`scripts/e2e-sdk-wiring.mjs`); run against the local stack it reported **54 pass / 12 typed-error (reached) / 0 broken / resilience ok**.

## Notes
- A handful of pre-existing Python test failures in `registry`/`reputation`/`marketplace` (SIWS signature/base64 format) exist on `main` already and are unrelated to this change.
- Please run `pnpm format` if the format check is enforced — deps weren't installed in my working checkout so I couldn't run prettier locally (tsc/build/tests all pass).