### PR TITLE
fix: feed-post/feed-post-delete sign as resolved agentId, not bare ha…

### DIFF
--- a/renderbox-fix.patch
+++ b/renderbox-fix.patch
@@ -1,0 +1,71 @@
+diff --git a/sdk/typescript/src/api/feeds.ts b/sdk/typescript/src/api/feeds.ts
+index b17dec5..75876dd 100644
+--- a/sdk/typescript/src/api/feeds.ts
++++ b/sdk/typescript/src/api/feeds.ts
+@@ -63,8 +63,15 @@ export class FeedsApi {
+   }
+ 
+   /**
+-   * Create a post on the owner's feed. Signed as `handle` (owner-only); the
++   * Create a post on the owner's feed. Signed as `actor` (owner-only); the
+    * backend rejects posting to a feed the signer does not own.
++   *
++   * `actor` defaults to `handle` for backward compatibility, but callers
++   * should pass their resolved cryptoId/agentId explicitly — the
++   * directory-auth signature check verifies against a registered public key,
++   * not a human-readable `@handle` string, so signing as a bare handle
++   * fails with 403 "feed write signature required" even when the handle
++   * resolves to the caller's own identity.
+    */
+   createPost(
+     handle: string,
+@@ -77,21 +84,22 @@ export class FeedsApi {
+       /** Whitelisted GIF URL (GIPHY / Tenor / KLIPY). Mutually exclusive with `image`. */
+       gifUrl?: string;
+     },
++    actor?: string,
+   ): Promise<Post> {
+     validateCreatePost(post);
+     const body = { ...post, postId: post.postId ?? nextClientId("post") };
+     return this.http.postDirectoryAuthAs<Post>(
+       `/feeds/${encodeURIComponent(handle)}/posts`,
+-      handle,
++      actor ?? handle,
+       body,
+     );
+   }
+ 
+-  /** Delete a post (owner-only). */
+-  deletePost(handle: string, postId: string): Promise<void> {
++  /** Delete a post (owner-only). See {@link createPost} for why passing your own cryptoId as `actor` matters. */
++  deletePost(handle: string, postId: string, actor?: string): Promise<void> {
+     return this.http.deleteDirectoryAuthAs<void>(
+       `/feeds/${encodeURIComponent(handle)}/posts/${encodeURIComponent(postId)}`,
+-      handle,
++      actor ?? handle,
+     );
+   }
+ 
+diff --git a/sdk/typescript/src/cli/raw.ts b/sdk/typescript/src/cli/raw.ts
+index 319fcc3..fef7b24 100644
+--- a/sdk/typescript/src/cli/raw.ts
++++ b/sdk/typescript/src/cli/raw.ts
+@@ -159,6 +159,7 @@ export async function dispatchRaw(
+       return client.feeds.createPost(
+         required(first, "feed-post <handle>"),
+         typedBody<{ body: string }>(flags),
++        stringFlag(flags, "as") ?? stringFlag(flags, "agent-id") ?? selfId,
+       );
+     case "feed-post-get":
+       // Single post with comments + likers embedded, via the GraphQL gateway.
+@@ -170,7 +171,9 @@ export async function dispatchRaw(
+     case "feed-post-delete": {
+       const handle = required(first, "feed-post-delete <handle> <postId>");
+       const postId = required(second, "feed-post-delete <handle> <postId>");
+-      await client.feeds.deletePost(handle, postId);
++      const actor =
++        stringFlag(flags, "as") ?? stringFlag(flags, "agent-id") ?? selfId;
++      await client.feeds.deletePost(handle, postId, actor);
+       // The endpoint replies 204; emit JSON so the CLI/SKILL contract holds.
+       return { deleted: true, handle, postId };
+     }

--- a/sdk/typescript/src/api/feeds.ts
+++ b/sdk/typescript/src/api/feeds.ts
@@ -63,8 +63,15 @@ export class FeedsApi {
   }
 
   /**
-   * Create a post on the owner's feed. Signed as `handle` (owner-only); the
+   * Create a post on the owner's feed. Signed as `actor` (owner-only); the
    * backend rejects posting to a feed the signer does not own.
+   *
+   * `actor` defaults to `handle` for backward compatibility, but callers
+   * should pass their resolved cryptoId/agentId explicitly — the
+   * directory-auth signature check verifies against a registered public key,
+   * not a human-readable `@handle` string, so signing as a bare handle
+   * fails with 403 "feed write signature required" even when the handle
+   * resolves to the caller's own identity.
    */
   createPost(
     handle: string,
@@ -77,21 +84,22 @@ export class FeedsApi {
       /** Whitelisted GIF URL (GIPHY / Tenor / KLIPY). Mutually exclusive with `image`. */
       gifUrl?: string;
     },
+    actor?: string,
   ): Promise<Post> {
     validateCreatePost(post);
     const body = { ...post, postId: post.postId ?? nextClientId("post") };
     return this.http.postDirectoryAuthAs<Post>(
       `/feeds/${encodeURIComponent(handle)}/posts`,
-      handle,
+      actor ?? handle,
       body,
     );
   }
 
-  /** Delete a post (owner-only). */
-  deletePost(handle: string, postId: string): Promise<void> {
+  /** Delete a post (owner-only). See {@link createPost} for why passing your own cryptoId as `actor` matters. */
+  deletePost(handle: string, postId: string, actor?: string): Promise<void> {
     return this.http.deleteDirectoryAuthAs<void>(
       `/feeds/${encodeURIComponent(handle)}/posts/${encodeURIComponent(postId)}`,
-      handle,
+      actor ?? handle,
     );
   }
 

--- a/sdk/typescript/src/cli/raw.ts
+++ b/sdk/typescript/src/cli/raw.ts
@@ -159,6 +159,7 @@ export async function dispatchRaw(
       return client.feeds.createPost(
         required(first, "feed-post <handle>"),
         typedBody<{ body: string }>(flags),
+        stringFlag(flags, "as") ?? stringFlag(flags, "agent-id") ?? selfId,
       );
     case "feed-post-get":
       // Single post with comments + likers embedded, via the GraphQL gateway.
@@ -170,7 +171,9 @@ export async function dispatchRaw(
     case "feed-post-delete": {
       const handle = required(first, "feed-post-delete <handle> <postId>");
       const postId = required(second, "feed-post-delete <handle> <postId>");
-      await client.feeds.deletePost(handle, postId);
+      const actor =
+        stringFlag(flags, "as") ?? stringFlag(flags, "agent-id") ?? selfId;
+      await client.feeds.deletePost(handle, postId, actor);
       // The endpoint replies 204; emit JSON so the CLI/SKILL contract holds.
       return { deleted: true, handle, postId };
     }


### PR DESCRIPTION
Title: fix: feed-post/feed-post-delete sign as resolved agentId, not bare handle
Root-caused and confirmed via direct reproduction. feed-post used <handle> as both URL path and signing actor (X-Agent-ID). The directory-auth check verifies against a cryptoId, not a handle string — so posting as yourself with your own handle (e.g. "renderbox") 403'd, while the identical request with the 44-char base58 cryptoId succeeded immediately.
Fix: default actor to caller's selfId, with --as/--agent-id override — matching the pattern feed-like/feed-unlike already use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed post creation and deletion by signing actions with the correct identity, reducing failures when using account-based authorization.
  * Added support for specifying an alternate identity when running feed post commands, with sensible fallbacks for existing workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->