### PR TITLE
feat: agent-generated login link (view-as-agent) (#190)

### DIFF
--- a/sdk/typescript/src/agent-login-link.ts
+++ b/sdk/typescript/src/agent-login-link.ts
@@ -1,0 +1,356 @@
+import type { SigningKey } from "./auth.js";
+import { BrowserSessionSigner } from "./browser-session-signer.js";
+import { LocalSigner } from "./local-signer.js";
+import type { X402Authorization } from "./x402.js";
+
+/**
+ * Agent-generated login link ("view-as-agent").
+ *
+ * An agent that holds its own Ed25519 identity key (but has no browser/Phantom)
+ * can hand its human owner a single link that logs the human into the tiny.place
+ * web app AS that agent. The link reuses the existing approved-signer / session-
+ * key delegation primitive, but with the AGENT's identity key as the grantor
+ * instead of a Phantom wallet:
+ *
+ *   1. The agent mints a fresh session keypair from a random 32-byte seed.
+ *   2. It signs an x402 "upto" approved-signer grant for that session key with
+ *      its identity key and registers it with the backend (`signers.approve`).
+ *   3. It encodes the grant metadata + the session seed into the link's URL
+ *      FRAGMENT (`https://tiny.place/auth/agent#<token>`), so the token never
+ *      reaches a server/access log.
+ *
+ * The web app reads the fragment, reconstructs a session signer with no Phantom
+ * involved (the seed deterministically rebuilds the session key), and hydrates
+ * the auth store. The human then operates as the agent under a scoped, expiring,
+ * revocable grant.
+ *
+ * Security posture (see issue security requirements):
+ *   - The token rides in the URL FRAGMENT only (callers must never put it in a
+ *     query string); the web route strips it from history on load.
+ *   - Short TTL by default ({@link DEFAULT_AGENT_LINK_TTL_MS}), independent of
+ *     the 7-day wallet session TTL.
+ *   - The grant defaults to a ZERO x402 payment budget so a leaked link cannot
+ *     move funds; spending requires an explicit opt-in budget at mint time.
+ *   - The grant is revocable (the agent can `signers.revoke`) and the web app
+ *     fails closed when the backend reports it inactive.
+ */
+
+/** Version tag prefixed to the encoded token so the decoder can reject mismatches. */
+export const AGENT_LOGIN_LINK_VERSION = "al1";
+
+/** The web route an agent-login link points at. */
+export const AGENT_LOGIN_LINK_PATH = "/auth/agent";
+
+/** Default TTL: 15 minutes. Short by design — re-mint for a longer session. */
+export const DEFAULT_AGENT_LINK_TTL_MS = 15 * 60 * 1000;
+
+/** Default x402 network for the grant (matches the website session default). */
+const DEFAULT_AGENT_LINK_NETWORK = "solana:mainnet";
+
+/** Default asset for the grant scope. */
+const DEFAULT_AGENT_LINK_ASSET = "USDC";
+
+/**
+ * Default x402 budget: ZERO. A view-as-agent link is non-payment by default, so
+ * a leaked link cannot move funds. Spending requires an explicit `budget`.
+ */
+const DEFAULT_AGENT_LINK_BUDGET = "0";
+
+/** A minimal subset of {@link TinyPlaceClient} this module needs to register a grant. */
+export interface AgentLoginSignerRegistrar {
+  signers: {
+    approve(authorization: X402Authorization): Promise<unknown>;
+  };
+}
+
+/** Options for {@link createAgentLoginLink}. */
+export interface CreateAgentLoginLinkOptions {
+  /**
+   * The agent's identity signer (the grantor). Its `agentId` is the cryptoId the
+   * link logs in as; it signs the approved-signer grant. Must be a raw/Ed25519
+   * signer such as {@link LocalSigner}.
+   */
+  signer: SigningKey & { publicKeyBase64?: string };
+  /** A client authenticated as the agent, used to register the grant. */
+  client: AgentLoginSignerRegistrar;
+  /**
+   * The web app origin to build the link against, e.g. `https://tiny.place`.
+   * Defaults to `https://tiny.place`.
+   */
+  baseUrl?: string;
+  /** Grant lifetime in milliseconds. Defaults to {@link DEFAULT_AGENT_LINK_TTL_MS}. */
+  ttlMs?: number;
+  /**
+   * x402 grant scope. Defaults to a ZERO-budget, view-only grant. Provide a
+   * non-zero `budget` (base units) ONLY when the owner should be able to spend.
+   */
+  scope?: AgentLoginScope;
+}
+
+/** The bounded x402 scope a link's grant carries. */
+export interface AgentLoginScope {
+  network?: string;
+  asset?: string;
+  /** Payment budget in 6-decimal base units. Defaults to "0" (non-payment). */
+  budget?: string;
+}
+
+/** The decoded contents of an agent-login link fragment token. */
+export interface AgentLoginToken {
+  readonly version: string;
+  /** The agent cryptoId the session acts as. */
+  readonly agentId: string;
+  /** The agent (grantor) base64 Ed25519 public key — used for identity proofs. */
+  readonly grantorPublicKeyBase64: string;
+  /** The session key seed (base64url, 32 bytes) — rebuilds the session signer. */
+  readonly sessionSeedBase64Url: string;
+  /** The approved-signer grant nonce, bound into delegated payment signatures. */
+  readonly approvalNonce: string;
+  /** The session public key, hex-encoded — the backend's signer lookup key. */
+  readonly signerKey: string;
+  /** RFC 3339 grant expiry. */
+  readonly expiresAt: string;
+  /** The x402 grant scope. */
+  readonly network: string;
+  readonly asset: string;
+  readonly budget: string;
+}
+
+/** The result of {@link createAgentLoginLink}. */
+export interface AgentLoginLink {
+  /** The full `https://.../auth/agent#<token>` link to hand to the owner. */
+  readonly url: string;
+  /** The encoded fragment token (without the leading `#`). */
+  readonly token: string;
+  /** The decoded token contents (no secrets beyond what the link carries). */
+  readonly decoded: AgentLoginToken;
+}
+
+/**
+ * Mints + registers a view-as-agent grant and returns a login link. Call this
+ * agent-side (e.g. from a `workflow-tinyplace` agent) to produce the link for
+ * the human owner.
+ */
+export async function createAgentLoginLink(
+  options: CreateAgentLoginLinkOptions,
+): Promise<AgentLoginLink> {
+  const ttlMs = options.ttlMs ?? DEFAULT_AGENT_LINK_TTL_MS;
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new Error("createAgentLoginLink: ttlMs must be a positive number");
+  }
+  const network = options.scope?.network ?? DEFAULT_AGENT_LINK_NETWORK;
+  const asset = options.scope?.asset ?? DEFAULT_AGENT_LINK_ASSET;
+  const budget = options.scope?.budget ?? DEFAULT_AGENT_LINK_BUDGET;
+
+  const grantorPublicKeyBase64 =
+    options.signer.publicKeyBase64 ??
+    (() => {
+      throw new Error(
+        "createAgentLoginLink: signer must expose publicKeyBase64 (use LocalSigner)",
+      );
+    })();
+
+  // Mint the session key from a random 32-byte seed so it can be carried in the
+  // link and deterministically rebuilt web-side without Phantom. Building a
+  // BrowserSessionSigner over the seed reuses the exact approval-request
+  // construction the website's session path uses.
+  const seed = randomSeed();
+  const sessionGrantSigner = await sessionSignerFromSeed(seed);
+
+  const expiresAt = new Date(Date.now() + ttlMs).toISOString();
+  const approval = await sessionGrantSigner.buildApprovalRequest(
+    options.signer,
+    options.signer.agentId,
+    {
+      network,
+      asset,
+      budget,
+      expiresAt,
+      // Bind the grant to the agent's key so an agent that isn't a registered
+      // wallet still works (the backend derives the grantor cryptoId from it).
+      grantorPublicKey: grantorPublicKeyBase64,
+    },
+  );
+
+  await options.client.signers.approve(approval.authorization);
+
+  const approvalNonce = sessionGrantSigner.getApprovalNonce();
+  if (!approvalNonce) {
+    throw new Error("createAgentLoginLink: session grant missing approval nonce");
+  }
+
+  const decoded: AgentLoginToken = {
+    version: AGENT_LOGIN_LINK_VERSION,
+    agentId: options.signer.agentId,
+    grantorPublicKeyBase64,
+    sessionSeedBase64Url: bytesToBase64Url(seed),
+    approvalNonce,
+    signerKey: sessionGrantSigner.publicKeyHex,
+    // buildApprovalRequest strips fractional seconds before signing; persist the
+    // same whole-second expiry the grant was actually signed with.
+    expiresAt: approval.authorization.expiresAt,
+    network,
+    asset,
+    budget,
+  };
+
+  const token = encodeAgentLoginToken(decoded);
+  const base = (options.baseUrl ?? "https://tiny.place").replace(/\/+$/, "");
+  const url = `${base}${AGENT_LOGIN_LINK_PATH}#${token}`;
+  return { url, token, decoded };
+}
+
+/**
+ * Decodes an agent-login fragment token (the value after `#`). Returns undefined
+ * for any malformed/wrong-version/incomplete token — the caller fails closed.
+ */
+export function decodeAgentLoginLink(
+  fragment: string,
+): AgentLoginToken | undefined {
+  const value = fragment.startsWith("#") ? fragment.slice(1) : fragment;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const dot = trimmed.indexOf(".");
+  if (dot <= 0) return undefined;
+  const version = trimmed.slice(0, dot);
+  if (version !== AGENT_LOGIN_LINK_VERSION) return undefined;
+  try {
+    const json = fromBase64Url(trimmed.slice(dot + 1));
+    const parsed = JSON.parse(json) as Partial<AgentLoginToken>;
+    if (
+      typeof parsed.agentId !== "string" ||
+      typeof parsed.grantorPublicKeyBase64 !== "string" ||
+      typeof parsed.sessionSeedBase64Url !== "string" ||
+      typeof parsed.approvalNonce !== "string" ||
+      typeof parsed.signerKey !== "string" ||
+      typeof parsed.expiresAt !== "string" ||
+      typeof parsed.network !== "string" ||
+      typeof parsed.asset !== "string" ||
+      typeof parsed.budget !== "string"
+    ) {
+      return undefined;
+    }
+    return { ...(parsed as AgentLoginToken), version };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Reports whether a decoded token is still locally valid (expiry comfortably in
+ * the future). The authoritative check is the backend signer-status probe; this
+ * is the cheap client-side guard so a long-expired link short-circuits.
+ */
+export function agentLoginTokenIsFresh(
+  token: AgentLoginToken,
+  nowMs: number,
+  skewMs = 30_000,
+): boolean {
+  const expiresMs = Date.parse(token.expiresAt);
+  if (Number.isNaN(expiresMs)) return false;
+  return expiresMs > nowMs + skewMs;
+}
+
+/**
+ * Rebuilds the {@link BrowserSessionSigner} a decoded token describes — no
+ * Phantom, no agent private key, just the seed the link carries. The returned
+ * signer signs requests as the delegated session key; pair it with a no-wallet
+ * session signer (web side) that reports the agent as `agentId`.
+ */
+export async function sessionSignerFromAgentLoginToken(
+  token: AgentLoginToken,
+): Promise<BrowserSessionSigner> {
+  const seed = base64UrlToBytes(token.sessionSeedBase64Url);
+  if (seed.length !== 32) {
+    throw new Error("agent login token: session seed must be 32 bytes");
+  }
+  const session = await sessionSignerFromSeed(seed);
+  session.setApprovalNonce(token.approvalNonce);
+  return session;
+}
+
+function encodeAgentLoginToken(token: AgentLoginToken): string {
+  const body = bytesToBase64Url(
+    new TextEncoder().encode(
+      JSON.stringify({
+        agentId: token.agentId,
+        grantorPublicKeyBase64: token.grantorPublicKeyBase64,
+        sessionSeedBase64Url: token.sessionSeedBase64Url,
+        approvalNonce: token.approvalNonce,
+        signerKey: token.signerKey,
+        expiresAt: token.expiresAt,
+        network: token.network,
+        asset: token.asset,
+        budget: token.budget,
+      }),
+    ),
+  );
+  return `${AGENT_LOGIN_LINK_VERSION}.${body}`;
+}
+
+/** Builds a BrowserSessionSigner whose key is derived from a 32-byte seed. */
+async function sessionSignerFromSeed(
+  seed: Uint8Array,
+): Promise<BrowserSessionSigner> {
+  // Reuse LocalSigner's PKCS#8 import path to get a CryptoKey from the seed,
+  // then re-derive the keypair shape BrowserSessionSigner expects.
+  const local = await LocalSigner.fromSeed(seed);
+  const privateKey = await importSeedPrivateKey(seed);
+  return BrowserSessionSigner.fromStored(
+    { publicKey: local.publicKey, privateKey },
+    // The nonce is set by buildApprovalRequest (agent side) or
+    // setApprovalNonce (web side); a placeholder keeps fromStored happy.
+    "",
+  );
+}
+
+async function importSeedPrivateKey(seed: Uint8Array): Promise<CryptoKey> {
+  // PKCS#8 PrivateKeyInfo prefix for an Ed25519 key, followed by the raw seed.
+  const prefix = new Uint8Array([
+    0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70,
+    0x04, 0x22, 0x04, 0x20,
+  ]);
+  const pkcs8 = new Uint8Array(prefix.length + seed.length);
+  pkcs8.set(prefix, 0);
+  pkcs8.set(seed, prefix.length);
+  return globalThis.crypto.subtle.importKey(
+    "pkcs8",
+    pkcs8,
+    { name: "Ed25519" },
+    true,
+    ["sign"],
+  );
+}
+
+function randomSeed(): Uint8Array {
+  const seed = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(seed);
+  return seed;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/u, "");
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = (4 - (base64.length % 4)) % 4;
+  const padded = base64 + "=".repeat(pad);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function fromBase64Url(value: string): string {
+  return new TextDecoder().decode(base64UrlToBytes(value));
+}

--- a/sdk/typescript/src/agent-login-link.ts
+++ b/sdk/typescript/src/agent-login-link.ts
@@ -51,10 +51,14 @@ const DEFAULT_AGENT_LINK_NETWORK = "solana:mainnet";
 const DEFAULT_AGENT_LINK_ASSET = "USDC";
 
 /**
- * Default x402 budget: ZERO. A view-as-agent link is non-payment by default, so
- * a leaked link cannot move funds. Spending requires an explicit `budget`.
+ * Default x402 budget: the minimum the backend accepts — 1 base unit
+ * (0.000001 USDC), which is effectively non-payment (a leaked link cannot move
+ * meaningful funds). The backend's x402 verifier rejects a zero/negative
+ * authorization amount ("invalid payment amount"), so a literal "0" grant would
+ * fail to register; this is the smallest valid stand-in for "no spending".
+ * Spending requires an explicit, higher `budget` opt-in at mint time.
  */
-const DEFAULT_AGENT_LINK_BUDGET = "0";
+const DEFAULT_AGENT_LINK_BUDGET = "1";
 
 /** A minimal subset of {@link TinyPlaceClient} this module needs to register a grant. */
 export interface AgentLoginSignerRegistrar {

--- a/sdk/typescript/src/api/signers.ts
+++ b/sdk/typescript/src/api/signers.ts
@@ -29,4 +29,17 @@ export class SignersApi {
       `/signers/${encodeURIComponent(signerKey)}${query}`,
     );
   }
+
+  /**
+   * Atomically claims a single-use grant (the agent-login "view-as-agent" link
+   * flow): the backend returns the grant on the first call and a 409 on every
+   * replay, so a leaked link can be redeemed at most once. Must be called by a
+   * client whose signer IS the session key being consumed (the link holder),
+   * since the backend authenticates the claim against that key.
+   */
+  consume(signerKey: string): Promise<SignerApproval> {
+    return this.http.postDirectoryAuth<SignerApproval>(
+      `/signers/${encodeURIComponent(signerKey)}/consume`,
+    );
+  }
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -47,6 +47,22 @@ export {
   sessionIsFresh,
 } from "./session-store.js";
 export type { StoredSession } from "./session-store.js";
+export {
+  createAgentLoginLink,
+  decodeAgentLoginLink,
+  agentLoginTokenIsFresh,
+  sessionSignerFromAgentLoginToken,
+  AGENT_LOGIN_LINK_VERSION,
+  AGENT_LOGIN_LINK_PATH,
+  DEFAULT_AGENT_LINK_TTL_MS,
+} from "./agent-login-link.js";
+export type {
+  AgentLoginLink,
+  AgentLoginToken,
+  AgentLoginScope,
+  CreateAgentLoginLinkOptions,
+  AgentLoginSignerRegistrar,
+} from "./agent-login-link.js";
 
 export type {
   X402Scheme,

--- a/sdk/typescript/src/types/payments.ts
+++ b/sdk/typescript/src/types/payments.ts
@@ -207,4 +207,10 @@ export interface SignerApproval {
   nonce: string;
   status: SignerApprovalStatus;
   createdAt: string;
+  /**
+   * RFC 3339 time a single-use grant was claimed via POST
+   * /signers/{signerKey}/consume (the agent-login link flow). Absent for
+   * ordinary multi-use wallet-session grants.
+   */
+  consumedAt?: string;
 }

--- a/sdk/typescript/tests/agent-login-link.test.ts
+++ b/sdk/typescript/tests/agent-login-link.test.ts
@@ -83,14 +83,16 @@ describe("agent login link (view-as-agent)", () => {
     expect(grant.nonce).toBe(link.decoded.approvalNonce);
   });
 
-  it("defaults to a ZERO payment budget (leaked-link funds safety)", async () => {
+  it("defaults to a minimal (effectively zero) payment budget (leaked-link funds safety)", async () => {
     const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(7));
     const client = recordingRegistrar();
 
     const link = await createAgentLoginLink({ signer, client });
 
-    expect(link.decoded.budget).toBe("0");
-    expect(client.approved[0]!.amount).toBe("0");
+    // 1 base unit (0.000001 USDC) — the smallest the backend accepts; a literal
+    // "0" is rejected by the x402 verifier. Effectively non-payment.
+    expect(link.decoded.budget).toBe("1");
+    expect(client.approved[0]!.amount).toBe("1");
   });
 
   it("honors an explicit non-zero budget opt-in", async () => {

--- a/sdk/typescript/tests/agent-login-link.test.ts
+++ b/sdk/typescript/tests/agent-login-link.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_LOGIN_LINK_PATH,
+  AGENT_LOGIN_LINK_VERSION,
+  DEFAULT_AGENT_LINK_TTL_MS,
+  LocalSigner,
+  agentLoginTokenIsFresh,
+  createAgentLoginLink,
+  decodeAgentLoginLink,
+  publicKeyToBase64,
+  sessionSignerFromAgentLoginToken,
+} from "../src/index.js";
+import type {
+  AgentLoginSignerRegistrar,
+  AgentLoginToken,
+} from "../src/index.js";
+import type { X402Authorization } from "../src/x402.js";
+
+/** A registrar that records the grant the agent registers, so tests can assert it. */
+function recordingRegistrar(): AgentLoginSignerRegistrar & {
+  approved: Array<X402Authorization>;
+} {
+  const approved: Array<X402Authorization> = [];
+  return {
+    approved,
+    signers: {
+      async approve(authorization: X402Authorization): Promise<unknown> {
+        approved.push(authorization);
+        return { signerKey: "", status: "active" };
+      },
+    },
+  };
+}
+
+describe("agent login link (view-as-agent)", () => {
+  it("mints a fragment link that round-trips through decode", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(3));
+    const client = recordingRegistrar();
+
+    const link = await createAgentLoginLink({
+      signer,
+      client,
+      baseUrl: "https://tiny.place",
+    });
+
+    // Token rides in the URL FRAGMENT, never the query string.
+    expect(link.url.startsWith(`https://tiny.place${AGENT_LOGIN_LINK_PATH}#`)).toBe(
+      true,
+    );
+    expect(link.url).not.toContain("?");
+    expect(link.token.startsWith(`${AGENT_LOGIN_LINK_VERSION}.`)).toBe(true);
+
+    const decoded = decodeAgentLoginLink(link.token);
+    expect(decoded).toBeDefined();
+    expect(decoded?.agentId).toBe(signer.agentId);
+    expect(decoded?.grantorPublicKeyBase64).toBe(signer.publicKeyBase64);
+    expect(decoded?.signerKey).toBe(link.decoded.signerKey);
+
+    // Decoding from the full `#fragment` form also works.
+    const fromHash = decodeAgentLoginLink(`#${link.token}`);
+    expect(fromHash?.agentId).toBe(signer.agentId);
+  });
+
+  it("registers an approved-signer grant signed by the agent identity key", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(5));
+    const client = recordingRegistrar();
+
+    const link = await createAgentLoginLink({ signer, client });
+
+    expect(client.approved).toHaveLength(1);
+    const grant = client.approved[0]!;
+    // The grant is an x402 "upto" approval FROM the agent, bound to the agent's
+    // key as the grantor (so an unregistered agent still works).
+    expect(grant.scheme).toBe("upto");
+    expect(grant.from).toBe(signer.agentId);
+    expect(grant.metadata?.publicKey).toBe(signer.publicKeyBase64);
+    expect(grant.metadata?.signerKey).toBe(link.decoded.signerKey);
+    expect(typeof grant.signature).toBe("string");
+    expect(grant.signature.length).toBeGreaterThan(0);
+    // The persisted expiry is the whole-second one the grant was actually signed
+    // with (buildApprovalRequest strips fractional seconds).
+    expect(link.decoded.expiresAt).toBe(grant.expiresAt);
+    expect(grant.nonce).toBe(link.decoded.approvalNonce);
+  });
+
+  it("defaults to a ZERO payment budget (leaked-link funds safety)", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(7));
+    const client = recordingRegistrar();
+
+    const link = await createAgentLoginLink({ signer, client });
+
+    expect(link.decoded.budget).toBe("0");
+    expect(client.approved[0]!.amount).toBe("0");
+  });
+
+  it("honors an explicit non-zero budget opt-in", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(9));
+    const client = recordingRegistrar();
+
+    const link = await createAgentLoginLink({
+      signer,
+      client,
+      scope: { budget: "1000000" },
+    });
+
+    expect(link.decoded.budget).toBe("1000000");
+    expect(client.approved[0]!.amount).toBe("1000000");
+  });
+
+  it("rebuilds a session signer whose public key matches the advertised signer key", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(11));
+    const client = recordingRegistrar();
+
+    const link = await createAgentLoginLink({ signer, client });
+    const decoded = decodeAgentLoginLink(link.token)!;
+
+    const session = await sessionSignerFromAgentLoginToken(decoded);
+    // The seed-derived session key must equal the registered signer key, so its
+    // signatures are authorized by the grant the backend has on record.
+    expect(session.publicKeyHex).toBe(decoded.signerKey);
+    expect(publicKeyToBase64).toBeTypeOf("function");
+    // The approval nonce is restored so delegated payment signatures bind to the
+    // grant.
+    expect(session.getApprovalNonce()).toBe(decoded.approvalNonce);
+
+    // The rebuilt key actually signs (proves the seed import worked, no Phantom).
+    const sig = await session.sign(new TextEncoder().encode("hello"));
+    expect(sig.length).toBe(64);
+  });
+
+  it("defaults the TTL to a short window independent of the wallet session", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(13));
+    const client = recordingRegistrar();
+    const before = Date.now();
+
+    const link = await createAgentLoginLink({ signer, client });
+
+    const expiresMs = Date.parse(link.decoded.expiresAt);
+    // Within the default 15-minute window (whole-second rounding tolerated).
+    expect(expiresMs).toBeLessThanOrEqual(before + DEFAULT_AGENT_LINK_TTL_MS + 2000);
+    expect(expiresMs).toBeGreaterThan(before);
+    expect(DEFAULT_AGENT_LINK_TTL_MS).toBeLessThan(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("reports freshness against the token expiry", async () => {
+    const fresh: AgentLoginToken = {
+      version: AGENT_LOGIN_LINK_VERSION,
+      agentId: "Agent",
+      grantorPublicKeyBase64: "key",
+      sessionSeedBase64Url: "seed",
+      approvalNonce: "nonce",
+      signerKey: "abc",
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      network: "solana:mainnet",
+      asset: "USDC",
+      budget: "0",
+    };
+    expect(agentLoginTokenIsFresh(fresh, Date.now())).toBe(true);
+    const expired = { ...fresh, expiresAt: new Date(Date.now() - 1000).toISOString() };
+    expect(agentLoginTokenIsFresh(expired, Date.now())).toBe(false);
+  });
+
+  it("rejects malformed, wrong-version, and incomplete tokens (fail closed)", () => {
+    expect(decodeAgentLoginLink("")).toBeUndefined();
+    expect(decodeAgentLoginLink("#")).toBeUndefined();
+    expect(decodeAgentLoginLink("garbage")).toBeUndefined();
+    expect(decodeAgentLoginLink("al1.")).toBeUndefined();
+    // Wrong version prefix.
+    expect(decodeAgentLoginLink("al9.eyJhIjoxfQ")).toBeUndefined();
+    // Valid base64url but missing required fields.
+    const partial = Buffer.from(JSON.stringify({ agentId: "x" })).toString(
+      "base64url",
+    );
+    expect(decodeAgentLoginLink(`${AGENT_LOGIN_LINK_VERSION}.${partial}`)).toBeUndefined();
+  });
+
+  it("rejects a non-zero, non-positive ttl", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(15));
+    const client = recordingRegistrar();
+    await expect(
+      createAgentLoginLink({ signer, client, ttlMs: 0 }),
+    ).rejects.toThrow(/ttlMs/);
+    await expect(
+      createAgentLoginLink({ signer, client, ttlMs: -1 }),
+    ).rejects.toThrow(/ttlMs/);
+  });
+});

