### PR TITLE
fix(rust-sdk): tolerate object skills/capabilities on agent cards

### DIFF
--- a/sdk/rust/src/types/directory.rs
+++ b/sdk/rust/src/types/directory.rs
@@ -1,7 +1,61 @@
 #[allow(unused_imports)]
 use super::*;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap; // sibling types share a flat namespace, like the TS barrel
+
+// The backend normalizes an agent card's `skills` and `capabilities` to richer
+// shapes on read: `skills` comes back as `[{"id":..,"name":..}]` (not a bare
+// string array) and `capabilities` as `{"additional":[..]}`. The SDK exposes
+// both as plain string lists (matching the write form and the TypeScript SDK),
+// so these tolerant deserializers accept either shape and flatten to Vec<String>.
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum SkillEntry {
+    Str(String),
+    Named {
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        id: Option<String>,
+    },
+}
+
+fn deserialize_skill_list<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let entries: Option<Vec<SkillEntry>> = Option::deserialize(deserializer)?;
+    Ok(entries.map(|list| {
+        list.into_iter()
+            .filter_map(|entry| match entry {
+                SkillEntry::Str(s) => Some(s),
+                SkillEntry::Named { name, id } => name.or(id),
+            })
+            .collect()
+    }))
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum CapabilitiesField {
+    List(Vec<String>),
+    Object {
+        #[serde(default)]
+        additional: Vec<String>,
+    },
+}
+
+fn deserialize_capabilities<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: Option<CapabilitiesField> = Option::deserialize(deserializer)?;
+    Ok(value.map(|c| match c {
+        CapabilitiesField::List(v) => v,
+        CapabilitiesField::Object { additional } => additional,
+    }))
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -83,9 +137,17 @@ pub struct AgentCard {
     pub endpoint: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub supported_interfaces: Option<Vec<AgentInterface>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "deserialize_skill_list"
+    )]
     pub skills: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "deserialize_capabilities"
+    )]
     pub capabilities: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
@@ -125,7 +187,11 @@ pub struct AgentCardSummary {
     pub bio: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reputation: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "deserialize_skill_list"
+    )]
     pub skills: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
@@ -159,7 +225,11 @@ pub struct ExtendedAgentCard {
     #[serde(default)]
     pub agent_id: String,
     pub agent: AgentCard,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "deserialize_skill_list"
+    )]
     pub private_skills: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub rate_limits: Option<HashMap<String, String>>,
@@ -206,7 +276,6 @@ pub struct AgentQueryParams {
     pub offset: Option<i64>,
 }
 
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveResponse {
@@ -225,4 +294,43 @@ pub struct ReverseResponse {
     pub identities: Vec<crate::types::Identity>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub agents: Option<Vec<AgentCard>>,
+}
+
+#[cfg(test)]
+mod skill_deser_tests {
+    use super::*;
+
+    // The v2 backend returns skills as [{id,name}] and capabilities as
+    // {additional:[..]}; both must flatten to the SDK's Vec<String>.
+    #[test]
+    fn agent_card_accepts_object_skills_and_capabilities() {
+        let json = r#"{
+            "agentId":"a1","name":"n","cryptoId":"c1",
+            "skills":[{"id":"summarize","name":"Summarize"},{"id":"code","name":"Code"}],
+            "capabilities":{"additional":["fast","cheap"]},
+            "createdAt":"t","updatedAt":"t"
+        }"#;
+        let card: AgentCard = serde_json::from_str(json).expect("object shape");
+        assert_eq!(
+            card.skills,
+            Some(vec!["Summarize".to_string(), "Code".to_string()])
+        );
+        assert_eq!(
+            card.capabilities,
+            Some(vec!["fast".to_string(), "cheap".to_string()])
+        );
+    }
+
+    // The legacy/write shape (plain string arrays) still deserializes.
+    #[test]
+    fn agent_card_accepts_string_skills_and_capabilities() {
+        let json = r#"{
+            "agentId":"a1","name":"n","cryptoId":"c1",
+            "skills":["a","b"],"capabilities":["x"],
+            "createdAt":"t","updatedAt":"t"
+        }"#;
+        let card: AgentCard = serde_json::from_str(json).expect("string shape");
+        assert_eq!(card.skills, Some(vec!["a".to_string(), "b".to_string()]));
+        assert_eq!(card.capabilities, Some(vec!["x".to_string()]));
+    }
 }


### PR DESCRIPTION
The v2 backend returns an agent card's `skills` as `[{"id","name"}]` and `capabilities` as `{"additional":[..]}`, but the Rust SDK typed both as `Vec<String>`, so **every directory read** (`get_agent`/`list_agents`/search) failed with serde `invalid type: map, expected a string`. (The TS SDK only "works" because it doesn't validate JSON at runtime.)

Keep the public `Vec<String>` API but add tolerant deserializers that accept **either** the string form or the backend's object form and flatten to the string list. Backwards-compatible for writes (still serialized as string arrays).

Tests: `AgentCard` deserializes both the object shape and the legacy string shape.

Note: a pre-existing, unrelated test (`tests/x402_standard.rs::built_transaction_structure`, a tx-header byte assertion) fails on this crate independent of this change.