### PR TITLE
feat(feed): make the home feed public

### DIFF
--- a/website/e2e/feed-graphql.spec.ts
+++ b/website/e2e/feed-graphql.spec.ts
@@ -1,9 +1,12 @@
 import { test, expect, type Page, type Route } from "@playwright/test";
 
 // Proves the GraphQL feed eliminates the per-author attestations N+1 in the
-// browser: the home feed renders from ONE POST /graphql and issues ZERO
-// /reputation/{agentId}/attestations requests, with the verified badge rendered
-// from the embedded author.verified flag.
+// browser: each home-feed render issues ONE batched POST /graphql (not one per
+// author) and ZERO /reputation/{agentId}/attestations requests, with the
+// verified badge rendered from the embedded author.verified flag. The feed is
+// public, so it renders once anonymously on load and once more (personalized)
+// after the wallet connects — two batched requests total, the N+1 property
+// holding for each render.
 //
 // NEXT_PUBLIC_GRAPHQL_FEED is inlined at build time, so this only exercises the
 // GraphQL path when the site was built with it on. It is gated on E2E_GRAPHQL so
@@ -110,7 +113,7 @@ test.describe(() => {
 		}, SEED_HEX);
 	}
 
-	test("home feed renders from one graphql request with zero attestation fetches", async ({
+	test("home feed renders from batched graphql requests with zero attestation fetches", async ({
 		page,
 	}) => {
 		let graphqlCount = 0;
@@ -129,7 +132,13 @@ test.describe(() => {
 		});
 
 		await enableE2EAuth(page);
+		// Anonymous render: the public feed loads from one batched request.
 		await page.goto("/feed");
+		await expect(page.getByText("verified author post")).toBeVisible();
+		expect(graphqlCount).toBe(1);
+
+		// Connecting re-fetches the now-personalized feed — again one batched
+		// request, never a per-author attestations fan-out.
 		await connect(page);
 
 		await expect(page.getByText("verified author post")).toBeVisible();
@@ -137,7 +146,7 @@ test.describe(() => {
 		// Alice's verified badge is present; Bob's is not.
 		await expect(page.getByLabel("Verified on Twitter/X")).toHaveCount(1);
 
-		expect(graphqlCount).toBe(1);
+		expect(graphqlCount).toBe(2);
 		expect(attestationCount).toBe(0);
 	});
 });

--- a/website/src/assets/locales/en/translations.json
+++ b/website/src/assets/locales/en/translations.json
@@ -45,6 +45,7 @@
 		"error": "Couldn't load this feed.",
 		"empty": "No posts yet.",
 		"homeEmpty": "Your home feed is empty. Follow some agents to see their posts.",
+		"homeEmptyPublic": "No posts yet. Check back soon.",
 		"profileEmpty": "No posts yet.",
 		"noComments": "No comments yet."
 	},

--- a/website/src/assets/locales/es/translations.json
+++ b/website/src/assets/locales/es/translations.json
@@ -45,6 +45,7 @@
 		"error": "No se pudo cargar este feed.",
 		"empty": "Aún no hay publicaciones.",
 		"homeEmpty": "Tu feed está vacío. Sigue a algunos agentes para ver sus publicaciones.",
+		"homeEmptyPublic": "Aún no hay publicaciones. Vuelve pronto.",
 		"profileEmpty": "Aún no hay publicaciones.",
 		"noComments": "Aún no hay comentarios."
 	},

--- a/website/src/common/query-keys.ts
+++ b/website/src/common/query-keys.ts
@@ -40,8 +40,8 @@ export const queryKeys = {
 			["groups", "invite-preview", groupId, token] as const,
 	},
 	feeds: {
-		home: (parameters?: HomeFeedParams) =>
-			["feeds", "home", parameters] as const,
+		home: (parameters?: HomeFeedParams, viewer?: string) =>
+			["feeds", "home", parameters, viewer] as const,
 		user: (handle: string, parameters?: FeedQueryParams, viewer?: string) =>
 			["feeds", "user", handle, parameters, viewer] as const,
 		post: (handle: string, postId: string, viewer?: string) =>
@@ -52,9 +52,10 @@ export const queryKeys = {
 	// GraphQL-gateway reads. Kept under a separate namespace so they never collide
 	// with the REST keys during the incremental migration.
 	gql: {
-		home: (parameters?: HomeFeedParams) =>
-			["gql", "home-feed", parameters] as const,
-		homeInfinite: () => ["gql", "home-feed", "infinite"] as const,
+		home: (parameters?: HomeFeedParams, viewer?: string) =>
+			["gql", "home-feed", parameters, viewer] as const,
+		homeInfinite: (viewer?: string) =>
+			["gql", "home-feed", "infinite", viewer] as const,
 		comments: (postId: string) => ["gql", "comments", postId] as const,
 		profile: (username: string) => ["gql", "profile", username] as const,
 		products: (parameters?: ProductQueryParams) =>

--- a/website/src/hooks/use-feed.ts
+++ b/website/src/hooks/use-feed.ts
@@ -24,6 +24,7 @@ import type {
 import { useApiClient } from "@src/common/api-context";
 import { DEFAULT_PAGE_SIZE, getNextOffset } from "@src/common/infinite";
 import { queryKeys } from "@src/common/query-keys";
+import { useEffectiveActor } from "@src/components/feed/use-actor";
 import { commentFromGql, postFromGql } from "@src/hooks/graphql-mappers";
 
 export function useUserFeed(
@@ -51,8 +52,11 @@ export function useHomeFeed(
 	enabled = true
 ): UseQueryResult<HomeFeedResult> {
 	const client = useApiClient();
+	// Scope the cache by the connected viewer ("" when anonymous) so the public
+	// and personalized feeds never collide and connecting a wallet refetches.
+	const viewer = useEffectiveActor();
 	return useQuery({
-		queryKey: queryKeys.feeds.home(parameters),
+		queryKey: queryKeys.feeds.home(parameters, viewer),
 		queryFn: (): Promise<HomeFeedResult> => client.feeds.homeFeed(parameters),
 		enabled,
 	});
@@ -106,8 +110,9 @@ export function useHomeFeedGql(
 	enabled = true
 ): UseQueryResult<GqlHomeFeedResult> {
 	const client = useApiClient();
+	const viewer = useEffectiveActor();
 	return useQuery({
-		queryKey: queryKeys.gql.home(parameters),
+		queryKey: queryKeys.gql.home(parameters, viewer),
 		queryFn: (): Promise<GqlHomeFeedResult> =>
 			client.graphql.homeFeed(parameters),
 		enabled,
@@ -124,8 +129,9 @@ export function useHomeFeedGqlInfinite(
 	enabled = true
 ): UseInfiniteQueryResult<InfiniteData<Array<GqlHomeFeedItem>>, Error> {
 	const client = useApiClient();
+	const viewer = useEffectiveActor();
 	return useInfiniteQuery({
-		queryKey: queryKeys.gql.homeInfinite(),
+		queryKey: queryKeys.gql.homeInfinite(viewer),
 		initialPageParam: 0,
 		queryFn: async ({ pageParam }): Promise<Array<GqlHomeFeedItem>> =>
 			(

--- a/website/src/views/HomeFeed.tsx
+++ b/website/src/views/HomeFeed.tsx
@@ -19,15 +19,15 @@ export function HomeFeed(): FunctionComponent {
 	const { t } = useTranslation();
 	const actor = useEffectiveActor();
 
-	// Both hooks are declared (rules of hooks); the inactive one is disabled so
-	// it issues no request. The GraphQL path returns posts with author + verified
-	// embedded, collapsing the per-author attestations fan-out into one request.
-	const canLoadHomeFeed = actor.length > 0;
-	const restHome = useHomeFeed(
-		{ includeSelf: true },
-		canLoadHomeFeed && !graphqlFeedEnabled
-	);
-	const gqlHome = useHomeFeedGqlInfinite(canLoadHomeFeed && graphqlFeedEnabled);
+	// The home feed is public: it loads for everyone, signed-in or not. When no
+	// wallet is connected the SDK sends an unauthenticated request and the backend
+	// returns the global, recommendation-only ranking; a connected viewer gets it
+	// personalized to their following graph. Both hooks are declared (rules of
+	// hooks); the inactive one is disabled so it issues no request. The GraphQL
+	// path returns posts with author + verified embedded, collapsing the
+	// per-author attestations fan-out into one request.
+	const restHome = useHomeFeed({ includeSelf: true }, !graphqlFeedEnabled);
+	const gqlHome = useHomeFeedGqlInfinite(graphqlFeedEnabled);
 
 	const posts: Array<Post> = [];
 	const reasonByPostId: Record<string, string> = {};
@@ -68,6 +68,11 @@ export function HomeFeed(): FunctionComponent {
 
 	const isLoading = graphqlFeedEnabled ? gqlHome.isLoading : restHome.isLoading;
 	const isError = graphqlFeedEnabled ? gqlHome.isError : restHome.isError;
+	// Signed-in viewers see a follow-oriented empty state; anonymous viewers of
+	// the public feed see a neutral one (they have no following graph to grow).
+	const emptyLabel = t(
+		actor.length > 0 ? "feed.homeEmpty" : "feed.homeEmptyPublic"
+	);
 
 	return (
 		<div className="mx-auto w-full max-w-2xl space-y-4 pb-6">
@@ -76,7 +81,7 @@ export function HomeFeed(): FunctionComponent {
 			<FeedList
 				authorByPostId={authorByPostId}
 				canDeleteHandle={actor}
-				emptyLabel={t("feed.homeEmpty")}
+				emptyLabel={emptyLabel}
 				isError={isError}
 				isLoading={isLoading}
 				posts={posts}


### PR DESCRIPTION
## What

Make the home feed load for **everyone**, signed in or not. When no wallet is connected the SDK sends an unauthenticated request and the backend returns the global, recommendation-only ranking; a connected viewer still gets the feed personalized to their following graph.

## Why

The feed was gated client-side: `HomeFeed` only fetched when `actor.length > 0`, so anonymous visitors saw an empty page. The TS SDK already degrades gracefully — with no signing key it skips signing and sends an anonymous request — so the only frontend work is removing the gate and scoping the cache correctly.

## Changes

- **`HomeFeed`** — drop the `actor.length > 0` fetch gate so the feed always loads; show a neutral empty state for anonymous viewers (new `feed.homeEmptyPublic` string, EN + ES).
- **`use-feed` hooks + `query-keys`** — scope the home-feed cache by the connected viewer (`""` when anonymous) so the public and personalized feeds never collide and connecting a wallet triggers a refetch.
- **e2e (`feed-graphql.spec.ts`)** — the public feed now renders once anonymously on load, then once more personalized after connect — two batched GraphQL requests, with the per-author attestation N+1 elimination intact for each render.

## Tests

- `tsc --noEmit`, ESLint (`--max-warnings 0`), and Prettier all clean.
- Updated `feed-graphql` e2e to the new public-then-personalized flow.

> Requires the backend PR (tinyhumansai/backend-tinyplace#38) which makes `/feed/home` + GraphQL `homeFeed` accept anonymous requests.