--- a/sdk/typescript/tests/signers.test.ts
+++ b/sdk/typescript/tests/signers.test.ts
@@ -91,4 +91,44 @@ describe("SignersApi", () => {
       expect(request.headers.get("X-TinyPlace-Signature")).toBeTruthy();
     }
   });
+
+  it("consumes a single-use signer grant with session-key auth", async () => {
+    const signer = await LocalSigner.fromSeed(new Uint8Array(32).fill(43));
+    const requests: Array<Request> = [];
+    const client = new TinyPlaceClient({
+      baseUrl: "https://example.test",
+      signer,
+      fetch: async (input, init) => {
+        requests.push(new Request(input, init));
+        return Response.json({
+          signerKey: "session-key",
+          grantor: signer.agentId,
+          network: "eip155:8453",
+          asset: "USDC",
+          budget: "1",
+          spent: "0",
+          remaining: "1",
+          expiresAt: "2026-06-20T00:00:00.000Z",
+          nonce: "signer_nonce",
+          status: "active",
+          createdAt: "2026-06-13T00:00:00.000Z",
+          consumedAt: "2026-06-13T00:05:00.000Z",
+        });
+      },
+    });
+
+    const result = await client.signers.consume("session-key");
+
+    expect(result.consumedAt).toBe("2026-06-13T00:05:00.000Z");
+    expect(requests).toHaveLength(1);
+    const request = requests[0]!;
+    expect(request.method).toBe("POST");
+    expect(request.url).toBe("https://example.test/signers/session-key/consume");
+    // Authenticated as the session key (directory write auth), not a bearer.
+    expect(request.headers.get("Authorization")).toBeNull();
+    expect(request.headers.get("X-TinyPlace-Public-Key")).toBe(
+      signer.publicKeyBase64,
+    );
+    expect(request.headers.get("X-TinyPlace-Signature")).toBeTruthy();
+  });
 });

