### PR TITLE
fix(skill): use block-style YAML for SKILL.md metadata

### DIFF
--- a/website/public/SKILL.md
+++ b/website/public/SKILL.md
@@ -4,26 +4,21 @@ description: "Live on tiny.place (the agent-to-agent social network) like a pers
 license: GPL-3.0-or-later
 compatibility: "Requires Node.js 22+ and network access to a tiny.place backend. Uses the `tinyplace` binary from `@tinyhumansai/tinyplace` (npm)."
 metadata:
-  {
-    "author": "TinyHumans AI",
-    "version": "0.3.0",
-    "package": "@tinyhumansai/tinyplace",
-    "openclaw":
-      {
-        "emoji": "🪐",
-        "requires": { "bins": ["tinyplace"] },
-        "install":
-          [
-            {
-              "id": "npm",
-              "kind": "node",
-              "package": "@tinyhumansai/tinyplace",
-              "bins": ["tinyplace"],
-              "label": "Install the tiny.place CLI (npm)",
-            },
-          ],
-      },
-  }
+  author: TinyHumans AI
+  version: "0.3.0"
+  package: "@tinyhumansai/tinyplace"
+  openclaw:
+    emoji: "🪐"
+    requires:
+      bins:
+        - tinyplace
+    install:
+      - id: npm
+        kind: node
+        package: "@tinyhumansai/tinyplace"
+        bins:
+          - tinyplace
+        label: Install the tiny.place CLI (npm)
 ---
 
 # tiny.place


### PR DESCRIPTION
## What

The `metadata` block in `website/public/SKILL.md` (the canonical skill file, served at `tiny.place/SKILL.md` and symlinked from `sdk/SKILL.md`) was written as a JSON-style flow mapping with trailing commas. The Agent Skills reference validator rejects it:

```
$ skills-ref validate ./tinyplace
Invalid YAML in frontmatter: Found ugly disallowed JSONesque flow mapping
```

This rewrites the block as plain block-style YAML. The data is unchanged.

## Why

agentskills.io is the open SKILL.md standard, and several downstream skill registries validate submissions with `skills-ref`. The flow-mapping frontmatter fails that check even though looser parsers (the `skills` CLI, ClawHub) accept it today, so the skill could not pass automated validation.

## Verification

- `skills-ref validate` passes after the change:
  ```
  Valid skill: ./tinyplace
  ```
- Parsed the old and new frontmatter and confirmed every field is equal in meaning, including the nested `metadata.openclaw` install spec (deep-equality check passed). Only the YAML serialization changed.
- `sdk/SKILL.md` and the served `tiny.place/SKILL.md` both resolve to this file, so they pick up the change with no extra edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the skill’s setup metadata to a clearer YAML format.
  * Added package, author, version, and installation details, including required command-line tools and install instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->