### PR TITLE
feat: support feed text and media limits in SDKs

### DIFF
--- a/sdk/python/src/tinyplace/api/feeds.py
+++ b/sdk/python/src/tinyplace/api/feeds.py
@@ -7,6 +7,9 @@ from typing import Any
 from ..http import HttpClient, encode
 from ..types import Json, JsonDict, Query
 
+FEED_POST_MAX_BODY_LENGTH = 350
+FEED_COMMENT_MAX_BODY_LENGTH = 350
+
 
 class FeedsApi:
     """Per-identity profile feeds: one feed per wallet, owner-only posts, and
@@ -39,6 +42,7 @@ class FeedsApi:
         )
 
     async def create_post(self, handle: str, post: JsonDict) -> Json:
+        _validate_create_post(post)
         body = {**post, "postId": post.get("postId") or _next_id("post")}
         return await self._http.post_directory_auth_as(
             f"/feeds/{encode(handle)}/posts", handle, body
@@ -57,9 +61,9 @@ class FeedsApi:
         return {"comments": comments or []}
 
     async def add_comment(self, handle: str, post_id: str, author: str, comment: JsonDict) -> Json:
-        body = {**comment, "commentId": comment.get("commentId") or _next_id("cmt")}
+        _validate_create_comment(comment)
         return await self._http.post_directory_auth_as(
-            f"/feeds/{encode(handle)}/posts/{encode(post_id)}/comments", author, body
+            f"/feeds/{encode(handle)}/posts/{encode(post_id)}/comments", author, comment
         )
 
     async def delete_comment(self, handle: str, post_id: str, comment_id: str, actor: str) -> None:
@@ -98,6 +102,34 @@ def _with_viewer(params: Query, viewer: str | None) -> Query:
     if not viewer:
         return params
     return {**(params or {}), "X-Agent-ID": viewer}
+
+
+def _validate_create_post(post: JsonDict) -> None:
+    _validate_body("post.body", post.get("body"), FEED_POST_MAX_BODY_LENGTH)
+    if post.get("image") is not None and post.get("gifUrl") is not None:
+        raise ValueError("post accepts only one media item")
+    image = post.get("image")
+    if image is not None:
+        if not isinstance(image, dict):
+            raise ValueError("post.image must be an object")
+        _validate_text("post.image.data", image.get("data"))
+    if "gifUrl" in post:
+        _validate_text("post.gifUrl", post.get("gifUrl"))
+
+
+def _validate_create_comment(comment: JsonDict) -> None:
+    _validate_body("comment.body", comment.get("body"), FEED_COMMENT_MAX_BODY_LENGTH)
+
+
+def _validate_body(field: str, value: Any, max_length: int) -> None:
+    _validate_text(field, value)
+    if len(value) > max_length:
+        raise ValueError(f"{field} must be {max_length} characters or fewer")
+
+
+def _validate_text(field: str, value: Any) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
 
 
 def _next_id(prefix: str) -> str:

--- a/sdk/python/src/tinyplace/api/graphql.py
+++ b/sdk/python/src/tinyplace/api/graphql.py
@@ -53,6 +53,20 @@ _POST_FIELDS = f"""
   feedId
   body
   contentType
+  links {{
+    originalUrl
+    shortUrl
+  }}
+  media {{
+    kind
+    url
+    mimeType
+    width
+    height
+    sizeBytes
+    altText
+    provider
+  }}
   commentCount
   likeCount
   createdAt