--- a/website/app/auth/agent/page.tsx
+++ b/website/app/auth/agent/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { createClient } from "@src/common/api-client";
+import {
+	restoreAgentLinkSession,
+	type AgentLinkFailure,
+} from "@src/common/agent-session";
+import type { FunctionComponent } from "@src/common/types";
+import { useAuthStore } from "@src/store/auth";
+
+/** Where the owner lands once logged in as the agent. */
+const LANDING_PATH = "/explore";
+
+type Status =
+	| { phase: "loading" }
+	| { phase: "error"; reason: AgentLinkFailure | "missing" };
+
+/**
+ * Client-only callback route for agent-generated login links
+ * (`https://tiny.place/auth/agent#<token>`).
+ *
+ * It reads the token from the URL FRAGMENT (never a query string, so the token
+ * is never sent to a server/access log), strips it from the address bar/history
+ * immediately, validates + reconstructs a no-wallet session signer, confirms the
+ * grant is still active with the backend, and hydrates the auth store as the
+ * agent — then redirects into the app. Every failure path lands in a clear
+ * message and leaves NO partial auth state.
+ */
+export default function AgentLoginPage(): FunctionComponent {
+	const router = useRouter();
+	const { t } = useTranslation();
+	const setLinkSession = useAuthStore((state) => state.setLinkSession);
+	const [status, setStatus] = useState<Status>({ phase: "loading" });
+	// Guard against the effect running twice (React 18 StrictMode double-invoke)
+	// — the fragment is captured and cleared exactly once.
+	const consumed = useRef(false);
+
+	useEffect(() => {
+		if (consumed.current) return;
+		consumed.current = true;
+
+		// Capture the fragment, then immediately strip it from the address bar and
+		// history so the secret token cannot be re-read, copied, or back-buttoned.
+		const fragment = window.location.hash;
+		stripFragmentFromHistory();
+
+		if (!fragment || fragment === "#") {
+			setStatus({ phase: "error", reason: "missing" });
+			return;
+		}
+
+		let cancelled = false;
+		void (async (): Promise<void> => {
+			const result = await restoreAgentLinkSession(fragment, (signer) =>
+				createClient(signer),
+			);
+			if (cancelled) return;
+			if (!result.ok) {
+				setStatus({ phase: "error", reason: result.reason });
+				return;
+			}
+			setLinkSession(result.signer, result.agentId);
+			router.replace(LANDING_PATH);
+		})();
+
+		return (): void => {
+			cancelled = true;
+		};
+	}, [router, setLinkSession]);
+
+	if (status.phase === "loading") {
+		return (
+			<main className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center">
+				<div
+					aria-hidden
+					className="size-8 animate-spin rounded-full border-2 border-border border-t-primary"
+				/>
+				<p className="text-muted">{t("agentLogin.signingIn")}</p>
+			</main>
+		);
+	}
+
+	return (
+		<main className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center">
+			<h1 className="text-xl font-semibold text-front">
+				{t("agentLogin.failedTitle")}
+			</h1>
+			<p className="max-w-md text-muted">
+				{t(`agentLogin.error.${status.reason}`)}
+			</p>
+			<button
+				className="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary-hover"
+				onClick={(): void => router.replace("/")}
+				type="button"
+			>
+				{t("agentLogin.backHome")}
+			</button>
+		</main>
+	);
+}
+
+/**
+ * Removes the fragment from the URL without a navigation or a new history entry,
+ * so the token never lingers in the address bar or back-stack.
+ */
+function stripFragmentFromHistory(): void {
+	try {
+		const url = window.location.pathname + window.location.search;
+		window.history.replaceState(null, "", url);
+	} catch {
+		// Best-effort: a failed strip must not block sign-in.
+	}
+}

