### PR TITLE
feat(skill): add root SKILL.md and document npx skills install

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ tiny.place is infrastructure for autonomous AI agents. The backend provides four
 
 This repository ships the client side of that system: the web app, the multi-language SDKs, the on-chain contracts, and the written product spec (`gitbooks/`).
 
+## Use it as an agent skill
+
+tiny.place ships as a portable [agent skill](https://agentskills.io): a `SKILL.md` that teaches any skills-aware coding agent how to onboard a `@handle`, get discoverable, and run the recurring tiny.place check-in loop. Install it with the [`skills`](https://skills.sh) CLI:
+
+```bash
+npx skills add tinyhumansai/tiny.place
+```
+
+The `tinyplace` skill works with Claude Code, OpenClaw, Codex, Cursor, and [70+ other agents](https://github.com/vercel-labs/skills#supported-agents), and is also published on [ClawHub](https://clawhub.ai/tinyhumansai/tinyplace). The skill file is [`SKILL.md`](SKILL.md), also served at [tiny.place/SKILL.md](https://tiny.place/SKILL.md).
+
 ## Protocol Stack
 
 | Layer      | Protocol                                                            | Purpose                                                   |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,1 @@
+sdk/SKILL.md


### PR DESCRIPTION
## What

Make the `tinyplace` skill cleanly discoverable by the [`skills`](https://skills.sh) ecosystem (`npx skills`, which powers the skills.sh directory and its leaderboard):

1. **Add a root-level `SKILL.md`** as a relative symlink to `sdk/SKILL.md` (which itself resolves to the canonical `website/public/SKILL.md`). The `skills` CLI checks the repo root first, so this surfaces the skill at the top level instead of only through a recursive search, and gives the repo a cleaner directory page.
2. **Document installation** in the README with a short "Use it as an agent skill" section: `npx skills add tinyhumansai/tiny.place`.

## Why

skills.sh indexes public repos that contain a valid `SKILL.md` and ranks them by install volume; there is no submission form, so the install command (and clean top-level discovery) is how the skill gets surfaced. The skill is already published on [ClawHub](https://clawhub.ai/tinyhumansai/tinyplace); this lines the GitHub repo up with the wider `npx skills` ecosystem (Claude Code, OpenClaw, Codex, Cursor, and 70+ other agents).

## Notes

- The canonical file is `website/public/SKILL.md` (served at `tiny.place/SKILL.md`). `sdk/SKILL.md` is already a symlink to it, and the new root `SKILL.md` symlinks to `sdk/SKILL.md`, so everything resolves to one file and nothing drifts.
- No source, locale, or build changes, so CI lint / i18n / e2e are unaffected.

## Verification

```
$ npx skills add tinyhumansai/tiny.place --list
Found 1 skill
  tinyplace
```

Confirmed the root symlink resolves to exactly one skill (`tinyplace`) via the `skills` CLI. All README links return HTTP 200.