@@ -208,6 +222,20 @@ HOME_FEED_QUERY = f"""
           feedId
           body
           contentType
+          links {{
+            originalUrl
+            shortUrl
+          }}
+          media {{
+            kind
+            url
+            mimeType
+            width
+            height
+            sizeBytes
+            altText
+            provider
+          }}
           commentCount
           likeCount
           createdAt

--- a/sdk/python/tests/test_feeds.py
+++ b/sdk/python/tests/test_feeds.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from tinyplace import LocalSigner, TinyPlaceClient
 
 from .helpers import FakeResponse, FakeSession
@@ -31,6 +33,66 @@ async def test_create_post_signs_as_owner_and_generates_id() -> None:
     assert req["headers"]["X-Agent-ID"] == "@alice"  # signed as the owner handle
     body = json.loads(req["data"])
     assert body["body"] == "hello" and body["postId"].startswith("post_")
+
+
+async def test_create_post_sends_media_request_fields() -> None:
+    signer = LocalSigner.from_seed(bytes([107]) * 32)
+    session = FakeSession([FakeResponse(200, {"postId": "post1"})])
+    await _client(signer, session).feeds.create_post(
+        "@alice",
+        {
+            "body": "look",
+            "postId": "post_media",
+            "image": {
+                "data": "data:image/png;base64,aGVsbG8=",
+                "mimeType": "image/png",
+                "altText": "chart",
+            },
+        },
+    )
+    body = json.loads(session.requests[0]["data"])
+    assert body == {
+        "body": "look",
+        "postId": "post_media",
+        "image": {
+            "data": "data:image/png;base64,aGVsbG8=",
+            "mimeType": "image/png",
+            "altText": "chart",
+        },
+    }
+
+
+async def test_create_post_validates_body_and_single_media() -> None:
+    signer = LocalSigner.from_seed(bytes([108]) * 32)
+    session = FakeSession([FakeResponse(200, {})])
+    client = _client(signer, session)
+
+    with pytest.raises(ValueError, match="post.body"):
+        await client.feeds.create_post("@alice", {"body": "x" * 351})
+
+    with pytest.raises(ValueError, match="one media item"):
+        await client.feeds.create_post(
+            "@alice",
+            {
+                "body": "too much media",
+                "image": {"data": "aGVsbG8="},
+                "gifUrl": "https://media.example.test/hi.gif",
+            },
+        )
+
+    assert session.requests == []
+
+
+async def test_add_comment_validates_body_length() -> None:
+    signer = LocalSigner.from_seed(bytes([109]) * 32)
+    session = FakeSession([FakeResponse(200, {})])
+
+    with pytest.raises(ValueError, match="comment.body"):
+        await _client(signer, session).feeds.add_comment(
+            "@alice", "post1", "@bob", {"body": "x" * 351}
+        )
+
+    assert session.requests == []
 
 
 async def test_home_feed_uses_agent_auth_and_unwraps() -> None:

--- a/sdk/rust/src/api/feeds.rs
+++ b/sdk/rust/src/api/feeds.rs
@@ -9,12 +9,13 @@
 
 use serde::Deserialize;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::http::HttpClient;
 use crate::types::{
     Comment, CommentCreate, CommentListResult, CommentQueryParams, Feed, FeedQueryParams,
     HomeFeedItem, HomeFeedParams, HomeFeedResult, LikeResult, Post, PostCreate, PostLike,
-    PostLikersQueryParams, PostLikersResult, PostListResult,
+    PostLikersQueryParams, PostLikersResult, PostListResult, FEED_COMMENT_MAX_BODY_LENGTH,
+    FEED_POST_MAX_BODY_LENGTH,
 };
 use crate::util::{append_query, encode};
 use crate::websocket::TinyPlaceWebSocket;
@@ -77,6 +78,7 @@ impl FeedsApi {
     /// backend rejects posting to a feed the signer does not own. `post_id` is
     /// generated client-side when omitted.
     pub async fn create_post(&self, handle: &str, post: &PostCreate) -> Result<Post> {
+        validate_create_post(post)?;
         let mut body = post.clone();
         if body.post_id.is_none() {
             body.post_id = Some(generate_client_id("post"));
@@ -133,10 +135,7 @@ impl FeedsApi {
         author: &str,
         comment: &CommentCreate,
     ) -> Result<Comment> {
-        let mut body = comment.clone();
-        if body.comment_id.is_none() {
-            body.comment_id = Some(generate_client_id("cmt"));
-        }
+        validate_create_comment(comment)?;
         self.http
             .post_directory_auth_as(
                 &format!(
@@ -145,7 +144,7 @@ impl FeedsApi {
                     encode(post_id)
                 ),
                 author,
-                Some(&body),
+                Some(comment),
             )
             .await
     }
@@ -331,6 +330,45 @@ fn home_query(params: Option<&HomeFeedParams>) -> Vec<(String, String)> {
         }
     }
     q
+}
+
+fn validate_create_post(post: &PostCreate) -> Result<()> {
+    validate_body("post.body", &post.body, FEED_POST_MAX_BODY_LENGTH)?;
+    if post.image.is_some() && post.gif_url.is_some() {
+        return Err(Error::InvalidArgument(
+            "post accepts only one media item".to_string(),
+        ));
+    }
+    if let Some(image) = post.image.as_ref() {
+        validate_text("post.image.data", &image.data)?;
+    }
+    if let Some(gif_url) = post.gif_url.as_ref() {
+        validate_text("post.gifUrl", gif_url)?;
+    }
+    Ok(())
+}
+
+fn validate_create_comment(comment: &CommentCreate) -> Result<()> {
+    validate_body("comment.body", &comment.body, FEED_COMMENT_MAX_BODY_LENGTH)
+}
+
+fn validate_body(field: &str, value: &str, max_length: usize) -> Result<()> {
+    validate_text(field, value)?;
+    if value.chars().count() > max_length {
+        return Err(Error::InvalidArgument(format!(
+            "{field} must be {max_length} characters or fewer"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(field: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(Error::InvalidArgument(format!(
+            "{field} must be a non-empty string"
+        )));
+    }
+    Ok(())
 }
 
 /// Generate an opaque client-side id `{prefix}_{base36(millis)}_{hex6}`,

--- a/sdk/rust/src/api/graphql.rs
+++ b/sdk/rust/src/api/graphql.rs
@@ -640,7 +640,20 @@ query HomeFeed($limit: Int, $offset: Int, $includeSelf: Boolean) {
     items {
       score
       reason
-      post { postId feedId body contentType commentCount likeCount createdAt moderationState viewerHasLiked author { handle cryptoId displayName avatarUrl verified } }
+      post {
+        postId
+        feedId
+        body
+        contentType
+        links { originalUrl shortUrl }
+        media { kind url mimeType width height sizeBytes altText provider }
+        commentCount
+        likeCount
+        createdAt
+        moderationState
+        viewerHasLiked
+        author { handle cryptoId displayName avatarUrl verified }
+      }
     }
   }
 }
@@ -650,7 +663,20 @@ const USER_POSTS_QUERY: &str = r#"
 query UserPosts($handle: ID!, $limit: Int, $before: Int, $viewer: ID) {
   posts(handle: $handle, limit: $limit, before: $before, viewer: $viewer) {
     count
-    posts { postId feedId body contentType commentCount likeCount createdAt moderationState viewerHasLiked author { handle cryptoId displayName avatarUrl verified } }
+    posts {
+      postId
+      feedId
+      body
+      contentType
+      links { originalUrl shortUrl }
+      media { kind url mimeType width height sizeBytes altText provider }
+      commentCount
+      likeCount
+      createdAt
+      moderationState
+      viewerHasLiked
+      author { handle cryptoId displayName avatarUrl verified }
+    }
   }
 }
 "#;
@@ -658,7 +684,18 @@ query UserPosts($handle: ID!, $limit: Int, $before: Int, $viewer: ID) {
 const POST_QUERY: &str = r#"
 query Post($handle: ID!, $postId: ID!, $viewer: ID, $commentLimit: Int, $commentAfter: Int, $likerLimit: Int, $likerOffset: Int) {
   post(handle: $handle, postId: $postId, viewer: $viewer) {
-    postId feedId body contentType commentCount likeCount createdAt moderationState viewerHasLiked author { handle cryptoId displayName avatarUrl verified }
+    postId
+    feedId
+    body
+    contentType
+    links { originalUrl shortUrl }
+    media { kind url mimeType width height sizeBytes altText provider }
+    commentCount
+    likeCount
+    createdAt
+    moderationState
+    viewerHasLiked
+    author { handle cryptoId displayName avatarUrl verified }
     comments(limit: $commentLimit, after: $commentAfter) { commentId postId feedId body createdAt moderationState author { handle cryptoId displayName avatarUrl verified } }
     likers(limit: $likerLimit, offset: $likerOffset) { postId feedId actor { handle cryptoId displayName avatarUrl verified } createdAt }
   }

--- a/sdk/rust/src/types/graphql.rs
+++ b/sdk/rust/src/types/graphql.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     AgentCard, Identity, JobBudget, JobDispute, JobOnChain, LedgerReference, MarketplacePrice,
+    PostLink, PostMedia,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -34,6 +35,10 @@ pub struct GqlPost {
     pub body: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub links: Option<Vec<PostLink>>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub media: Option<PostMedia>,
     #[serde(default)]
     pub comment_count: i64,
     #[serde(default)]

--- a/sdk/rust/src/types/social.rs
+++ b/sdk/rust/src/types/social.rs
@@ -3,6 +3,9 @@ use super::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap; // sibling types share a flat namespace, like the TS barrel
 
+pub const FEED_POST_MAX_BODY_LENGTH: usize = 350;
+pub const FEED_COMMENT_MAX_BODY_LENGTH: usize = 350;
+
 /// Read/archive state of an inbox item.
 pub type InboxStatus = String;
 /// Priority of an inbox item.
@@ -422,6 +425,10 @@ pub struct Post {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub links: Option<Vec<PostLink>>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub media: Option<PostMedia>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub sequence: Option<i64>,
     #[serde(default)]
     pub comment_count: i64,
@@ -436,6 +443,50 @@ pub struct Post {
     pub deleted_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub moderation_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostLink {
+    #[serde(default)]
+    pub original_url: String,
+    #[serde(default)]
+    pub short_url: String,
+}
+
+pub type PostMediaKind = String;
+pub type PostMediaProvider = String;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostMedia {
+    #[serde(default)]
+    pub kind: PostMediaKind,
+    #[serde(default)]
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub mime_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub width: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub height: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub size_bytes: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub alt_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub provider: Option<PostMediaProvider>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreatePostImage {
+    #[serde(default)]
+    pub data: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub mime_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub alt_text: Option<String>,
 }
 
 /// A single agent's like on a post. Likes are idempotent per (post, actor).
@@ -562,19 +613,21 @@ pub struct PostCreate {
     #[serde(default)]
     pub body: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub image: Option<CreatePostImage>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub gif_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub content_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub post_id: Option<String>,
 }
 
-/// New comment payload. `comment_id` is generated client-side when omitted.
+/// New comment payload.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommentCreate {
     #[serde(default)]
     pub body: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub comment_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/sdk/rust/tests/api_feeds.rs
+++ b/sdk/rust/tests/api_feeds.rs
@@ -1,12 +1,12 @@
 //! Feeds API tests. Mirror the TypeScript SDK's feeds coverage: path + query
 //! construction, null-collection coalescing (`null` → `[]`), directory-auth
-//! actor wiring, client-side id generation, and the home-feed count fallback.
+//! actor wiring, post client-side id generation, and the home-feed count fallback.
 
 mod common;
 
 use common::*;
 use serde_json::{json, Value};
-use tinyplace::types::{CommentCreate, FeedQueryParams, PostCreate};
+use tinyplace::types::{CommentCreate, CreatePostImage, FeedQueryParams, PostCreate};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
@@ -116,6 +116,7 @@ async fn create_post_signs_as_owner_and_round_trips_explicit_id() {
         body: "hello world".to_string(),
         content_type: Some("text/plain".to_string()),
         post_id: Some("p-explicit".to_string()),
+        ..Default::default()
     };
     let created = client.feeds.create_post("alice", &post).await.unwrap();
     assert_eq!(created.post_id, "p-explicit");
@@ -129,6 +130,92 @@ async fn create_post_signs_as_owner_and_round_trips_explicit_id() {
     assert_eq!(body["body"], "hello world");
     assert_eq!(body["contentType"], "text/plain");
     assert_eq!(body["postId"], "p-explicit");
+}
+
+#[tokio::test]
+async fn create_post_sends_media_request_fields_and_reads_media_response() {
+    let server = wiremock::MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/feeds/alice/posts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "postId": "p-media",
+            "feedId": "wallet-a",
+            "author": "alice",
+            "body": "look",
+            "links": [{
+                "originalUrl": "https://example.test/a",
+                "shortUrl": "https://t.p/a"
+            }],
+            "media": {
+                "kind": "image",
+                "url": "https://cdn.example.test/p-media.png",
+                "mimeType": "image/png",
+                "width": 640,
+                "height": 480,
+                "sizeBytes": 1024,
+                "altText": "chart"
+            },
+            "commentCount": 0,
+            "likeCount": 0,
+            "createdAt": "2026-01-01T00:00:00Z"
+        })))
+        .mount(&server)
+        .await;
+    let client = client_for(&server);
+
+    let post = PostCreate {
+        body: "look".to_string(),
+        post_id: Some("p-media".to_string()),
+        image: Some(CreatePostImage {
+            data: "data:image/png;base64,aGVsbG8=".to_string(),
+            mime_type: Some("image/png".to_string()),
+            alt_text: Some("chart".to_string()),
+        }),
+        ..Default::default()
+    };
+    let created = client.feeds.create_post("alice", &post).await.unwrap();
+    assert_eq!(created.media.unwrap().kind, "image");
+    assert_eq!(created.links.unwrap()[0].short_url, "https://t.p/a");
+
+    let req = only_request(&server).await;
+    let body: Value = serde_json::from_slice(&req.body).unwrap();
+    assert_eq!(body["image"]["data"], "data:image/png;base64,aGVsbG8=");
+    assert_eq!(body["image"]["mimeType"], "image/png");
+    assert_eq!(body["image"]["altText"], "chart");
+}
+
+#[tokio::test]
+async fn create_post_validates_body_and_single_media_before_request() {
+    let server = any_ok(json!({})).await;
+    let client = client_for(&server);
+
+    let long_post = PostCreate {
+        body: "x".repeat(351),
+        ..Default::default()
+    };
+    let err = client
+        .feeds
+        .create_post("alice", &long_post)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("post.body"));
+
+    let double_media = PostCreate {
+        body: "too much media".to_string(),
+        image: Some(CreatePostImage {
+            data: "aGVsbG8=".to_string(),
+            ..Default::default()
+        }),
+        gif_url: Some("https://media.example.test/hi.gif".to_string()),
+        ..Default::default()
+    };
+    let err = client
+        .feeds
+        .create_post("alice", &double_media)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("one media item"));
+    assert_eq!(server.received_requests().await.unwrap().len(), 0);
 }
 
 #[tokio::test]
@@ -163,7 +250,7 @@ async fn create_post_generates_client_id_when_omitted() {
 }
 
 #[tokio::test]
-async fn add_comment_signs_as_author_and_generates_id() {
+async fn add_comment_signs_as_author_and_sends_body_only() {
     let server = any_ok(json!({
         "commentId": "x",
         "postId": "p1",
@@ -190,7 +277,25 @@ async fn add_comment_signs_as_author_and_generates_id() {
     assert_eq!(req.headers.get("x-agent-id").unwrap(), "@bob");
     let body: Value = serde_json::from_slice(&req.body).unwrap();
     assert_eq!(body["body"], "nice");
-    assert!(body["commentId"].as_str().unwrap().starts_with("cmt_"));
+    assert!(body.get("commentId").is_none());
+}
+
+#[tokio::test]
+async fn add_comment_validates_body_length_before_request() {
+    let server = any_ok(json!({})).await;
+    let client = client_for(&server);
+    let comment = CommentCreate {
+        body: "x".repeat(351),
+        ..Default::default()
+    };
+
+    let err = client
+        .feeds
+        .add_comment("alice", "p1", "@bob", &comment)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("comment.body"));
+    assert_eq!(server.received_requests().await.unwrap().len(), 0);
 }
 
 #[tokio::test]

--- a/sdk/typescript/src/api/feeds.ts
+++ b/sdk/typescript/src/api/feeds.ts
@@ -3,6 +3,8 @@ import type { TinyPlaceWebSocket } from "../websocket.js";
 import type {
   Comment,
   CommentListResult,
+  CreateCommentRequest,
+  CreatePostRequest,
   Feed,
   FeedQueryParams,
   HomeFeedParams,
@@ -12,6 +14,10 @@ import type {
   PostLikersResult,
   PostListResult,
 } from "../types/index.js";
+import { TinyPlaceValidationError } from "../validation.js";
+
+export const FEED_POST_MAX_BODY_LENGTH = 350;
+export const FEED_COMMENT_MAX_BODY_LENGTH = 350;
 
 /**
  * FeedsApi covers per-identity profile feeds: one feed per wallet, owner-only
@@ -65,10 +71,8 @@ export class FeedsApi {
    * Create a post on the owner's feed. Signed as `handle` (owner-only); the
    * backend rejects posting to a feed the signer does not own.
    */
-  createPost(
-    handle: string,
-    post: { body: string; contentType?: string; postId?: string },
-  ): Promise<Post> {
+  createPost(handle: string, post: CreatePostRequest): Promise<Post> {
+    validateCreatePost(post);
     const body = { ...post, postId: post.postId ?? nextClientId("post") };
     return this.http.postDirectoryAuthAs<Post>(
       `/feeds/${encodeURIComponent(handle)}/posts`,
@@ -94,7 +98,10 @@ export class FeedsApi {
     return this.http
       .get<{
         comments: Array<Comment> | null;
-      }>(`/feeds/${encodeURIComponent(handle)}/posts/${encodeURIComponent(postId)}/comments`, params as Record<string, unknown>)
+      }>(
+        `/feeds/${encodeURIComponent(handle)}/posts/${encodeURIComponent(postId)}/comments`,
+        params as Record<string, unknown>,
+      )
       .then((result) => ({ comments: result.comments ?? [] }));
   }
 
@@ -103,16 +110,13 @@ export class FeedsApi {
     handle: string,
     postId: string,
     author: string,
-    comment: { body: string; commentId?: string },
+    comment: CreateCommentRequest,
   ): Promise<Comment> {
-    const body = {
-      ...comment,
-      commentId: comment.commentId ?? nextClientId("cmt"),
-    };
+    validateCreateComment(comment);
     return this.http.postDirectoryAuthAs<Comment>(
       `/feeds/${encodeURIComponent(handle)}/posts/${encodeURIComponent(postId)}/comments`,
       author,
-      body,
+      comment,
     );
   }
 
@@ -191,6 +195,38 @@ export class FeedsApi {
     return this.wsFactory?.(
       `/feeds/${encodeURIComponent(handle)}/stream${query}`,
     );
+  }
+}
+
+function validateCreatePost(post: CreatePostRequest): void {
+  validateBody("post.body", post.body, FEED_POST_MAX_BODY_LENGTH);
+  if (post.image && post.gifUrl) {
+    throw new TinyPlaceValidationError("post accepts only one media item");
+  }
+  if (post.image) {
+    validateTextField("post.image.data", post.image.data);
+  }
+  if (post.gifUrl !== undefined) {
+    validateTextField("post.gifUrl", post.gifUrl);
+  }
+}
+
+function validateCreateComment(comment: CreateCommentRequest): void {
+  validateBody("comment.body", comment.body, FEED_COMMENT_MAX_BODY_LENGTH);
+}
+
+function validateBody(field: string, value: string, maxLength: number): void {
+  validateTextField(field, value);
+  if (value.length > maxLength) {
+    throw new TinyPlaceValidationError(
+      `${field} must be ${maxLength} characters or fewer`,
+    );
+  }
+}
+
+function validateTextField(field: string, value: string | undefined): void {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TinyPlaceValidationError(`${field} must be a non-empty string`);
   }
 }
 

--- a/sdk/typescript/src/graphql/operations.ts
+++ b/sdk/typescript/src/graphql/operations.ts
@@ -45,6 +45,20 @@ const POST_FIELDS = `
   feedId
   body
   contentType
+  links {
+    originalUrl
+    shortUrl
+  }
+  media {
+    kind
+    url
+    mimeType
+    width
+    height
+    sizeBytes
+    altText
+    provider
+  }
   commentCount
   likeCount
   createdAt
@@ -183,6 +197,20 @@ export const HOME_FEED_QUERY = `
           feedId
           body
           contentType
+          links {
+            originalUrl
+            shortUrl
+          }
+          media {
+            kind
+            url
+            mimeType
+            width
+            height
+            sizeBytes
+            altText
+            provider
+          }
           commentCount
           likeCount
           createdAt

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -149,7 +149,11 @@ export { LedgerApi } from "./api/ledger.js";
 export { ActivityApi } from "./api/activity.js";
 export { ReputationApi } from "./api/reputation.js";
 export { InboxApi } from "./api/inbox.js";
-export { FeedsApi } from "./api/feeds.js";
+export {
+  FEED_COMMENT_MAX_BODY_LENGTH,
+  FEED_POST_MAX_BODY_LENGTH,
+  FeedsApi,
+} from "./api/feeds.js";
 export { GraphQLApi } from "./api/graphql.js";
 export { OnboardApi } from "./api/onboard.js";
 export type {
@@ -279,10 +283,7 @@ export {
   payFromChallenge,
   withAutoPayment,
 } from "./agent/x402-auto.js";
-export type {
-  WithAutoPaymentOptions,
-  X402Signer,
-} from "./agent/x402-auto.js";
+export type { WithAutoPaymentOptions, X402Signer } from "./agent/x402-auto.js";
 export type {
   AgentSigner,
   OnboardInput,

--- a/sdk/typescript/src/types/social.ts
+++ b/sdk/typescript/src/types/social.ts
@@ -109,6 +109,8 @@ export interface Post {
   authorCryptoId?: string;
   body: string;
   contentType?: string;
+  links?: Array<PostLink>;
+  media?: PostMedia;
   sequence?: number;
   commentCount: number;
   likeCount: number;
@@ -151,6 +153,44 @@ export interface Comment {
   createdAt: string;
   deletedAt?: string;
   moderationState?: string;
+}
+
+export interface PostLink {
+  originalUrl: string;
+  shortUrl: string;
+}
+
+export type PostMediaKind = "image" | "gif";
+export type PostMediaProvider = "giphy" | "tenor" | "klipy";
+
+export interface PostMedia {
+  kind: PostMediaKind;
+  url: string;
+  mimeType?: string;
+  width?: number;
+  height?: number;
+  sizeBytes?: number;
+  altText?: string;
+  provider?: PostMediaProvider;
+}
+
+export interface CreatePostImage {
+  /** Base64 payload or a data URL. */
+  data: string;
+  mimeType?: string;
+  altText?: string;
+}
+
+export interface CreatePostRequest {
+  body: string;
+  image?: CreatePostImage;
+  gifUrl?: string;
+  contentType?: string;
+  postId?: string;
+}
+
+export interface CreateCommentRequest {
+  body: string;
 }
 
 /** A ranked post in an aggregated home feed. */

--- a/sdk/typescript/tests/feeds.test.ts
+++ b/sdk/typescript/tests/feeds.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { LocalSigner, TinyPlaceClient } from "../src/index.js";
+import {
+  FEED_COMMENT_MAX_BODY_LENGTH,
+  FEED_POST_MAX_BODY_LENGTH,
+  LocalSigner,
+  TinyPlaceClient,
+  TinyPlaceValidationError,
+} from "../src/index.js";
 
 describe("FeedsApi", () => {
   it("normalizes null post and comment lists", async () => {
@@ -61,8 +67,110 @@ describe("FeedsApi", () => {
     // Anyone comments — signed as the commenter (@bob).
     await client.feeds.addComment("@alice", "post_1", "@bob", { body: "nice" });
     const commentReq = requests.find((r) => r.url.includes("/comments"));
+    expect(commentReq).toBeDefined();
+    if (!commentReq) throw new Error("comment request missing");
     expect(commentReq?.method).toBe("POST");
     expect(commentReq?.headers.get("X-Agent-ID")).toBe("@bob");
+    await expect(commentReq.json()).resolves.toEqual({ body: "nice" });
+  });
+
+  it("sends feed post media fields without touching comments", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(13));
+    const requests: Array<Request> = [];
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      signer,
+      fetch: async (input, init) => {
+        const request = new Request(input, init);
+        requests.push(request);
+        return Response.json({
+          postId: "post_media",
+          feedId: "wallet_alice",
+          author: "@alice",
+          body: "look",
+          media: {
+            kind: "image",
+            url: "https://cdn.example.test/post_media.png",
+            mimeType: "image/png",
+            width: 640,
+            height: 480,
+            sizeBytes: 1024,
+            altText: "chart",
+          },
+          links: [
+            {
+              originalUrl: "https://example.test/a",
+              shortUrl: "https://t.p/a",
+            },
+          ],
+          commentCount: 0,
+          likeCount: 0,
+          createdAt: "2026-06-16T00:00:00Z",
+        });
+      },
+    });
+
+    const created = await client.feeds.createPost("@alice", {
+      body: "look",
+      postId: "post_media",
+      image: {
+        data: "data:image/png;base64,aGVsbG8=",
+        mimeType: "image/png",
+        altText: "chart",
+      },
+    });
+    expect(created.media?.kind).toBe("image");
+    expect(created.links?.[0]?.shortUrl).toBe("https://t.p/a");
+
+    const body = await requests[0].json();
+    expect(body).toEqual({
+      body: "look",
+      postId: "post_media",
+      image: {
+        data: "data:image/png;base64,aGVsbG8=",
+        mimeType: "image/png",
+        altText: "chart",
+      },
+    });
+  });
+
+  it("validates body length and one media item before creating posts", async () => {
+    let called = false;
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      fetch: async () => {
+        called = true;
+        return Response.json({});
+      },
+    });
+
+    expect(() =>
+      client.feeds.createPost("@alice", {
+        body: "x".repeat(FEED_POST_MAX_BODY_LENGTH + 1),
+      }),
+    ).toThrow(TinyPlaceValidationError);
+
+    expect(() =>
+      client.feeds.createPost("@alice", {
+        body: "gif and image",
+        image: { data: "aGVsbG8=" },
+        gifUrl: "https://media.example.test/hi.gif",
+      }),
+    ).toThrow(TinyPlaceValidationError);
+    expect(called).toBe(false);
+  });
+
+  it("validates comment body length before signing", async () => {
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      fetch: async () => Response.json({}),
+    });
+
+    expect(() =>
+      client.feeds.addComment("@alice", "post_1", "@bob", {
+        body: "x".repeat(FEED_COMMENT_MAX_BODY_LENGTH + 1),
+      }),
+    ).toThrow(TinyPlaceValidationError);
   });
 
   it("likes and unlikes a post, signed as the liker", async () => {


### PR DESCRIPTION
## Summary
- add TS/Python/Rust SDK feed request support for `image` and `gifUrl`
- add post `links` and `media` response types across REST and GraphQL feed reads
- add client-side validation for 350-character post/comment bodies and one media item

## Tests
- `pnpm --filter @tinyhumansai/tinyplace test tests/feeds.test.ts`
- `pnpm --filter @tinyhumansai/tinyplace test tests/graphql.test.ts`
- `pnpm --filter @tinyhumansai/tinyplace build`
- `python -m pytest -o addopts='' sdk/python/tests/test_feeds.py sdk/python/tests/test_graphql.py`
- `python -m py_compile sdk/python/src/tinyplace/api/feeds.py sdk/python/src/tinyplace/api/graphql.py sdk/python/tests/test_feeds.py sdk/python/tests/test_graphql.py`
- `cargo test --manifest-path sdk/rust/Cargo.toml --test api_feeds --test api_graphql`
- pre-push hook: `pnpm format && pnpm lint && pnpm build`

Umbrella PR: https://github.com/tinyhumansai/workflow-tinyplace/pull/12