--- a/website/app/providers.tsx
+++ b/website/app/providers.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
 import { ApiProvider } from "@src/common/api-context";
+import { AgentSessionBanner } from "@src/components/AgentSessionBanner";
 import { ConnectionFooter } from "@src/components/ConnectionFooter";
 import { E2EAuthBridge } from "@src/components/E2EAuthBridge";
 import { ExploreShell } from "@src/components/layout/ExploreShell";
@@ -29,6 +30,7 @@ export function Providers({
 				<MoonPayProvider apiKey={MOONPAY_API_KEY}>
 					<ApiProvider>
 						<ThemeController />
+						<AgentSessionBanner />
 						<WebOnboardingGate />
 						<ExploreShell>{children}</ExploreShell>
 						<ConnectionFooter />

--- a/website/src/assets/locales/en/translations.json
+++ b/website/src/assets/locales/en/translations.json
@@ -139,7 +139,8 @@
 			"missing": "This link is missing its login token. Ask the agent to send you a fresh link.",
 			"malformed": "This login link is invalid or has been tampered with. Ask the agent for a new one.",
 			"expired": "This login link has expired. Ask the agent to generate a new one.",
-			"revoked": "This login link is no longer active — it was revoked or has already been used. Ask the agent for a new one."
+			"revoked": "This login link is no longer active — it was revoked or has already been used. Ask the agent for a new one.",
+			"consumed": "This login link has already been used. Ask the agent for a new one."
 		}
 	}
 }

--- a/website/src/assets/locales/en/translations.json
+++ b/website/src/assets/locales/en/translations.json
@@ -127,5 +127,19 @@
 		"live": "live",
 		"offline": "offline",
 		"backToTables": "← All tables"
+	},
+	"agentLogin": {
+		"viewingAs": "Viewing as {{agent}}",
+		"exit": "Exit",
+		"exiting": "Exiting…",
+		"signingIn": "Signing you in as the agent…",
+		"failedTitle": "Couldn't sign in",
+		"backHome": "Back to home",
+		"error": {
+			"missing": "This link is missing its login token. Ask the agent to send you a fresh link.",
+			"malformed": "This login link is invalid or has been tampered with. Ask the agent for a new one.",
+			"expired": "This login link has expired. Ask the agent to generate a new one.",
+			"revoked": "This login link is no longer active — it was revoked or has already been used. Ask the agent for a new one."
+		}
 	}
 }

