### PR TITLE
chore(sdk): point production endpoint at api-v2.tiny.place

### DIFF
--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -126,7 +126,7 @@ async fn main() -> tinyplace::Result<()> {
 
 | Environment | `base_url`                       |
 | ----------- | -------------------------------- |
-| Production  | `https://api.tiny.place`         |
+| Production  | `https://api-v2.tiny.place`      |
 | Staging     | `https://staging-api.tiny.place` |
 | Local       | `http://localhost:8080`          |
 

--- a/sdk/rust/src/cli/config.rs
+++ b/sdk/rust/src/cli/config.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-const DEFAULT_ENDPOINT: &str = "https://api.tiny.place";
+const DEFAULT_ENDPOINT: &str = "https://api-v2.tiny.place";
 
 #[derive(Debug, Default, Deserialize)]
 pub struct ConfigFile {

--- a/sdk/skill/tinyplace/SKILL.md
+++ b/sdk/skill/tinyplace/SKILL.md
@@ -77,7 +77,7 @@ export TINYPLACE_SECRET_KEY="<hex-ed25519-seed>"
 
 | Environment | Endpoint                          |
 | ----------- | --------------------------------- |
-| Production  | `https://api.tiny.place` (default) |
+| Production  | `https://api-v2.tiny.place` (default) |
 | Staging     | `https://staging-api.tiny.place`  |
 | Local       | `http://localhost:8080`           |
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -114,7 +114,7 @@ await client.directory.upsertAgent(signer.agentId, {
 
 | Environment | `baseUrl`                        |
 | ----------- | -------------------------------- |
-| Production  | `https://api.tiny.place`         |
+| Production  | `https://api-v2.tiny.place`      |
 | Staging     | `https://staging-api.tiny.place` |
 | Local       | `http://localhost:8080`          |
 

--- a/sdk/typescript/src/cli/context.ts
+++ b/sdk/typescript/src/cli/context.ts
@@ -11,7 +11,7 @@ import type {
   TinyPlaceCliOptions,
 } from "./types.js";
 
-const DEFAULT_ENDPOINT = "https://api.tiny.place";
+const DEFAULT_ENDPOINT = "https://api-v2.tiny.place";
 
 export async function makeContext(
   options: TinyPlaceCliOptions,


### PR DESCRIPTION
Production now runs the v2 backend at `https://api-v2.tiny.place`. This bumps the production endpoint across the SDKs:

- **TypeScript CLI** default endpoint (`cli/context.ts`)
- **Rust CLI** default endpoint (`cli/config.rs`)
- Production rows in the **SKILL.md** and the **TS / Rust SDK READMEs**

The SDK clients take an explicit `base_url`/`baseUrl`, so library callers pass the new host for production. **Staging** (`staging-api.tiny.place`) and **Local** (`localhost:8080`) are unchanged. The Python SDK has no production default to bump (its client requires an explicit `base_url`).

Verified: TS SDK builds (`tsc`), Rust SDK builds + CLI config test references the constant (unchanged behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default production API endpoint to the new v2 address across SDKs and CLI behavior when no custom endpoint is provided.

* **Documentation**
  * Refreshed Rust, TypeScript, and skill docs to show the new production endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->