### PR TITLE
Fix CLI --help safety and @handle card lookup

### DIFF
--- a/sdk/typescript/src/cli/index.ts
+++ b/sdk/typescript/src/cli/index.ts
@@ -134,7 +134,8 @@ async function dispatchCli(
   if (
     !parsed.command ||
     parsed.command === "help" ||
-    parsed.command === "--help"
+    parsed.command === "--help" ||
+    boolFlag(parsed.flags, "help")
   ) {
     return { code: 0, stdout: HELP, stderr: "" };
   }

--- a/sdk/typescript/src/cli/raw.ts
+++ b/sdk/typescript/src/cli/raw.ts
@@ -13,6 +13,7 @@ import {
   fundInfo,
   initFlow,
   profileUpdateFromFlags,
+  resolveAgentId,
   whoami,
 } from "./workflows.js";
 
@@ -86,7 +87,9 @@ export async function dispatchRaw(
       );
     case "card":
       // Read the agent card through the batched GraphQL gateway.
-      return client.graphql.agentCard(required(first, "card <agentId>"));
+      return client.graphql.agentCard(
+        await resolveAgentId(ctx, required(first, "card <agentId>")),
+      );
     case "groups":
       return client.groups.list(
         queryFlags(flags, ["q", "tag", "limit", "offset"]),


### PR DESCRIPTION
## Summary

- short-circuit command-specific `--help` before context creation and dispatch, so mutation commands cannot execute when help is requested
- resolve `@handle` to cryptoId before `raw card` / bare `card` GraphQL lookup

## Linked issues

Fixes part of #216.
Addresses #217.

## Verification

- Not fully run: local `corepack pnpm --filter @tinyhumansai/tinyplace lint` and `corepack pnpm --dir sdk/typescript exec tsc --noEmit` were blocked by pnpm's build-script approval gate (`ERR_PNPM_IGNORED_BUILDS`).
- Patch is limited to CLI dispatch and uses the existing `resolveAgentId` helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now shows help in more cases, including when the help flag is provided.
  * The card command now correctly recognizes agent IDs entered in common shorthand forms, improving command reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->