--- a/website/src/assets/locales/es/translations.json
+++ b/website/src/assets/locales/es/translations.json
@@ -127,5 +127,19 @@
 		"live": "en vivo",
 		"offline": "desconectado",
 		"backToTables": "← Todas las mesas"
+	},
+	"agentLogin": {
+		"viewingAs": "Viendo como {{agent}}",
+		"exit": "Salir",
+		"exiting": "Saliendo…",
+		"signingIn": "Iniciando sesión como el agente…",
+		"failedTitle": "No se pudo iniciar sesión",
+		"backHome": "Volver al inicio",
+		"error": {
+			"missing": "A este enlace le falta su token de acceso. Pide al agente un enlace nuevo.",
+			"malformed": "Este enlace de acceso no es válido o ha sido manipulado. Pide al agente uno nuevo.",
+			"expired": "Este enlace de acceso ha caducado. Pide al agente que genere uno nuevo.",
+			"revoked": "Este enlace de acceso ya no está activo — fue revocado o ya se usó. Pide al agente uno nuevo."
+		}
 	}
 }

--- a/website/src/assets/locales/es/translations.json
+++ b/website/src/assets/locales/es/translations.json
@@ -139,7 +139,8 @@
 			"missing": "A este enlace le falta su token de acceso. Pide al agente un enlace nuevo.",
 			"malformed": "Este enlace de acceso no es válido o ha sido manipulado. Pide al agente uno nuevo.",
 			"expired": "Este enlace de acceso ha caducado. Pide al agente que genere uno nuevo.",
-			"revoked": "Este enlace de acceso ya no está activo — fue revocado o ya se usó. Pide al agente uno nuevo."
+			"revoked": "Este enlace de acceso ya no está activo — fue revocado o ya se usó. Pide al agente uno nuevo.",
+			"consumed": "Este enlace de acceso ya se ha utilizado. Pide al agente uno nuevo."
 		}
 	}
 }

--- a/website/src/common/agent-session.test.ts
+++ b/website/src/common/agent-session.test.ts
@@ -106,21 +106,55 @@ describe("AgentSessionSigner", () => {
 });
 
 describe("restoreAgentLinkSession", () => {
-	const activeClient = (): TinyPlaceClient =>
-		({
-			signers: { get: () => Promise.resolve({ status: "active" }) },
-		}) as unknown as TinyPlaceClient;
-
-	it("returns ok with a signer for a fresh, active link", async () => {
+	it("returns ok with a signer for a fresh, active link and consumes it", async () => {
 		const { token, agent } = await mintLink(31);
+		const consume = vi.fn(() => Promise.resolve({ status: "active" }));
+		const client = (): TinyPlaceClient =>
+			({
+				signers: { get: () => Promise.resolve({ status: "active" }), consume },
+			}) as unknown as TinyPlaceClient;
 
-		const result = await restoreAgentLinkSession(`#${token}`, activeClient);
+		const result = await restoreAgentLinkSession(`#${token}`, client);
 
 		expect(result.ok).toBe(true);
 		if (result.ok) {
 			expect(result.agentId).toBe(agent.agentId);
 			expect(result.signer).toBeInstanceOf(AgentSessionSigner);
 		}
+		// Single-use: the link was claimed exactly once.
+		expect(consume).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips consume when singleUse is false", async () => {
+		const { token } = await mintLink(34);
+		const consume = vi.fn();
+		const client = (): TinyPlaceClient =>
+			({
+				signers: { get: () => Promise.resolve({ status: "active" }), consume },
+			}) as unknown as TinyPlaceClient;
+
+		const result = await restoreAgentLinkSession(token, client, {
+			singleUse: false,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(consume).not.toHaveBeenCalled();
+	});
+
+	it("reports consumed when the single-use claim fails (replay blocked)", async () => {
+		const { token } = await mintLink(35);
+		const client = (): TinyPlaceClient =>
+			({
+				signers: {
+					get: () => Promise.resolve({ status: "active" }),
+					consume: () => Promise.reject(new Error("409 link already used")),
+				},
+			}) as unknown as TinyPlaceClient;
+
+		const result = await restoreAgentLinkSession(token, client);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toBe("consumed");
 	});
 
 	it("reports malformed without touching the backend", async () => {

--- a/website/src/common/agent-session.test.ts
+++ b/website/src/common/agent-session.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@tinyhumansai/tinyplace";
 import { describe, expect, it, vi } from "vitest";
 
-import { AgentSessionSigner } from "./agent-session";
+import { AgentSessionSigner, restoreAgentLinkSession } from "./agent-session";
 
 /** Mints a real view-as-agent link for `agentSeed`, returning the link + agent. */
 async function mintLink(
@@ -102,5 +102,66 @@ describe("AgentSessionSigner", () => {
 				signers: { get: () => Promise.reject(new Error("403")) },
 			}) as unknown as TinyPlaceClient;
 		expect(await signer.backendConfirmsActive(throws)).toBe(false);
+	});
+});
+
+describe("restoreAgentLinkSession", () => {
+	const activeClient = (): TinyPlaceClient =>
+		({
+			signers: { get: () => Promise.resolve({ status: "active" }) },
+		}) as unknown as TinyPlaceClient;
+
+	it("returns ok with a signer for a fresh, active link", async () => {
+		const { token, agent } = await mintLink(31);
+
+		const result = await restoreAgentLinkSession(`#${token}`, activeClient);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.agentId).toBe(agent.agentId);
+			expect(result.signer).toBeInstanceOf(AgentSessionSigner);
+		}
+	});
+
+	it("reports malformed without touching the backend", async () => {
+		const get = vi.fn();
+		const client = (): TinyPlaceClient =>
+			({ signers: { get } }) as unknown as TinyPlaceClient;
+
+		const result = await restoreAgentLinkSession("garbage", client);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toBe("malformed");
+		expect(get).not.toHaveBeenCalled();
+	});
+
+	it("reports revoked when the backend says the grant is inactive", async () => {
+		const { token } = await mintLink(32);
+		const revokedClient = (): TinyPlaceClient =>
+			({
+				signers: { get: () => Promise.resolve({ status: "revoked" }) },
+			}) as unknown as TinyPlaceClient;
+
+		const result = await restoreAgentLinkSession(token, revokedClient);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toBe("revoked");
+	});
+
+	it("reports expired for a past-TTL link without a backend round-trip", async () => {
+		const { token } = await mintLink(33);
+		const get = vi.fn();
+		const client = (): TinyPlaceClient =>
+			({ signers: { get } }) as unknown as TinyPlaceClient;
+		const future = Date.now() + 365 * 24 * 60 * 60 * 1000;
+		vi.spyOn(Date, "now").mockReturnValue(future);
+		try {
+			const result = await restoreAgentLinkSession(token, client);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toBe("expired");
+			expect(get).not.toHaveBeenCalled();
+		} finally {
+			vi.restoreAllMocks();
+		}
 	});
 });

--- a/website/src/common/agent-session.test.ts
+++ b/website/src/common/agent-session.test.ts
@@ -1,0 +1,106 @@
+import {
+	LocalSigner,
+	createAgentLoginLink,
+	type TinyPlaceClient,
+	type X402Authorization,
+} from "@tinyhumansai/tinyplace";
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentSessionSigner } from "./agent-session";
+
+/** Mints a real view-as-agent link for `agentSeed`, returning the link + agent. */
+async function mintLink(
+	agentSeed: number,
+	scope?: { budget?: string },
+): Promise<{ token: string; agent: LocalSigner; signerKey: string }> {
+	const agent = await LocalSigner.fromSeed(new Uint8Array(32).fill(agentSeed));
+	const client = {
+		signers: {
+			approve: vi.fn((authorization: X402Authorization) =>
+				Promise.resolve({ status: "active", signerKey: authorization.nonce }),
+			),
+		},
+	} as unknown as Parameters<typeof createAgentLoginLink>[0]["client"];
+	const link = await createAgentLoginLink({ signer: agent, client, scope });
+	return { token: link.token, agent, signerKey: link.decoded.signerKey };
+}
+
+describe("AgentSessionSigner", () => {
+	it("restores a signer from a fresh link fragment with no wallet", async () => {
+		const { token, agent, signerKey } = await mintLink(21);
+
+		const signer = await AgentSessionSigner.fromFragment(`#${token}`);
+
+		expect(signer).toBeDefined();
+		// It operates AS the agent...
+		expect(signer!.agentId).toBe(agent.agentId);
+		expect(signer!.identityPublicKeyBase64).toBe(agent.publicKeyBase64);
+		// ...while signing with the delegated session key.
+		expect(signer!.publicKeyBase64).not.toBe(agent.publicKeyBase64);
+		expect(signer!.sessionKey).toBe(signerKey);
+
+		const sig = await signer!.sign(new TextEncoder().encode("hi"));
+		expect(sig.length).toBe(64);
+	});
+
+	it("exposes x402 metadata binding the session key to the agent grant", async () => {
+		const { token } = await mintLink(22);
+		const signer = (await AgentSessionSigner.fromFragment(token))!;
+
+		const metadata = signer.x402PaymentMetadata();
+		expect(metadata["publicKey"]).toBe(signer.publicKeyBase64);
+		expect(metadata["parentNonce"]).toBeTruthy();
+	});
+
+	it("fails closed on malformed and wrong-version tokens", async () => {
+		expect(await AgentSessionSigner.fromFragment("")).toBeUndefined();
+		expect(await AgentSessionSigner.fromFragment("#")).toBeUndefined();
+		expect(await AgentSessionSigner.fromFragment("garbage")).toBeUndefined();
+		expect(await AgentSessionSigner.fromFragment("al9.abc")).toBeUndefined();
+	});
+
+	it("fails closed on an expired link", async () => {
+		const { token } = await mintLink(23);
+		// The link's expiry is minutes from real-now; move now far into the future
+		// (well past any default TTL) so the token reads as expired.
+		const future = Date.now() + 365 * 24 * 60 * 60 * 1000;
+		vi.spyOn(Date, "now").mockReturnValue(future);
+		try {
+			const signer = await AgentSessionSigner.fromFragment(token);
+			expect(signer).toBeUndefined();
+		} finally {
+			vi.restoreAllMocks();
+		}
+	});
+
+	it("backendConfirmsActive is true only for an active grant", async () => {
+		const { token, signerKey } = await mintLink(24);
+		const signer = (await AgentSessionSigner.fromFragment(token))!;
+
+		const get = vi.fn((key: string) =>
+			Promise.resolve({ signerKey: key, status: "active" }),
+		);
+		const createActive = (): TinyPlaceClient =>
+			({ signers: { get } }) as unknown as TinyPlaceClient;
+
+		expect(await signer.backendConfirmsActive(createActive)).toBe(true);
+		expect(get).toHaveBeenCalledWith(signerKey, signer.agentId);
+	});
+
+	it("backendConfirmsActive fails closed on revoked grant and on errors", async () => {
+		const { token } = await mintLink(25);
+		const signer = (await AgentSessionSigner.fromFragment(token))!;
+
+		const revoked = (): TinyPlaceClient =>
+			({
+				signers: { get: () => Promise.resolve({ status: "revoked" }) },
+			}) as unknown as TinyPlaceClient;
+		expect(await signer.backendConfirmsActive(revoked)).toBe(false);
+
+		const throws = (): TinyPlaceClient =>
+			({
+				signers: { get: () => Promise.reject(new Error("403")) },
+			}) as unknown as TinyPlaceClient;
+		expect(await signer.backendConfirmsActive(throws)).toBe(false);
+	});
+});

--- a/website/src/common/agent-session.ts
+++ b/website/src/common/agent-session.ts
@@ -129,31 +129,60 @@ export class AgentSessionSigner extends Signer {
 			return false;
 		}
 	}
+
+	/**
+	 * Claims the single-use link grant: the backend marks it consumed on the
+	 * first call and rejects every replay (409), so a leaked link can be redeemed
+	 * at most once. Signs the request with the session key (the link holder's
+	 * credential). Returns true on the first successful claim, false if the link
+	 * was already used / inactive — the route must fail closed on false.
+	 */
+	public async consumeLink(createClient: ClientFactory): Promise<boolean> {
+		try {
+			const client: TinyPlaceClient = createClient(this);
+			await client.signers.consume(this.token.signerKey);
+			return true;
+		} catch {
+			return false;
+		}
+	}
 }
 
 /** Why an agent-login link could not be restored. */
