### PR TITLE
feat(sdk/rust): add tinyplace CLI binary (#56)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,13 +178,13 @@ jobs:
         working-directory: sdk/rust
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --features cli -- -D warnings
         working-directory: sdk/rust
 
       - name: Build
-        run: cargo build --all-targets
+        run: cargo build --all-targets --features cli
         working-directory: sdk/rust
 
       - name: Test
-        run: cargo test
+        run: cargo test --features cli
         working-directory: sdk/rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,13 +178,19 @@ jobs:
         working-directory: sdk/rust
 
       - name: Clippy
-        run: cargo clippy --all-targets --features cli -- -D warnings
+        run: |
+          cargo clippy --all-targets -- -D warnings
+          cargo clippy --all-targets --features cli -- -D warnings
         working-directory: sdk/rust
 
       - name: Build
-        run: cargo build --all-targets --features cli
+        run: |
+          cargo build --all-targets
+          cargo build --all-targets --features cli
         working-directory: sdk/rust
 
       - name: Test
-        run: cargo test --features cli
+        run: |
+          cargo test
+          cargo test --features cli
         working-directory: sdk/rust

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -32,6 +32,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +228,52 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
@@ -502,6 +598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +980,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "percent-encoding"
@@ -1331,6 +1445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1537,7 @@ dependencies = [
  "bs58",
  "cbc",
  "chrono",
+ "clap",
  "curve25519-dalek",
  "ed25519-dalek",
  "futures",
@@ -1657,6 +1778,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -26,6 +26,10 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 thiserror = "2"
 async-trait = "0.1"
 
+# CLI binary only (the `tinyplace` bin). Optional so library consumers don't
+# pull it in; enabled by the `cli` feature.
+clap = { version = "4", features = ["derive"], optional = true }
+
 # Signal protocol (E2E encryption) primitives. Algorithms chosen to be
 # byte-compatible with the TS/Python SDKs: X25519 ECDH, HKDF/HMAC-SHA256,
 # AES-256-CBC + HMAC-SHA256 Encrypt-then-MAC.
@@ -35,6 +39,14 @@ hkdf = "0.12"
 hmac = "0.12"
 aes = "0.8"
 cbc = { version = "0.1", features = ["alloc"] }
+
+[features]
+cli = ["dep:clap"]
+
+[[bin]]
+name = "tinyplace"
+path = "src/cli/main.rs"
+required-features = ["cli"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -143,6 +143,36 @@ let signer = LocalSigner::from_solana_secret_key(base58_secret)?;
 The agent id is the base58 (Solana address) of the Ed25519 public key, identical
 to the TypeScript SDK — the two are cross-compatible for the same key material.
 
+## CLI
+
+The crate ships an optional `tinyplace` binary (behind the `cli` feature) for
+driving the SDK from the shell. Output is JSON by default; pass `--format md`
+for Markdown.
+
+```bash
+# Install from a published/checked-out crate:
+cargo install --git https://github.com/tinyhumansai/tiny.place tinyplace --features cli
+# Or run from a checkout:
+cargo run --features cli -- <command>
+```
+
+Configuration is read from `~/.tinyplace/config.json`
+(`{ "endpoint": "…", "secretKey": "<hex 32-byte seed>" }`) and overridable with
+`$TINYPLACE_ENDPOINT` / `$TINYPLACE_API_URL`, `$TINYPLACE_SECRET_KEY`, and
+`$TINYPLACE_CONFIG`.
+
+```bash
+tinyplace whoami                          # agent id + public key (needs a key)
+tinyplace lookup @alice                   # resolve a handle's identity
+tinyplace groups --q ai --limit 20        # browse public groups
+tinyplace pricing quote --base SOL --quote USDC
+tinyplace pricing networks                # assets / pairs / networks / gas
+tinyplace debug                           # non-secret diagnostics
+```
+
+This first cut covers read-only commands; encrypted messaging and on-chain
+flows remain TypeScript-only (see [Scope](#scope)).
+
 ## Layout
 
 - `client` — [`TinyPlaceClient`], one field per API namespace.

--- a/sdk/rust/src/api/groups.rs
+++ b/sdk/rust/src/api/groups.rs
@@ -1,7 +1,7 @@
 //! Groups API. Mirrors `sdk/typescript/src/api/groups.ts`.
 
 use rand::RngCore as _;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 use crate::http::HttpClient;
@@ -14,6 +14,7 @@ use crate::types::{
 use crate::util::encode;
 
 /// Wrapper for the `{ groups: [...] }` list response.
+#[derive(Debug, Clone, Serialize)]
 pub struct GroupListResponse {
     pub groups: Vec<GroupMetadata>,
 }

--- a/sdk/rust/src/api/pricing.rs
+++ b/sdk/rust/src/api/pricing.rs
@@ -1,12 +1,12 @@
 //! Pricing. Mirrors `sdk/typescript/src/api/pricing.ts`.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 use crate::http::HttpClient;
 use crate::types::{GasEstimate, PriceHistory, PriceQuote, SupportedChain, TradePair};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PriceAsset {
     pub symbol: String,
     #[serde(default)]
@@ -14,17 +14,17 @@ pub struct PriceAsset {
     pub decimals: i64,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PriceAssets {
     pub assets: Vec<PriceAsset>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TradePairs {
     pub pairs: Vec<TradePair>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SupportedNetworks {
     pub networks: Vec<SupportedChain>,
 }

--- a/sdk/rust/src/cli/args.rs
+++ b/sdk/rust/src/cli/args.rs
@@ -19,11 +19,11 @@ pub struct Cli {
     pub format: OutputFormat,
 
     /// Shorthand for `--format json`.
-    #[arg(long, global = true)]
+    #[arg(long, global = true, conflicts_with_all = ["md", "format"])]
     pub json: bool,
 
     /// Shorthand for `--format md`.
-    #[arg(long, global = true)]
+    #[arg(long, global = true, conflicts_with_all = ["json", "format"])]
     pub md: bool,
 
     /// Override the API endpoint (else $TINYPLACE_ENDPOINT, config, or default).

--- a/sdk/rust/src/cli/args.rs
+++ b/sdk/rust/src/cli/args.rs
@@ -1,0 +1,98 @@
+use clap::{Parser, Subcommand, ValueEnum};
+
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum OutputFormat {
+    #[default]
+    Json,
+    Md,
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "tinyplace",
+    version,
+    about = "CLI for the tiny.place agent-to-agent network"
+)]
+pub struct Cli {
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json, global = true)]
+    pub format: OutputFormat,
+
+    /// Shorthand for `--format json`.
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    /// Shorthand for `--format md`.
+    #[arg(long, global = true)]
+    pub md: bool,
+
+    /// Override the API endpoint (else $TINYPLACE_ENDPOINT, config, or default).
+    #[arg(long, global = true)]
+    pub endpoint: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+impl Cli {
+    pub fn output_format(&self) -> OutputFormat {
+        if self.md {
+            OutputFormat::Md
+        } else if self.json {
+            OutputFormat::Json
+        } else {
+            self.format
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Print this agent's identity (requires a configured key).
+    Whoami,
+    /// Print the CLI version.
+    Version,
+    /// Print non-secret diagnostics (paths, endpoint, identity).
+    #[command(visible_alias = "doctor")]
+    Debug,
+    /// Look up an identity by @handle.
+    Lookup { handle: String },
+    /// List public groups.
+    Groups {
+        /// Free-text search query.
+        #[arg(long)]
+        q: Option<String>,
+        /// Filter by tag.
+        #[arg(long)]
+        tag: Option<String>,
+        /// Maximum results.
+        #[arg(long)]
+        limit: Option<i64>,
+    },
+    /// Asset pricing.
+    Pricing {
+        #[command(subcommand)]
+        command: PricingCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum PricingCommand {
+    /// List priceable assets.
+    Assets,
+    /// List supported trade pairs.
+    Pairs,
+    /// List supported networks.
+    Networks,
+    /// Quote a price for a base/quote pair.
+    Quote {
+        #[arg(long)]
+        base: String,
+        #[arg(long)]
+        quote: String,
+        #[arg(long)]
+        network: Option<String>,
+    },
+    /// Estimate gas for a network.
+    Gas { network: String },
+}

--- a/sdk/rust/src/cli/commands.rs
+++ b/sdk/rust/src/cli/commands.rs
@@ -193,6 +193,7 @@ mod tests {
     async fn pricing_networks_renders_array() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
+            .and(path("/pricing/networks"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "networks": [] })))
             .mount(&server)
             .await;
@@ -213,6 +214,7 @@ mod tests {
     async fn sdk_http_error_maps_to_sdk_error_code() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
+            .and(path("/registry/names/ghost"))
             .respond_with(ResponseTemplate::new(404).set_body_json(json!({ "error": "nope" })))
             .mount(&server)
             .await;

--- a/sdk/rust/src/cli/commands.rs
+++ b/sdk/rust/src/cli/commands.rs
@@ -1,0 +1,231 @@
+use std::sync::Arc;
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use tinyplace::api::pricing::QuoteParams;
+use tinyplace::types::GroupQueryParams;
+use tinyplace::{LocalSigner, Signer, TinyPlaceClient};
+
+use crate::args::{Cli, Command, PricingCommand};
+use crate::{config, context, output};
+
+#[derive(Debug)]
+pub struct CliError {
+    message: String,
+    code: &'static str,
+}
+
+impl CliError {
+    fn arg(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            code: "bad_request",
+        }
+    }
+
+    fn config(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            code: "config_error",
+        }
+    }
+
+    pub fn to_stderr_json(&self) -> String {
+        let body = json!({ "error": self.message, "code": self.code });
+        let mut out = serde_json::to_string_pretty(&body).unwrap_or_else(|_| body.to_string());
+        out.push('\n');
+        out
+    }
+}
+
+impl From<tinyplace::Error> for CliError {
+    fn from(err: tinyplace::Error) -> Self {
+        Self {
+            message: err.to_string(),
+            code: "sdk_error",
+        }
+    }
+}
+
+fn to_value<T: Serialize>(value: T) -> Result<Value, CliError> {
+    serde_json::to_value(value)
+        .map_err(|err| CliError::config(format!("could not encode response: {err}")))
+}
+
+fn client_for(
+    endpoint: Option<&str>,
+) -> Result<(TinyPlaceClient, Option<Arc<dyn Signer>>), CliError> {
+    let resolved = config::resolve(endpoint).map_err(CliError::config)?;
+    context::build(&resolved).map_err(CliError::config)
+}
+
+fn whoami(endpoint: Option<&str>) -> Result<Value, CliError> {
+    let (_client, signer) = client_for(endpoint)?;
+    let signer = signer.ok_or_else(|| {
+        CliError::arg(
+            "no identity configured — set $TINYPLACE_SECRET_KEY or `secretKey` in the config",
+        )
+    })?;
+    Ok(json!({
+        "agentId": signer.agent_id(),
+        "publicKey": signer.public_key_base64(),
+    }))
+}
+
+fn debug(endpoint: Option<&str>) -> Result<Value, CliError> {
+    let resolved = config::resolve(endpoint).map_err(CliError::config)?;
+    let agent_id = resolved
+        .seed
+        .as_ref()
+        .and_then(|seed| LocalSigner::from_seed(seed).ok())
+        .map(|signer| signer.agent_id());
+    Ok(json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "endpoint": resolved.endpoint,
+        "configPath": resolved.config_path.display().to_string(),
+        "hasKey": resolved.seed.is_some(),
+        "agentId": agent_id,
+    }))
+}
+
+async fn run_pricing(
+    client: &TinyPlaceClient,
+    command: &PricingCommand,
+) -> Result<Value, CliError> {
+    match command {
+        PricingCommand::Assets => to_value(client.pricing.assets().await?),
+        PricingCommand::Pairs => to_value(client.pricing.pairs().await?),
+        PricingCommand::Networks => to_value(client.pricing.networks().await?),
+        PricingCommand::Quote {
+            base,
+            quote,
+            network,
+        } => {
+            let params = QuoteParams {
+                base: base.clone(),
+                quote: quote.clone(),
+                network: network.clone(),
+            };
+            to_value(client.pricing.quote(&params).await?)
+        }
+        PricingCommand::Gas { network } => to_value(client.pricing.gas(network).await?),
+    }
+}
+
+/// Dispatch the commands that talk to the API, given an already-built client.
+/// Kept separate from [`run`] so it can be exercised against a mock server.
+async fn run_api_command(client: &TinyPlaceClient, command: &Command) -> Result<Value, CliError> {
+    match command {
+        Command::Lookup { handle } => to_value(client.registry.get(handle).await?),
+        Command::Groups { q, tag, limit } => {
+            let params = GroupQueryParams {
+                q: q.clone(),
+                tag: tag.clone(),
+                limit: *limit,
+                ..Default::default()
+            };
+            to_value(client.groups.list(Some(&params)).await?)
+        }
+        Command::Pricing { command } => run_pricing(client, command).await,
+        Command::Version | Command::Whoami | Command::Debug => {
+            Err(CliError::arg("not an API command"))
+        }
+    }
+}
+
+pub async fn run(cli: Cli) -> Result<String, CliError> {
+    let format = cli.output_format();
+    let endpoint = cli.endpoint.as_deref();
+
+    let value = match &cli.command {
+        Command::Version => json!({ "version": env!("CARGO_PKG_VERSION") }),
+        Command::Whoami => whoami(endpoint)?,
+        Command::Debug => debug(endpoint)?,
+        command => {
+            let (client, _signer) = client_for(endpoint)?;
+            run_api_command(&client, command).await?
+        }
+    };
+
+    Ok(output::render(&value, format))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tinyplace::TinyPlaceClientOptions;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn mock_client(server: &MockServer) -> TinyPlaceClient {
+        TinyPlaceClient::new(TinyPlaceClientOptions {
+            base_url: server.uri(),
+            ..Default::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn lookup_renders_registry_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/registry/names/alice"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "available": false, "name": "alice" })),
+            )
+            .mount(&server)
+            .await;
+
+        let value = run_api_command(
+            &mock_client(&server),
+            &Command::Lookup {
+                handle: "alice".into(),
+            },
+        )
+        .await
+        .expect("lookup should succeed against the mock");
+
+        assert_eq!(value["name"], "alice");
+        assert_eq!(value["available"], false);
+    }
+
+    #[tokio::test]
+    async fn pricing_networks_renders_array() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "networks": [] })))
+            .mount(&server)
+            .await;
+
+        let value = run_api_command(
+            &mock_client(&server),
+            &Command::Pricing {
+                command: PricingCommand::Networks,
+            },
+        )
+        .await
+        .expect("pricing networks should succeed against the mock");
+
+        assert!(value["networks"].is_array(), "got: {value}");
+    }
+
+    #[tokio::test]
+    async fn sdk_http_error_maps_to_sdk_error_code() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({ "error": "nope" })))
+            .mount(&server)
+            .await;
+
+        let err = run_api_command(
+            &mock_client(&server),
+            &Command::Lookup {
+                handle: "ghost".into(),
+            },
+        )
+        .await
+        .expect_err("a 404 should surface as an error");
+
+        assert_eq!(err.code, "sdk_error");
+    }
+}

--- a/sdk/rust/src/cli/config.rs
+++ b/sdk/rust/src/cli/config.rs
@@ -63,6 +63,17 @@ fn pick_endpoint(
         .to_string()
 }
 
+/// `$TINYPLACE_SECRET_KEY` then the config file. Blank/whitespace values are
+/// ignored, so an empty export doesn't shadow a configured key.
+fn pick_secret(env: Option<&str>, file: Option<&str>) -> Option<String> {
+    [env, file]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
 fn decode_seed_hex(hex: &str) -> Result<[u8; 32], String> {
     let hex = hex.trim();
     if hex.len() != 64 {
@@ -90,11 +101,12 @@ pub fn resolve(cli_endpoint: Option<&str>) -> Result<Resolved, String> {
         file.endpoint.as_deref(),
     );
 
-    let seed = std::env::var("TINYPLACE_SECRET_KEY")
-        .ok()
-        .or(file.secret_key)
-        .map(|hex| decode_seed_hex(&hex))
-        .transpose()?;
+    let seed = pick_secret(
+        std::env::var("TINYPLACE_SECRET_KEY").ok().as_deref(),
+        file.secret_key.as_deref(),
+    )
+    .map(|hex| decode_seed_hex(&hex))
+    .transpose()?;
 
     Ok(Resolved {
         endpoint,
@@ -140,6 +152,15 @@ mod tests {
             pick_endpoint(Some("   "), Some("https://env"), None, None),
             "https://env"
         );
+    }
+
+    #[test]
+    fn secret_precedence_ignores_blank() {
+        assert_eq!(pick_secret(Some("aa"), Some("bb")).as_deref(), Some("aa"));
+        // A blank env export must fall back to the config key, not block it.
+        assert_eq!(pick_secret(Some("   "), Some("bb")).as_deref(), Some("bb"));
+        assert_eq!(pick_secret(Some(""), None), None);
+        assert_eq!(pick_secret(None, None), None);
     }
 
     #[test]

--- a/sdk/rust/src/cli/config.rs
+++ b/sdk/rust/src/cli/config.rs
@@ -1,0 +1,156 @@
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+const DEFAULT_ENDPOINT: &str = "https://api.tiny.place";
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ConfigFile {
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default, rename = "secretKey")]
+    pub secret_key: Option<String>,
+}
+
+pub struct Resolved {
+    pub endpoint: String,
+    pub seed: Option<[u8; 32]>,
+    pub config_path: PathBuf,
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+pub fn config_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("TINYPLACE_CONFIG") {
+        return PathBuf::from(path);
+    }
+    let mut base = home_dir().unwrap_or_default();
+    base.push(".tinyplace");
+    base.push("config.json");
+    base
+}
+
+fn load_config_file(path: &Path) -> Result<ConfigFile, String> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => serde_json::from_str(&contents)
+            .map_err(|err| format!("invalid config at {}: {err}", path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(ConfigFile::default()),
+        Err(err) => Err(format!(
+            "could not read config at {}: {err}",
+            path.display()
+        )),
+    }
+}
+
+/// Endpoint precedence: CLI flag, `$TINYPLACE_ENDPOINT`, `$TINYPLACE_API_URL`,
+/// the config file, then the default. The first non-empty source wins.
+fn pick_endpoint(
+    cli: Option<&str>,
+    env_endpoint: Option<&str>,
+    env_api_url: Option<&str>,
+    file: Option<&str>,
+) -> String {
+    [cli, env_endpoint, env_api_url, file]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_ENDPOINT)
+        .to_string()
+}
+
+fn decode_seed_hex(hex: &str) -> Result<[u8; 32], String> {
+    let hex = hex.trim();
+    if hex.len() != 64 {
+        return Err(format!(
+            "secret key must be 64 hex chars (a 32-byte seed), got {}",
+            hex.len()
+        ));
+    }
+    let mut seed = [0u8; 32];
+    for (index, byte) in seed.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[index * 2..index * 2 + 2], 16)
+            .map_err(|_| "secret key is not valid hex".to_string())?;
+    }
+    Ok(seed)
+}
+
+pub fn resolve(cli_endpoint: Option<&str>) -> Result<Resolved, String> {
+    let path = config_path();
+    let file = load_config_file(&path)?;
+
+    let endpoint = pick_endpoint(
+        cli_endpoint,
+        std::env::var("TINYPLACE_ENDPOINT").ok().as_deref(),
+        std::env::var("TINYPLACE_API_URL").ok().as_deref(),
+        file.endpoint.as_deref(),
+    );
+
+    let seed = std::env::var("TINYPLACE_SECRET_KEY")
+        .ok()
+        .or(file.secret_key)
+        .map(|hex| decode_seed_hex(&hex))
+        .transpose()?;
+
+    Ok(Resolved {
+        endpoint,
+        seed,
+        config_path: path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_precedence_picks_first_non_empty() {
+        assert_eq!(
+            pick_endpoint(
+                Some("https://cli"),
+                Some("https://env"),
+                None,
+                Some("https://file")
+            ),
+            "https://cli"
+        );
+        assert_eq!(
+            pick_endpoint(
+                None,
+                Some("https://env"),
+                Some("https://api"),
+                Some("https://file")
+            ),
+            "https://env"
+        );
+        assert_eq!(
+            pick_endpoint(None, None, None, Some("https://file")),
+            "https://file"
+        );
+        assert_eq!(pick_endpoint(None, None, None, None), DEFAULT_ENDPOINT);
+    }
+
+    #[test]
+    fn endpoint_skips_blank_sources() {
+        assert_eq!(
+            pick_endpoint(Some("   "), Some("https://env"), None, None),
+            "https://env"
+        );
+    }
+
+    #[test]
+    fn decode_seed_hex_round_trips() {
+        let seed = decode_seed_hex(&"ab".repeat(32)).unwrap();
+        assert_eq!(seed, [0xab; 32]);
+    }
+
+    #[test]
+    fn decode_seed_hex_rejects_bad_input() {
+        assert!(decode_seed_hex("abcd").is_err());
+        assert!(decode_seed_hex(&"zz".repeat(32)).is_err());
+    }
+}

--- a/sdk/rust/src/cli/context.rs
+++ b/sdk/rust/src/cli/context.rs
@@ -1,0 +1,26 @@
+use std::sync::Arc;
+
+use tinyplace::{LocalSigner, Signer, TinyPlaceClient, TinyPlaceClientOptions};
+
+use crate::config::Resolved;
+
+/// The returned signer is `Some` only when a key is configured; read-only
+/// commands work without one.
+pub fn build(resolved: &Resolved) -> Result<(TinyPlaceClient, Option<Arc<dyn Signer>>), String> {
+    let signer: Option<Arc<dyn Signer>> = match resolved.seed.as_ref() {
+        Some(seed) => {
+            let local =
+                LocalSigner::from_seed(seed).map_err(|err| format!("invalid key: {err}"))?;
+            Some(Arc::new(local))
+        }
+        None => None,
+    };
+
+    let client = TinyPlaceClient::new(TinyPlaceClientOptions {
+        base_url: resolved.endpoint.clone(),
+        signer: signer.clone(),
+        ..Default::default()
+    });
+
+    Ok((client, signer))
+}

--- a/sdk/rust/src/cli/main.rs
+++ b/sdk/rust/src/cli/main.rs
@@ -1,0 +1,24 @@
+mod args;
+mod commands;
+mod config;
+mod context;
+mod output;
+
+use std::process::ExitCode;
+
+use clap::Parser;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> ExitCode {
+    let cli = args::Cli::parse();
+    match commands::run(cli).await {
+        Ok(stdout) => {
+            print!("{stdout}");
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprint!("{}", err.to_stderr_json());
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/sdk/rust/src/cli/output.rs
+++ b/sdk/rust/src/cli/output.rs
@@ -28,7 +28,7 @@ fn redact(value: Value) -> Value {
         Value::Object(map) => Value::Object(
             map.into_iter()
                 .map(|(key, val)| {
-                    if val.is_string() && is_sensitive_key(&key) {
+                    if is_sensitive_key(&key) {
                         (key, Value::String("[redacted]".into()))
                     } else {
                         (key, redact(val))
@@ -102,5 +102,12 @@ mod tests {
         assert!(out.contains("[redacted]"), "got: {out}");
         assert!(!out.contains("abcd"), "got: {out}");
         assert!(out.contains("https://x"), "got: {out}");
+    }
+
+    #[test]
+    fn redacts_sensitive_nested_values() {
+        let out = render(&json!({"secretKey": {"value": "abcd"}}), OutputFormat::Json);
+        assert!(out.contains("[redacted]"), "got: {out}");
+        assert!(!out.contains("abcd"), "got: {out}");
     }
 }

--- a/sdk/rust/src/cli/output.rs
+++ b/sdk/rust/src/cli/output.rs
@@ -1,0 +1,106 @@
+use serde_json::Value;
+
+use crate::args::OutputFormat;
+
+pub fn render(value: &Value, format: OutputFormat) -> String {
+    let value = redact(value.clone());
+    let mut out = match format {
+        OutputFormat::Json => {
+            serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+        }
+        OutputFormat::Md => to_markdown(&value, 0),
+    };
+    out.push('\n');
+    out
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let normalized: String = key
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .flat_map(char::to_lowercase)
+        .collect();
+    normalized.contains("secret") || normalized.contains("privatekey")
+}
+
+fn redact(value: Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(key, val)| {
+                    if val.is_string() && is_sensitive_key(&key) {
+                        (key, Value::String("[redacted]".into()))
+                    } else {
+                        (key, redact(val))
+                    }
+                })
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.into_iter().map(redact).collect()),
+        other => other,
+    }
+}
+
+fn scalar(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => Some("null".into()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::String(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+fn to_markdown(value: &Value, indent: usize) -> String {
+    let pad = "  ".repeat(indent);
+    match value {
+        Value::Object(map) => map
+            .iter()
+            .map(|(key, val)| match scalar(val) {
+                Some(text) => format!("{pad}- {key}: {text}"),
+                None => format!("{pad}- {key}:\n{}", to_markdown(val, indent + 1)),
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Value::Array(items) => items
+            .iter()
+            .map(|item| match scalar(item) {
+                Some(text) => format!("{pad}- {text}"),
+                None => format!("{pad}-\n{}", to_markdown(item, indent + 1)),
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        other => scalar(other).unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn json_is_pretty_with_trailing_newline() {
+        let out = render(&json!({"a": 1}), OutputFormat::Json);
+        assert_eq!(out, "{\n  \"a\": 1\n}\n");
+    }
+
+    #[test]
+    fn markdown_renders_nested_bullets() {
+        let out = render(&json!({"name": "x", "tags": ["a", "b"]}), OutputFormat::Md);
+        assert!(out.contains("- name: x"), "got: {out}");
+        assert!(out.contains("- tags:"), "got: {out}");
+        assert!(out.contains("  - a"), "got: {out}");
+    }
+
+    #[test]
+    fn redacts_sensitive_string_values() {
+        let out = render(
+            &json!({"secretKey": "abcd", "endpoint": "https://x"}),
+            OutputFormat::Json,
+        );
+        assert!(out.contains("[redacted]"), "got: {out}");
+        assert!(!out.contains("abcd"), "got: {out}");
+        assert!(out.contains("https://x"), "got: {out}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `tinyplace` CLI binary to the Rust SDK (a first slice of #56), built on the
existing `tinyplace` crate — `clap` for args, the SDK for everything else.

This cut ships a **read-only** command surface:

| Command | Purpose |
| --- | --- |
| `whoami` | agent id + public key (needs a configured key) |
| `version` | CLI version |
| `debug` / `doctor` | non-secret diagnostics (paths, endpoint, identity) |
| `lookup <handle>` | resolve a handle's identity (`registry.get`) |
| `groups [--q --tag --limit]` | browse public groups (`groups.list`) |
| `pricing {assets,pairs,networks,quote,gas}` | asset pricing |

Output is JSON by default (`--format md` for Markdown), errors are JSON on stderr
with a machine-readable `code` + exit 1, and config resolves from
`~/.tinyplace/config.json` with `$TINYPLACE_ENDPOINT` / `$TINYPLACE_API_URL`,
`$TINYPLACE_SECRET_KEY`, and `$TINYPLACE_CONFIG` overrides — matching the
TypeScript CLI's contract.

## Design notes

- **`clap` is optional, behind a `cli` feature** with a `required-features` bin, so
  library consumers don't pull it in. The Rust CI job now runs `--features cli` so
  the binary is still fully built / linted / tested.
- **Supporting SDK fix:** added `Serialize` to four response types that were
  `Deserialize`-only (`PriceAsset`/`PriceAssets`, `TradePairs`, `SupportedNetworks`,
  `GroupListResponse`) so the CLI can render them. This is consistent with their
  siblings (`GroupMetadata`, `PriceQuote`, `GasEstimate` already derive both).
- **Scope boundary:** per `sdk/rust/PORTING.md`, the Rust SDK omits Signal E2E
  encryption and on-chain Solana execution, so the TS CLI's encrypted-messaging and
  on-chain commands are intentionally **not** in this slice. Mutating/auth'd and
  workflow commands can follow incrementally.

## Testing

- Unit tests for config/env resolution and output formatting (JSON/Markdown +
  secret redaction).
- `wiremock`-backed command-dispatch tests (success, list response, and
  `404 → sdk_error` mapping) — the dispatch is split into `run_api_command(client, …)`
  so it runs against a mock with no live network.
- Verified locally: `cargo fmt --check`, `cargo clippy --all-targets --features cli
  -- -D warnings`, `cargo build --all-targets --features cli`, `cargo test
  --features cli` (all green), plus a manual smoke test of the binary against the
  live API.

Refs #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Rust CLI (`tinyplace`) to the Rust SDK with commands for identity, lookup, groups, and pricing.
  * Supports **JSON** and **Markdown** output formats, with automatic redaction of sensitive fields.
  * Endpoint and authentication settings can be configured via `~/.tinyplace/config.json` and environment variables (with CLI overrides).
* **Documentation**
  * Updated the Rust SDK README with CLI setup, run examples, output behavior, and command reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->