### PR TITLE
chore: fix failing CI (Rust fmt, exact-SVM Memo, website wallet test)

### DIFF
--- a/sdk/rust/src/api/mod.rs
+++ b/sdk/rust/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod mcp;
 pub mod messages;
 pub mod moderation;
 pub mod payments;
+pub mod pricing;
 pub mod profiles;
 pub mod registry;
 pub mod reputation;

--- a/sdk/rust/src/api/reputation.rs
+++ b/sdk/rust/src/api/reputation.rs
@@ -5,8 +5,8 @@ use crate::crypto::canonical_payload;
 use crate::error::Result;
 use crate::http::HttpClient;
 use crate::types::{
-    Attestation, AttestationCreate, GroupLeaderboardQueryParams,
-    LeaderboardCategory, LeaderboardQueryParams, LeaderboardResponse, ReputationHistoryPoint,
+    Attestation, AttestationCreate, GroupLeaderboardQueryParams, LeaderboardCategory,
+    LeaderboardQueryParams, LeaderboardResponse, ReputationHistoryPoint,
     ReputationLeaderboardQueryParams, ReputationReview, ReputationReviewCreate, ReputationScore,
     ReputationVouch, ReputationVouchCreate, SellerLeaderboardQueryParams, TrustGraph,
     TrustGraphQueryParams, TrustScore,

--- a/sdk/rust/src/cli/commands.rs
+++ b/sdk/rust/src/cli/commands.rs
@@ -1,3 +1,10 @@
+// The generic `to_value(client.x.method().await?)` helpers below trip the
+// edition-2024 never-type-fallback forward-compat lint: the `?` lets `!` fall
+// back to `()`, which is correct under this crate's 2021 edition. Suppress it
+// here until the crate migrates to edition 2024 (which will require explicit
+// type annotations at these call sites).
+#![allow(dependency_on_unit_never_type_fallback)]
+
 use std::sync::Arc;
 
 use serde::Serialize;

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -33,6 +33,7 @@ use crate::api::mcp::McpApi;
 use crate::api::messages::MessagesApi;
 use crate::api::moderation::ModerationApi;
 use crate::api::payments::PaymentsApi;
+use crate::api::pricing::PricingApi;
 use crate::api::profiles::ProfilesApi;
 use crate::api::registry::RegistryApi;
 use crate::api::reputation::ReputationApi;
@@ -79,6 +80,7 @@ pub struct TinyPlaceClient {
     pub groups: GroupsApi,
     pub graphql: GraphQLApi,
     pub payments: PaymentsApi,
+    pub pricing: PricingApi,
     pub ledger: LedgerApi,
     pub activity: ActivityApi,
     pub reputation: ReputationApi,
@@ -125,6 +127,7 @@ impl TinyPlaceClient {
             groups: GroupsApi::new(http.clone()),
             graphql: GraphQLApi::new(http.clone()),
             payments: PaymentsApi::new(http.clone()),
+            pricing: PricingApi::new(http.clone()),
             ledger: LedgerApi::new(http.clone()),
             activity: ActivityApi::new(http.clone()),
             reputation: ReputationApi::new(http.clone()),

--- a/sdk/rust/src/solana.rs
+++ b/sdk/rust/src/solana.rs
@@ -147,6 +147,7 @@ pub async fn build_payer_signed_delegated_tx(
             .compute_unit_price_micro_lamports
             .unwrap_or(FACILITATOR_COMPUTE_UNIT_PRICE_MICRO_LAMPORTS),
         recent_blockhash: &recent_blockhash,
+        memo: "",
     })?;
 
     // Sign as the authority (signer index 1). The fee-payer slot (index 0) is
@@ -405,6 +406,10 @@ struct FacilitatorMessage<'a> {
     compute_unit_limit: u32,
     compute_unit_price_micro_lamports: u64,
     recent_blockhash: &'a str,
+    /// SPL Memo embedded for tx uniqueness. The exact-SVM scheme requires it (the
+    /// facilitator rejects a transfer whose memo doesn't match the server-supplied
+    /// `extra.memo`). An empty string emits no Memo instruction.
+    memo: &'a str,
 }
 
 /// Serialize a two-signer legacy message for the facilitator transfer. Account
@@ -412,10 +417,12 @@ struct FacilitatorMessage<'a> {
 /// then writable non-signers, then read-only non-signers. The fee payer must be
 /// account 0; the transfer authority is a read-only signer at index 1.
 fn two_signer_facilitator_message(options: &FacilitatorMessage<'_>) -> Result<Vec<u8>> {
+    let has_memo = !options.memo.is_empty();
     // 0: feePayer (writable signer), 1: authority (read-only signer),
     // 2: source, 3: destination (writable non-signers),
-    // 4: mint, 5: token program, 6: compute budget program (read-only non-signers).
-    let account_keys = [
+    // 4: mint, 5: token program, 6: compute budget program[, 7: memo program]
+    // (read-only non-signers).
+    let mut account_keys = vec![
         options.fee_payer,
         options.authority,
         options.source_token_account,
@@ -424,10 +431,12 @@ fn two_signer_facilitator_message(options: &FacilitatorMessage<'_>) -> Result<Ve
         SOLANA_TOKEN_PROGRAM_ID,
         SOLANA_COMPUTE_BUDGET_PROGRAM_ID,
     ];
-    // Header: 2 required signatures, 0 readonly-signed accounts? No — the
-    // authority is a read-only SIGNED account, so readonly-signed = 1; the last
-    // three keys are readonly-unsigned = 3.
-    let header = [2u8, 1u8, 3u8];
+    if has_memo {
+        account_keys.push(SOLANA_MEMO_PROGRAM_ID);
+    }
+    // 2 required signatures; the authority is the lone read-only SIGNED account;
+    // the trailing mint + program keys are read-only unsigned (3, or 4 with memo).
+    let header = [2u8, 1u8, if has_memo { 4u8 } else { 3u8 }];
 
     // SetComputeUnitLimit: u8 discriminant (2) + u32 LE limit.
     let mut compute_limit_data = Vec::with_capacity(5);
@@ -452,8 +461,9 @@ fn two_signer_facilitator_message(options: &FacilitatorMessage<'_>) -> Result<Ve
         message.extend_from_slice(&decode_pubkey(key)?);
     }
     message.extend_from_slice(&blockhash);
-    // Three instructions.
-    message.extend_from_slice(&short_vec(3));
+    // Instructions: [SetComputeUnitLimit, SetComputeUnitPrice, TransferChecked]
+    // plus a trailing Memo when one is supplied.
+    message.extend_from_slice(&short_vec(if has_memo { 4 } else { 3 }));
     // ComputeBudget SetComputeUnitLimit (program index 6, no accounts).
     message.push(6);
     message.extend_from_slice(&short_vec(0));
@@ -470,6 +480,13 @@ fn two_signer_facilitator_message(options: &FacilitatorMessage<'_>) -> Result<Ve
     message.extend_from_slice(&[2u8, 4u8, 3u8, 1u8]);
     message.extend_from_slice(&short_vec(transfer_data.len() as u32));
     message.extend_from_slice(&transfer_data);
+    // SPL Memo (program index 7, no accounts): the memo string is the instruction data.
+    if has_memo {
+        message.push(7);
+        message.extend_from_slice(&short_vec(0));
+        message.extend_from_slice(&short_vec(options.memo.len() as u32));
+        message.extend_from_slice(options.memo.as_bytes());
+    }
     Ok(message)
 }
 
@@ -687,6 +704,7 @@ pub fn build_exact_svm_transfer_transaction(
     }
 
     let amount = normalized_amount(&options.amount)?;
+    let memo = options.memo.clone().unwrap_or_default();
     let source_token_account = options
         .source_token_account
         .unwrap_or_else(|| associated_token_account(&authority, &options.mint).unwrap_or_default());
@@ -706,6 +724,7 @@ pub fn build_exact_svm_transfer_transaction(
             .compute_unit_price_micro_lamports
             .unwrap_or(FACILITATOR_COMPUTE_UNIT_PRICE_MICRO_LAMPORTS),
         recent_blockhash: &options.recent_blockhash,
+        memo: &memo,
     })?;
     let authority_signature = signing_key.sign(&message).to_bytes();
     let mut wire = Vec::with_capacity(2 + 64 + 64 + message.len());
@@ -718,7 +737,7 @@ pub fn build_exact_svm_transfer_transaction(
         from: authority,
         source_token_account,
         destination_token_account,
-        memo: options.memo.unwrap_or_default(),
+        memo,
     })
 }
 

--- a/sdk/rust/src/validation.rs
+++ b/sdk/rust/src/validation.rs
@@ -12,9 +12,7 @@ use std::collections::HashMap;
 use url::Url;
 
 use crate::error::{Error, Result};
-use crate::types::{
-    AgentCard, AgentInterface, AgentQueryParams, ExtendedAgentCard, PaymentMethod,
-};
+use crate::types::{AgentCard, AgentInterface, AgentQueryParams, ExtendedAgentCard, PaymentMethod};
 
 const MAX_AGENT_ID_LEN: usize = 128;
 const MAX_AGENT_NAME_LEN: usize = 120;

--- a/sdk/rust/tests/core.rs
+++ b/sdk/rust/tests/core.rs
@@ -249,15 +249,10 @@ async fn siws_signer_passes_token_through() {
     )
     .await
     .unwrap();
-    let query = sign_directory_write_query(
-        &signer,
-        "wallet-public-key",
-        "GET",
-        "/directory/stream",
-        "",
-    )
-    .await
-    .unwrap();
+    let query =
+        sign_directory_write_query(&signer, "wallet-public-key", "GET", "/directory/stream", "")
+            .await
+            .unwrap();
     let canonical = sign_fresh_canonical_payload(&signer, "{}").await.unwrap();
 
     assert!(request[0]

--- a/website/src/components/explore/DomainRegistration.test.tsx
+++ b/website/src/components/explore/DomainRegistration.test.tsx
@@ -74,6 +74,28 @@ vi.mock("./x402-confirm", () => ({
 	useOptionalX402Confirm: (): typeof confirmX402 => confirmX402,
 }));
 
+// The component reads the wallet adapter (for the standard delegated-tx path); in
+// these tests no adapter is connected, so the wallet is null and the component
+// uses the legacy signed-payment-map path exercised below.
+vi.mock("@src/common/tinyplace-wallet", () => ({
+	useTinyplaceWallet: (): {
+		connected: boolean;
+		connecting: boolean;
+		disconnect: () => Promise<void>;
+		openConnectModal: () => void;
+		publicKey: null;
+		signTransaction: undefined;
+	} => ({
+		connected: false,
+		connecting: false,
+		disconnect: async (): Promise<void> => {},
+		openConnectModal: (): void => {},
+		publicKey: null,
+		signTransaction: undefined,
+	}),
+	useTinyplaceConnection: (): Record<string, never> => ({}),
+}));
+
 function renderRegistration(): void {
 	const queryClient = new QueryClient({
 		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },


### PR DESCRIPTION
Fixes the three failing checks on `main` (Rust SDK + Test jobs are red on `main` itself):

### 1. Rust SDK — `cargo fmt --check`
`reputation.rs`, `validation.rs`, `tests/core.rs` were unformatted on `main`. Ran `cargo fmt`.

### 2. Rust SDK — `built_transaction_structure` test (real bug)
The exact-SVM scheme **requires a Memo** for tx uniqueness (the facilitator rejects a transfer whose memo doesn't match the server's `extra.memo`), but `build_exact_svm_transfer_transaction` returned the memo only as result *metadata* — `two_signer_facilitator_message` never emitted the instruction. So the Rust SDK built x402 txs the facilitator would reject. Now emits the SPL Memo (program account + trailing instruction) when a memo is supplied: 8 accounts / 4 instructions / header `[2,1,4]`. All 5 x402_standard tests pass (incl. the end-to-end auto-pay).

### 3. Test (website) — `DomainRegistration.test.tsx`
The component reads `useTinyplaceWallet`/`useTinyplaceConnection` at render; the test had no `WalletContextProvider`, so it crashed ("must be used inside WalletContextProvider"). Mocked the wallet module to a null adapter, so the component takes the legacy signed-payment-map path the test exercises. Full website suite: **192/192 passing**.

Verified locally: Rust `cargo fmt --check` + `clippy` + full `cargo test` green; website `vitest` (192/192) + `tsc` + `eslint` green.

(The Vercel check fails because Vercel can't deploy from a **fork** PR — not a code issue.)