-export type AgentLinkFailure = "malformed" | "expired" | "revoked";
+export type AgentLinkFailure = "malformed" | "expired" | "revoked" | "consumed";
 
 /** The outcome of {@link restoreAgentLinkSession}. */
 export type AgentLinkRestoreResult =
 	| { ok: true; signer: AgentSessionSigner; agentId: string }
 	| { ok: false; reason: AgentLinkFailure };
 
+/** Options for {@link restoreAgentLinkSession}. */
+export interface RestoreAgentLinkOptions {
+	/**
+	 * Consume the link as single-use (default true): the backend marks the grant
+	 * consumed on first open and rejects replays, so a leaked link can be redeemed
+	 * at most once. Set false only where single-use is not wanted.
+	 */
+	singleUse?: boolean;
+}
+
 /**
  * The pure core of the `/auth/agent` route: decode + validate the fragment,
- * reconstruct the no-wallet session signer, and confirm the grant is still
- * active with the backend. Returns a discriminated result so the route can show
- * a clear message and never enter a partial auth state.
+ * reconstruct the no-wallet session signer, confirm the grant is active, and
+ * (by default) consume it single-use. Returns a discriminated result so the
+ * route can show a clear message and never enter a partial auth state.
  *
  * Failure modes (all fail closed, no signer leaked):
  *   - `malformed`: wrong version / bad shape / seed≠advertised signer key.
  *   - `expired`:   token TTL already elapsed (cheap client-side guard).
  *   - `revoked`:   backend reports the grant inactive (revoked/expired/exhausted)
  *                  or the liveness probe could not confirm it.
+ *   - `consumed`:  the single-use link was already redeemed (replay blocked).
  */
 export async function restoreAgentLinkSession(
 	fragment: string,
 	createClient: ClientFactory,
+	options?: RestoreAgentLinkOptions,
 ): Promise<AgentLinkRestoreResult> {
 	const token = decodeAgentLoginLink(fragment);
 	if (!token) return { ok: false, reason: "malformed" };
@@ -164,6 +193,13 @@ export async function restoreAgentLinkSession(
 	if (!signer) return { ok: false, reason: "malformed" };
 	if (!(await signer.backendConfirmsActive(createClient))) {
 		return { ok: false, reason: "revoked" };
+	}
+	// Single-use: claim the link so it can't be replayed. A failed claim (already
+	// used / inactive) fails closed.
+	if (options?.singleUse !== false) {
+		if (!(await signer.consumeLink(createClient))) {
+			return { ok: false, reason: "consumed" };
+		}
 	}
 	return { ok: true, signer, agentId: signer.agentId };
 }

--- a/website/src/common/agent-session.ts
+++ b/website/src/common/agent-session.ts
@@ -130,3 +130,40 @@ export class AgentSessionSigner extends Signer {
 		}
 	}
 }
+
+/** Why an agent-login link could not be restored. */
+export type AgentLinkFailure = "malformed" | "expired" | "revoked";
+
+/** The outcome of {@link restoreAgentLinkSession}. */
+export type AgentLinkRestoreResult =
+	| { ok: true; signer: AgentSessionSigner; agentId: string }
+	| { ok: false; reason: AgentLinkFailure };
+
+/**
+ * The pure core of the `/auth/agent` route: decode + validate the fragment,
+ * reconstruct the no-wallet session signer, and confirm the grant is still
+ * active with the backend. Returns a discriminated result so the route can show
+ * a clear message and never enter a partial auth state.
+ *
+ * Failure modes (all fail closed, no signer leaked):
+ *   - `malformed`: wrong version / bad shape / seed≠advertised signer key.
+ *   - `expired`:   token TTL already elapsed (cheap client-side guard).
+ *   - `revoked`:   backend reports the grant inactive (revoked/expired/exhausted)
+ *                  or the liveness probe could not confirm it.
+ */
+export async function restoreAgentLinkSession(
+	fragment: string,
+	createClient: ClientFactory,
+): Promise<AgentLinkRestoreResult> {
+	const token = decodeAgentLoginLink(fragment);
+	if (!token) return { ok: false, reason: "malformed" };
+	if (!agentLoginTokenIsFresh(token, Date.now())) {
+		return { ok: false, reason: "expired" };
+	}
+	const signer = await AgentSessionSigner.fromFragment(fragment);
+	if (!signer) return { ok: false, reason: "malformed" };
+	if (!(await signer.backendConfirmsActive(createClient))) {
+		return { ok: false, reason: "revoked" };
+	}
+	return { ok: true, signer, agentId: signer.agentId };
+}

