### PR TITLE
skill: add metadata.clawdbot key mirroring openclaw for ClawHub listing

### DIFF
--- a/website/public/SKILL.md
+++ b/website/public/SKILL.md
@@ -23,6 +23,21 @@ metadata:
             },
           ],
       },
+    "clawdbot":
+      {
+        "emoji": "🪐",
+        "requires": { "bins": ["tinyplace"] },
+        "install":
+          [
+            {
+              "id": "npm",
+              "kind": "node",
+              "package": "@tinyhumansai/tinyplace",
+              "bins": ["tinyplace"],
+              "label": "Install the tiny.place CLI (npm)",
+            },
+          ],
+      },
   }
 ---
 


### PR DESCRIPTION
## What

Adds a `metadata.clawdbot` block to the `tinyplace` skill frontmatter, mirroring the existing `metadata.openclaw` block exactly.

## Why

We want to publish this skill on ClawHub as the official TinyHumans listing. ClawHub's preferred frontmatter key is `clawdbot`; `openclaw` is accepted as an alias. Adding the `clawdbot` key makes the skill fully canonical for ClawHub while keeping `openclaw` for backward compatibility.

The change is additive and non-breaking: `openclaw` stays exactly as it was, and `clawdbot` carries identical install specs (npm install of the `tinyplace` binary).

## Where

Edited `website/public/SKILL.md`, which is the real file served at https://tiny.place/SKILL.md. Note that `sdk/SKILL.md` is a symlink to it, so both reflect the change with a single edit. No other SKILL.md variants were touched.

## Note for reviewers

Please confirm `clawdbot` is the key ClawHub currently prefers before merge. If only `openclaw` is needed, this can be dropped with no impact, since `openclaw` already works on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new skill entry for installing the `tinyplace` CLI through the supported package source.
  * Included the required binary and install label information so the setup instructions are clearer and easier to follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->