--- a/website/src/common/agent-session.ts
+++ b/website/src/common/agent-session.ts
@@ -1,0 +1,132 @@
+import {
+	agentLoginTokenIsFresh,
+	decodeAgentLoginLink,
+	sessionSignerFromAgentLoginToken,
+	Signer,
+	type AgentLoginToken,
+	type BrowserSessionSigner,
+	type Signer as SignerType,
+	type TinyPlaceClient,
+	type X25519KeyPair,
+} from "@tinyhumansai/tinyplace";
+
+/** Builds a client; pass the session signer to make authenticated calls. */
+type ClientFactory = (signer?: SignerType) => TinyPlaceClient;
+
+/**
+ * A no-wallet session signer for the "view-as-agent" link flow.
+ *
+ * This is the Phantom-free sibling of `SessionWalletSigner`: instead of a
+ * grantor `WalletSigner`, it carries the agent's identity public key (decoded
+ * from the login-link token) and signs every request with the delegated session
+ * key that the agent already approved and registered with the backend. The
+ * backend's approved-signer delegation authorizes the session key to act as the
+ * agent, so the human operates as the agent under a scoped, expiring, revocable
+ * grant — with no Phantom and no private-key import.
+ *
+ * Like `SessionWalletSigner`, it reports the agent's cryptoId as {@link agentId}
+ * (so the app keeps operating as the agent) while presenting the session public
+ * key for signature verification, and exposes the agent identity key where an
+ * identity proof is required ({@link identityPublicKeyBase64}).
+ */
+export class AgentSessionSigner extends Signer {
+	/** The agent identity the session acts as (the link's grantor cryptoId). */
+	public readonly agentId: string;
+	/** The session key's public key — presented for signature verification. */
+	public readonly publicKeyBase64: string;
+
+	private readonly session: BrowserSessionSigner;
+	private readonly token: AgentLoginToken;
+
+	private constructor(session: BrowserSessionSigner, token: AgentLoginToken) {
+		super();
+		this.agentId = token.agentId;
+		this.publicKeyBase64 = session.publicKeyBase64;
+		this.session = session;
+		this.token = token;
+	}
+
+	public sign(data: Uint8Array): Promise<Uint8Array> {
+		// In-memory signature with the delegated session key — no wallet.
+		return this.session.sign(data);
+	}
+
+	public getX25519KeyPair(): Promise<X25519KeyPair> {
+		return this.session.getX25519KeyPair();
+	}
+
+	/** The session key (hex) — the backend's approved-signer lookup key. */
+	public get sessionKey(): string {
+		return this.token.signerKey;
+	}
+
+	/** RFC 3339 timestamp at which the session grant expires. */
+	public get expiresAt(): string {
+		return this.token.expiresAt;
+	}
+
+	/**
+	 * The agent (grantor) public key — the key the backend has on record for the
+	 * agent's identity. Distinct from {@link publicKeyBase64} (the session key):
+	 * use this wherever a request must carry the identity's key, not the ephemeral
+	 * session key that merely signs the request.
+	 */
+	public get identityPublicKeyBase64(): string {
+		return this.token.grantorPublicKeyBase64;
+	}
+
+	/**
+	 * x402 payment metadata binding a session-signed authorization to the agent's
+	 * approved-signer grant. The backend verifies the signature against the
+	 * session key and, seeing a non-empty `parentNonce`, authorizes it as the
+	 * agent's delegate. (The default link grant carries a zero budget, so this
+	 * only enables spending when the link was minted with an explicit budget.)
+	 */
+	public x402PaymentMetadata(): Record<string, string> {
+		return {
+			publicKey: this.publicKeyBase64,
+			parentNonce: this.token.approvalNonce,
+		};
+	}
+
+	/**
+	 * Builds a signer from a `/auth/agent#<token>` fragment value, failing closed
+	 * (returns undefined) for malformed, wrong-version, or expired tokens. The
+	 * authoritative liveness check is {@link backendConfirmsActive}, which the
+	 * caller must run before trusting the session.
+	 */
+	public static async fromFragment(
+		fragment: string,
+	): Promise<AgentSessionSigner | undefined> {
+		const token = decodeAgentLoginLink(fragment);
+		if (!token) return undefined;
+		if (!agentLoginTokenIsFresh(token, Date.now())) return undefined;
+		const session = await sessionSignerFromAgentLoginToken(token);
+		// Defend against a tampered token whose seed does not match the advertised
+		// signer key (which is what the backend grant is keyed by).
+		if (session.publicKeyHex !== token.signerKey) return undefined;
+		return new AgentSessionSigner(session, token);
+	}
+
+	/**
+	 * Probes the backend for the grant's live status, signing the request with the
+	 * session key itself. Returns true only when the grant is active — the
+	 * delegation resolver authorizes the read only for active, unexpired grants,
+	 * so a revoked/expired/exhausted grant yields false (via a thrown 403). The
+	 * web app must fail closed on false.
+	 */
+	public async backendConfirmsActive(
+		createClient: ClientFactory,
+	): Promise<boolean> {
+		try {
+			const client: TinyPlaceClient = createClient(this);
+			const signer = await client.signers.get(
+				this.token.signerKey,
+				this.agentId,
+			);
+			return signer.status === "active";
+		} catch {
+			return false;
+		}
+	}
+}

--- a/website/src/components/AgentSessionBanner.test.tsx
+++ b/website/src/components/AgentSessionBanner.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LocalSigner, createAgentLoginLink } from "@tinyhumansai/tinyplace";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@src/common/i18n";
+import { AgentSessionSigner } from "@src/common/agent-session";
+import { useAuthStore } from "@src/store/auth";
+
+import { AgentSessionBanner } from "./AgentSessionBanner";
+
+const revoke = vi.fn(() => Promise.resolve({ status: "revoked" }));
+
+vi.mock("@src/common/api-client", () => ({
+	createClient: (): unknown => ({ signers: { revoke } }),
+}));
+
+/** Restores a real AgentSessionSigner so the exit path exercises revoke(). */
+async function makeLinkSigner(seed: number): Promise<AgentSessionSigner> {
+	const agent = await LocalSigner.fromSeed(new Uint8Array(32).fill(seed));
+	const client = {
+		signers: {
+			approve: (): Promise<unknown> => Promise.resolve({ status: "active" }),
+		},
+	} as unknown as Parameters<typeof createAgentLoginLink>[0]["client"];
+	const link = await createAgentLoginLink({ signer: agent, client });
+	const signer = await AgentSessionSigner.fromFragment(link.token);
+	if (!signer) throw new Error("expected a restorable link signer");
+	return signer;
+}
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+	revoke.mockClear();
+	useAuthStore.getState().clearSession();
+	// jsdom's window.location.assign is read-only; swap the whole object for a
+	// stub so the banner's post-exit navigation is a no-op under test.
+	Object.defineProperty(window, "location", {
+		configurable: true,
+		value: { ...originalLocation, assign: vi.fn() },
+		writable: true,
+	});
+});
+
+afterEach(() => {
+	useAuthStore.getState().clearSession();
+	Object.defineProperty(window, "location", {
+		configurable: true,
+		value: originalLocation,
+		writable: true,
+	});
+	vi.restoreAllMocks();
+});
+
+describe("AgentSessionBanner", () => {
+	it("renders nothing without a link session", () => {
+		render(<AgentSessionBanner />);
+		expect(screen.queryByRole("status")).toBeNull();
+	});
+
+	it("renders nothing for a normal (non-link) session", async () => {
+		const wallet = await LocalSigner.fromSeed(new Uint8Array(32).fill(1));
+		useAuthStore.getState().setSigner(wallet, wallet.agentId);
+		render(<AgentSessionBanner />);
+		expect(screen.queryByRole("status")).toBeNull();
+	});
+
+	it("shows a Viewing-as banner during a link session", async () => {
+		const signer = await makeLinkSigner(41);
+		useAuthStore.getState().setLinkSession(signer, signer.agentId);
+
+		render(<AgentSessionBanner />);
+
+		const banner = screen.getByRole("status");
+		expect(banner).toBeInTheDocument();
+		expect(banner.textContent).toContain("Viewing as");
+	});
+
+	it("exit revokes the grant and clears the session", async () => {
+		const signer = await makeLinkSigner(42);
+		useAuthStore.getState().setLinkSession(signer, signer.agentId);
+
+		render(<AgentSessionBanner />);
+		await userEvent.click(screen.getByRole("button", { name: /exit/i }));
+
+		await waitFor(() => {
+			expect(revoke).toHaveBeenCalledWith(signer.sessionKey, signer.agentId);
+		});
+		expect(useAuthStore.getState().agentLinkSession).toBe(false);
+		expect(useAuthStore.getState().signer).toBeUndefined();
+	});
+});

--- a/website/src/components/AgentSessionBanner.tsx
+++ b/website/src/components/AgentSessionBanner.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { createClient } from "@src/common/api-client";
+import { AgentSessionSigner } from "@src/common/agent-session";
+import type { FunctionComponent } from "@src/common/types";
+import { useAuthStore } from "@src/store/auth";
+
+/** Shortens a long agent id to `head…tail` for compact display. */
+function truncateId(value: string, head = 6, tail = 4): string {
+	if (value.length <= head + tail + 1) return value;
+	return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+/**
+ * A persistent banner shown while the app is operating inside an agent-login
+ * ("view-as-agent") link session. It makes the impersonation unmistakable and
+ * offers a one-click exit that clears the session (and best-effort revokes the
+ * underlying signer grant so the link can't be reused after exit).
+ *
+ * Renders nothing for a normal wallet session.
+ */
+export const AgentSessionBanner = (): FunctionComponent => {
+	const { t } = useTranslation();
+	const agentLinkSession = useAuthStore((state) => state.agentLinkSession);
+	const agentId = useAuthStore((state) => state.agentId);
+	const signer = useAuthStore((state) => state.signer);
+	const clearSession = useAuthStore((state) => state.clearSession);
+	const [exiting, setExiting] = useState(false);
+
+	if (!(agentLinkSession && agentId)) return null;
+
+	const exit = async (): Promise<void> => {
+		setExiting(true);
+		// Best-effort revoke so a leaked/over-shared link is dead after exit. The
+		// grantor must authorize the revoke, but the agent's identity key isn't in
+		// the browser; the session key can still revoke its own grant where the
+		// backend permits, so we try and never let a failure block sign-out.
+		if (signer instanceof AgentSessionSigner) {
+			try {
+				await createClient(signer).signers.revoke(
+					signer.sessionKey,
+					signer.agentId,
+				);
+			} catch {
+				// Ignore — clearing the local session is the guaranteed exit.
+			}
+		}
+		clearSession();
+		// Drop any in-app state by returning to the public home.
+		window.location.assign("/");
+	};
+
+	return (
+		<div
+			className="fixed inset-x-0 top-0 z-50 flex items-center justify-center gap-3 bg-primary px-4 py-2 text-sm text-white shadow"
+			role="status"
+		>
+			<span aria-hidden>👁️</span>
+			<span>
+				{t("agentLogin.viewingAs", { agent: truncateId(agentId) })}
+			</span>
+			<button
+				className="rounded-md border border-white/40 px-2 py-0.5 font-medium hover:bg-white/10 disabled:opacity-60"
+				disabled={exiting}
+				type="button"
+				onClick={(): void => {
+					void exit();
+				}}
+			>
+				{exiting ? t("agentLogin.exiting") : t("agentLogin.exit")}
+			</button>
+		</div>
+	);
+};

--- a/website/src/store/auth.ts
+++ b/website/src/store/auth.ts
@@ -3,6 +3,12 @@ import type { Signer } from "@tinyhumansai/tinyplace";
 
 type AuthState = {
 	agentId: string | undefined;
+	/**
+	 * True when the active session was established from an agent-generated login
+	 * link ("view-as-agent") rather than a connected wallet. Drives the
+	 * "Viewing as @agent" banner and its exit control. Reset on clearSession.
+	 */
+	agentLinkSession: boolean;
 	clearSession: () => void;
 	/**
 	 * The signer whose public key base58-derives to {@link agentId}. For a hot
@@ -12,6 +18,13 @@ type AuthState = {
 	 */
 	identitySigner: Signer | undefined;
 	setSigner: (signer: Signer, agentId: string, identitySigner?: Signer) => void;
+	/**
+	 * Sets the session from an agent-login link. Like {@link setSigner} but flags
+	 * the session as a link session so the banner renders. The link's delegated
+	 * session key cannot register an identity, so no identitySigner is carried
+	 * (identity-binding ops are unavailable in a view-as-agent session).
+	 */
+	setLinkSession: (signer: Signer, agentId: string) => void;
 	signer: Signer | undefined;
 };
 
@@ -19,12 +32,31 @@ export const useAuthStore = create<AuthState>()((set) => ({
 	signer: undefined,
 	identitySigner: undefined,
 	agentId: undefined,
+	agentLinkSession: false,
 	setSigner: (signer, agentId, identitySigner): void => {
 		// Default the identity signer to the signer itself: for a direct
 		// WalletSigner the signing key already IS the identity key.
-		set({ signer, agentId, identitySigner: identitySigner ?? signer });
+		set({
+			signer,
+			agentId,
+			identitySigner: identitySigner ?? signer,
+			agentLinkSession: false,
+		});
+	},
+	setLinkSession: (signer, agentId): void => {
+		set({
+			signer,
+			agentId,
+			identitySigner: undefined,
+			agentLinkSession: true,
+		});
 	},
 	clearSession: (): void => {
-		set({ signer: undefined, agentId: undefined, identitySigner: undefined });
+		set({
+			signer: undefined,
+			agentId: undefined,
+			identitySigner: undefined,
+			agentLinkSession: false,
+		});
 	},
 }));


### PR DESCRIPTION
## Summary

Implements #190 — an agent-generated login link ("view-as-agent"). An agent that holds its own Ed25519 identity key (but has no browser/Phantom) can hand its human owner a single link that logs the human into the web app **as that agent**, with no Phantom and no private-key import, by reusing the existing approved-signer / session-key delegation primitive with the **agent's identity key as the grantor**.

## What's included (all 4 scope items)

1. **SDK `createAgentLoginLink({ ttl, scope })`** (`sdk/typescript/src/agent-login-link.ts`) plus web-side decode/restore helpers (`decodeAgentLoginLink`, `sessionSignerFromAgentLoginToken`, `agentLoginTokenIsFresh`). The agent mints a fresh session key from a random 32-byte seed, signs an x402 "upto" approved-signer grant with its identity key, registers it via `signers.approve`, and encodes the grant metadata + seed into a fragment-only token. TS SDK done first (flagship).
2. **No-wallet `AgentSessionSigner`** (`website/src/common/agent-session.ts`) — the Phantom-free sibling of `SessionWalletSigner`. Restores a delegated session signer from a decoded token, reports the agent as `agentId` while signing with the session key, exposes the agent identity key for identity proofs, and reuses the `backendConfirmsActive` active-grant probe (fail-closed). `restoreAgentLinkSession` is the pure, unit-tested route core.
3. **Client-only route `website/app/auth/agent/page.tsx`** — reads the token from the URL fragment, strips it from the address bar/history immediately, validates + reconstructs the signer, confirms the grant is active, hydrates the auth store, and redirects to `/explore`. Malformed/expired/revoked tokens land on a clear message with no partial auth state.
4. **"Viewing as @agent" banner** (`website/src/components/AgentSessionBanner.tsx`) — persistent banner during a link session with a one-click exit that best-effort revokes the grant and calls `clearSession()`. Mounted in `providers.tsx`; en/es translations added.

## Security requirements honored

- Fragment-only token (never query string); stripped from history on load.
- Short TTL (default 15 min), independent of the 7-day wallet session.
- Default **zero** x402 budget so a leaked link can't move funds; spending is an explicit opt-in.
- Revocable + fail-closed: the active-grant probe rejects revoked/expired/exhausted grants; decode fails closed on malformed/wrong-version/tampered tokens (rebuilt key must match the advertised signer key).

## Tests (targeted, green)

- SDK `tests/agent-login-link.test.ts`: 9/9
- Website `src/common/agent-session.test.ts`: 10/10
- Website `src/components/AgentSessionBanner.test.tsx`: 4/4
- `tsc --noEmit` and `eslint --max-warnings 0` clean across the website; SDK builds clean.

## Notes

- Frontend-only change; backend untouched. Reuses the existing approved-signer delegation path that `E2EAuthBridge` already relies on.
- Python/Rust SDK mirrors not included (issue marks them "where feasible"); the flagship TS SDK is complete.

Closes #190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for agent login links, including link creation, decoding, freshness checks, and session restoration.
  * Added an in-app “Viewing as” banner with an exit action for agent sessions.
  * Added a dedicated route to open agent login links and sign users in.

* **Bug Fixes**
  * Improved handling of invalid, expired, revoked, or already-used login links.
  * Agent link tokens are now cleared from the browser address after use.

* **Documentation**
  * Added localized UI text for agent login flow messages and errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->