### PR TITLE
fix(plugin): route inbound by the one common session id

### DIFF
--- a/sdk/plugin-tinyplace/envelope-test.mjs
+++ b/sdk/plugin-tinyplace/envelope-test.mjs
@@ -115,16 +115,19 @@ const dok = decodeBody(JSON.stringify(okLabelEnv));
 expect("safe labels (codex:1 / codex:2) pass validation", dok.fromSession === "codex:1" && dok.toSession === "codex:2");
 
 // ── conversation uuids on the wire ───────────────────────────────────────────
-// The sender's conversation id rides in scope.wrapper_session_id and decodes as
-// fromSessionUuid; to_session_uuid (addressing the peer's conversation) roundtrips.
+// One shared session id per thread: the conversation id rides in
+// scope.wrapper_session_id and decodes as fromSessionUuid. There is no separate
+// peer-id field — tp.to_session_uuid is neither emitted nor decoded.
 const CONV = "11111111-2222-3333-4444-555555555555";
-const PEER_CONV = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
-const convEnv = JSON.parse(encodeEnvelope({ text: "hi", fromSession: "codex:1", conversationUuid: CONV, toSessionUuid: PEER_CONV }));
+const convEnv = JSON.parse(encodeEnvelope({ text: "hi", fromSession: "codex:1", conversationUuid: CONV }));
 expect("conversationUuid is written to scope.wrapper_session_id", convEnv.scope.wrapper_session_id === CONV);
+expect("no tp.to_session_uuid is emitted (single shared id)", convEnv.tp.to_session_uuid === undefined);
 const dconv = decodeBody(JSON.stringify(convEnv));
 expect("wrapper_session_id decodes as fromSessionUuid", dconv.fromSessionUuid === CONV);
-expect("to_session_uuid roundtrips as toSessionUuid", dconv.toSessionUuid === PEER_CONV);
 expect("the routing label still rides in tp.from_session", dconv.fromSession === "codex:1");
+// Even if an envelope carries tp.to_session_uuid, decodeBody does not surface it.
+const withPeerId = { ...convEnv, tp: { ...convEnv.tp, to_session_uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" } };
+expect("tp.to_session_uuid is not decoded (no dual-id addressing)", decodeBody(JSON.stringify(withPeerId)).toSessionUuid === undefined);
 // A non-uuid wrapper_session_id (old peers put the harness id there) → no uuid.
 const legacyWrap = JSON.parse(encodeEnvelope({ text: "hi", fromSession: "codex:1", harnessSessionId: "legacy-harness-id" }));
 expect("non-uuid wrapper_session_id → fromSessionUuid null (label fallback)", decodeBody(JSON.stringify(legacyWrap)).fromSessionUuid === null);

--- a/sdk/plugin-tinyplace/hooks/agent-daemon.mjs
+++ b/sdk/plugin-tinyplace/hooks/agent-daemon.mjs
@@ -195,7 +195,6 @@ async function drainOutbound() {
         text: job.text,
         role: job.role,
         toSession: job.toSession,
-        toSessionUuid: job.toSessionUuid,
         conversationUuid: job.conversationUuid,
         inReplyTo: job.inReplyTo,
         auto: job.auto,
@@ -232,7 +231,9 @@ function notifyClosedTargets() {
       id: `sysclosed-${p.id}`,
       to: p.from,
       toSession: p.fromSession ?? null, // back to the sender's originating session
-      toSessionUuid: p.fromSessionUuid ?? null, // …addressed by their conversation id
+      // Reuse the sender's thread id as OUR wrapper_session_id (single shared id), so
+      // the notice threads into the conversation they opened.
+      conversationUuid: p.fromSessionUuid ?? null,
       role: "system",
       text: `The session "${p.toSession}" you addressed is no longer active; your message was not delivered. Start a new message to reach this agent.`,
       inReplyTo: p.id,

--- a/sdk/plugin-tinyplace/hooks/agent-daemon.mjs
+++ b/sdk/plugin-tinyplace/hooks/agent-daemon.mjs
@@ -19,7 +19,7 @@ import { FileSessionStore } from "@tinyhumansai/tinyplace/node";
 import { sendMessage, readMessages, publishKeys } from "@tinyhumansai/tinyplace/agent";
 
 import { buildEnvelope, decodeBody } from "../mcp/format.mjs";
-import { liveSessions } from "../mcp/registry.mjs";
+import { liveSessions, sessionUuidForConversation } from "../mcp/registry.mjs";
 import { enqueueRouted, redeliverUnrouted, reapClosedTargets } from "../mcp/routing.mjs";
 import { claimOutboxJobs, writeOutboxJob } from "../mcp/outbox.mjs";
 import { acquireLock, heartbeatLock, releaseLock } from "../mcp/daemon-lock.mjs";
@@ -141,13 +141,13 @@ async function drainInbound() {
     const pendingByLabel = new Map(); // label -> [decoded]
     let headlessPending = false;
     for (const raw of messages) {
-      const { auto, inReplyTo, text, messageId, fromSession, fromSessionUuid, role, toSession, toSessionUuid } = decodeBody(raw.text);
+      const { auto, inReplyTo, text, messageId, fromSession, fromSessionUuid, role, toSession } = decodeBody(raw.text);
       if (text === RESET_SENTINEL) continue; // handshake ping — consumed on decrypt
       // Correlate on the in-body envelope id when present, else the relay id.
       const id = messageId ?? raw.id;
       // Carry the conversation uuids so enqueueRouted can do reuse-proof routing and
       // held/closed mail keeps the sender's conversation id for the notice.
-      const decoded = { id, from: raw.from, fromSession, fromSessionUuid, role, text, inReplyTo, toSession, toSessionUuid, ts: raw.timestamp ?? new Date().toISOString() };
+      const decoded = { id, from: raw.from, fromSession, fromSessionUuid, role, text, inReplyTo, toSession, ts: raw.timestamp ?? new Date().toISOString() };
       const { target } = enqueueRouted(AGENT, decoded); // route to the session inbox(es)
       // Non-auto messages need a reply (loop guard: an auto-tagged reply is never
       // itself answered).
@@ -157,9 +157,10 @@ async function drainInbound() {
           if (!pendingByLabel.has(label)) pendingByLabel.set(label, []);
           pendingByLabel.get(label).push(decoded);
         }
-      } else if (!decoded.toSession && !decoded.toSessionUuid) {
-        // Untargeted + no live session → isolated responder (headless agent still
-        // auto-replies).
+      } else if (!decoded.toSession && !(decoded.fromSessionUuid && sessionUuidForConversation(decoded.fromSessionUuid))) {
+        // Truly untargeted (no toSession label, and the shared id — if any — is one we
+        // never minted, i.e. a brand-new thread) + no live session → isolated
+        // responder (headless agent still auto-replies).
         enqueueForAutoResponse(decoded);
         headlessPending = true;
       }
@@ -235,7 +236,7 @@ function notifyClosedTargets() {
       // the notice threads into the conversation they opened.
       conversationUuid: p.fromSessionUuid ?? null,
       role: "system",
-      text: `The session "${p.toSession}" you addressed is no longer active; your message was not delivered. Start a new message to reach this agent.`,
+      text: `The session${p.toSession ? ` "${p.toSession}"` : ""} you addressed is no longer active; your message was not delivered. Start a new message to reach this agent.`,
       inReplyTo: p.id,
       auto: true,
       fromSession: "system",

--- a/sdk/plugin-tinyplace/mcp/format.mjs
+++ b/sdk/plugin-tinyplace/mcp/format.mjs
@@ -120,11 +120,12 @@ export function encodeEnvelope(opts) {
     tp: { v: PLUGIN_TP_VERSION, from_session: label },
   };
   if (opts.toSession) envelope.tp.to_session = opts.toSession;
-  // Address a reply to the exact conversation the peer opened: to_session_uuid is the
-  // peer's wrapper_session_id (their per-conversation id), echoed back so their side
-  // routes it to the originating session — immune to label reuse. (The sender's own
-  // conversation id rides in scope.wrapper_session_id above.)
-  if (opts.toSessionUuid) envelope.tp.to_session_uuid = opts.toSessionUuid;
+  // Single shared session id: every message — whoever sends it — carries exactly one
+  // id, in scope.wrapper_session_id (the shared per-thread conversation id). A reply
+  // REUSES the id of the thread it answers (see dispatchSend), so there is no separate
+  // "peer session id" to echo. (Historically tp.to_session_uuid carried the peer's id
+  // back; that dual-id addressing is gone — routing keys on wrapper_session_id alone.
+  // tp.to_session above is an explicit label target, orthogonal to the session id.)
   if (opts.inReplyTo) envelope.tp.in_reply_to = opts.inReplyTo;
   if (opts.auto) envelope.tp.auto = true;
   return JSON.stringify(envelope);

--- a/sdk/plugin-tinyplace/mcp/format.mjs
+++ b/sdk/plugin-tinyplace/mcp/format.mjs
@@ -157,10 +157,10 @@ function decodeEnvelope(obj) {
     // fallback still only catches an OLD body that stored a short label there.
     fromSession: safeLabel(tp.from_session) ?? safeLabel(obj.scope?.wrapper_session_id),
     toSession: safeLabel(tp.to_session),
-    // The sender's per-conversation id is scope.wrapper_session_id (a uuid now);
-    // older peers put a non-uuid there, which safeUuid drops → label routing.
+    // The single shared session id for the thread is scope.wrapper_session_id (a
+    // uuid); a non-uuid there (e.g. a plain harness/label id) is dropped by safeUuid
+    // → label routing. There is no separate peer-id field — one id per message.
     fromSessionUuid: safeUuid(obj.scope?.wrapper_session_id),
-    toSessionUuid: safeUuid(tp.to_session_uuid),
     role,
     envelope: true,
   };
@@ -184,7 +184,7 @@ function decodeLegacyBody(raw) {
       }
     }
   }
-  return { auto, inReplyTo, text, messageId: null, fromSession: null, toSession: null, fromSessionUuid: null, toSessionUuid: null, role: null, envelope: false };
+  return { auto, inReplyTo, text, messageId: null, fromSession: null, toSession: null, fromSessionUuid: null, role: null, envelope: false };
 }
 
 // Build a legacy auto-reply body (auto tag + optional re: header + plaintext).

--- a/sdk/plugin-tinyplace/mcp/registry.mjs
+++ b/sdk/plugin-tinyplace/mcp/registry.mjs
@@ -196,12 +196,17 @@ export function resolveConversationUuid(sessionUuid, peer) {
 export function bindConversationUuid(convUuid, sessionUuid, peer) {
   if (!convUuid || !sessionUuid || !peer) return;
   const path = join(convIdxDir(), encodeURIComponent(convUuid) + ".json");
-  if (readEntryFile(path)?.sessionUuid) return; // already bound — keep the first owner
   try {
     mkdirSync(convIdxDir(), { recursive: true });
-    writeFileSync(path, JSON.stringify({ sessionUuid, peer }) + "\n", { mode: 0o600 });
-  } catch {
-    /* best-effort */
+    const fd = openSync(path, "wx", 0o600); // CAS: create only if absent — first owner wins
+    try {
+      writeSync(fd, JSON.stringify({ sessionUuid, peer }) + "\n");
+    } finally {
+      closeSync(fd);
+    }
+  } catch (e) {
+    if (e?.code === "EEXIST") return; // already bound — keep the first owner (idempotent)
+    /* best-effort otherwise — inbound routing falls back to policy if the write fails */
   }
 }
 

--- a/sdk/plugin-tinyplace/mcp/registry.mjs
+++ b/sdk/plugin-tinyplace/mcp/registry.mjs
@@ -192,7 +192,9 @@ export function sessionUuidForConversation(convUuid) {
 }
 
 // The label of the LIVE local session owning a conversation uuid, or null. Resolves
-// convUuid → sessionUuid (index) → live session (presence).
+// convUuid → sessionUuid (index) → live session (presence). The conversation uuid IS
+// the per-pair session id: a peer (including OpenHuman) that addresses a reply by the
+// id we minted for the pair resolves straight back to the owning local session.
 export function labelForConversationUuid(agentAddress, convUuid) {
   return labelForUuid(agentAddress, sessionUuidForConversation(convUuid));
 }

--- a/sdk/plugin-tinyplace/mcp/registry.mjs
+++ b/sdk/plugin-tinyplace/mcp/registry.mjs
@@ -185,6 +185,26 @@ export function resolveConversationUuid(sessionUuid, peer) {
   return convUuid;
 }
 
+// Adopt a conversation id we did NOT mint — one the PEER opened (their
+// wrapper_session_id) — binding it to the local session now handling the thread.
+// Writes only the reverse index (convUuid → {sessionUuid, peer}); it deliberately
+// does NOT touch the forward `sessionUuid|peer → convUuid` map, so a session can own
+// multiple thread ids for the same peer (each id is one thread) and the forward map
+// keeps naming the id WE'd mint for a fresh thread. Idempotent: never clobbers an
+// existing binding (the minter/first adopter wins), so re-adoption on every reply is a
+// cheap no-op. Best-effort — inbound routing falls back to policy if the write fails.
+export function bindConversationUuid(convUuid, sessionUuid, peer) {
+  if (!convUuid || !sessionUuid || !peer) return;
+  const path = join(convIdxDir(), encodeURIComponent(convUuid) + ".json");
+  if (readEntryFile(path)?.sessionUuid) return; // already bound — keep the first owner
+  try {
+    mkdirSync(convIdxDir(), { recursive: true });
+    writeFileSync(path, JSON.stringify({ sessionUuid, peer }) + "\n", { mode: 0o600 });
+  } catch {
+    /* best-effort */
+  }
+}
+
 // Reverse: the sessionUuid that owns a conversation uuid (or null for an unknown one).
 export function sessionUuidForConversation(convUuid) {
   if (!convUuid) return null;

--- a/sdk/plugin-tinyplace/mcp/routing.mjs
+++ b/sdk/plugin-tinyplace/mcp/routing.mjs
@@ -54,10 +54,19 @@ export function routeTarget({ toSession, liveLabels, primary, policy = "primary"
 // addressed a session UUID, deliver ONLY to the live session that actually owns it —
 // never to a reused label slot; no live owner → unrouted (held). Falls back to the
 // label/policy routing when there's no UUID (older peers, untargeted mail).
-function resolveBound(agentAddress, { toSession, toSessionUuid }, { liveList, primary, policy }) {
+function resolveBound(agentAddress, { toSession, toSessionUuid, fromSessionUuid }, { liveList, primary, policy }) {
   if (toSessionUuid) {
     const label = labelForConversationUuid(agentAddress, toSessionUuid);
     return label ? { kind: "session", labels: [label] } : { kind: "unrouted" };
+  }
+  // Some peers (e.g. OpenHuman) address a reply by the per-pair session id itself —
+  // the conversation uuid WE minted for the pair — carried in wrapper_session_id
+  // (decoded as fromSessionUuid), with no separate to_session_uuid. Resolve it
+  // through our conversation index. It matches ONLY ids we minted, so an ordinary
+  // peer's own wrapper convUuid (not in our index) falls through to policy routing.
+  if (fromSessionUuid) {
+    const label = labelForConversationUuid(agentAddress, fromSessionUuid);
+    if (label) return { kind: "session", labels: [label] };
   }
   return routeTarget({ toSession, liveLabels: liveList, primary, policy });
 }

--- a/sdk/plugin-tinyplace/mcp/routing.mjs
+++ b/sdk/plugin-tinyplace/mcp/routing.mjs
@@ -4,7 +4,7 @@
 import { mkdirSync, writeFileSync, readdirSync, readFileSync, renameSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-import { sessionsDir, liveSessions, primarySession, labelForConversationUuid } from "./registry.mjs";
+import { sessionsDir, liveSessions, primarySession, labelForConversationUuid, sessionUuidForConversation } from "./registry.mjs";
 
 // No-target delivery policy (TINYPLACE_UNROUTED_POLICY): primary (default),
 // broadcast (fan out to all live), or drop.
@@ -54,19 +54,16 @@ export function routeTarget({ toSession, liveLabels, primary, policy = "primary"
 // addressed a session UUID, deliver ONLY to the live session that actually owns it —
 // never to a reused label slot; no live owner → unrouted (held). Falls back to the
 // label/policy routing when there's no UUID (older peers, untargeted mail).
-function resolveBound(agentAddress, { toSession, toSessionUuid, fromSessionUuid }, { liveList, primary, policy }) {
-  if (toSessionUuid) {
-    const label = labelForConversationUuid(agentAddress, toSessionUuid);
-    return label ? { kind: "session", labels: [label] } : { kind: "unrouted" };
-  }
-  // Some peers (e.g. OpenHuman) address a reply by the per-pair session id itself —
-  // the conversation uuid WE minted for the pair — carried in wrapper_session_id
-  // (decoded as fromSessionUuid), with no separate to_session_uuid. Resolve it
-  // through our conversation index. It matches ONLY ids we minted, so an ordinary
-  // peer's own wrapper convUuid (not in our index) falls through to policy routing.
+function resolveBound(agentAddress, { toSession, fromSessionUuid }, { liveList, primary, policy }) {
+  // Every message carries ONE shared session id: the thread's conversation uuid, in
+  // wrapper_session_id (decoded as fromSessionUuid). Resolve it through our index.
   if (fromSessionUuid) {
     const label = labelForConversationUuid(agentAddress, fromSessionUuid);
-    if (label) return { kind: "session", labels: [label] };
+    if (label) return { kind: "session", labels: [label] }; // owner live → deliver
+    // A convUuid WE minted/adopted but whose owner is offline names a SPECIFIC,
+    // now-closed session — hold it (reuse-proof), never misdeliver to another live
+    // session via policy. Only a truly unknown id falls through to policy routing.
+    if (sessionUuidForConversation(fromSessionUuid)) return { kind: "unrouted" };
   }
   return routeTarget({ toSession, liveLabels: liveList, primary, policy });
 }
@@ -96,7 +93,6 @@ export function enqueueRouted(agentAddress, decoded, { policy = unroutedPolicy()
     text: decoded.text,
     inReplyTo: decoded.inReplyTo ?? null,
     toSession: decoded.toSession ?? null,
-    toSessionUuid: decoded.toSessionUuid ?? null,
     ts: decoded.ts ?? new Date().toISOString(),
   };
   const written = [];
@@ -176,11 +172,15 @@ export function reapClosedTargets(agentAddress, { graceMs = CLOSED_GRACE_MS } = 
     } catch {
       continue;
     }
-    if (!payload.toSession && !payload.toSessionUuid) continue; // untargeted → not a "closed session" case
-    // Is the addressed session still reachable? Prefer the UUID (a match is the SAME
-    // session, never a reused label); fall back to the label for older peers.
-    const stillLive = payload.toSessionUuid
-      ? Boolean(labelForConversationUuid(agentAddress, payload.toSessionUuid))
+    // Was this addressed to a SPECIFIC session (now gone), vs merely "no live
+    // session right now"? A known shared id (a convUuid in our index) names a
+    // specific thread; an explicit toSession names a specific label.
+    const knownConv = payload.fromSessionUuid && Boolean(sessionUuidForConversation(payload.fromSessionUuid));
+    if (!payload.toSession && !knownConv) continue; // untargeted → not a "closed session" case
+    // Is the addressed session still reachable? Prefer the shared id (a match is the
+    // SAME session, never a reused label); fall back to the explicit label.
+    const stillLive = knownConv
+      ? Boolean(labelForConversationUuid(agentAddress, payload.fromSessionUuid))
       : live.has(payload.toSession);
     if (stillLive) continue; // target is live → let redelivery handle it
     if (now - mtimeMs < graceMs) continue; // still within the grace window

--- a/sdk/plugin-tinyplace/mcp/server.mjs
+++ b/sdk/plugin-tinyplace/mcp/server.mjs
@@ -49,6 +49,7 @@ import {
   gcStale,
   resolveSessionUuid,
   resolveConversationUuid,
+  bindConversationUuid,
 } from "./registry.mjs";
 import { loadWallets, saveWallets } from "./wallets.mjs";
 import { drainInbox, redeliverUnrouted } from "./routing.mjs";
@@ -322,10 +323,10 @@ async function maybeRecoverSession(peer) {
 // a daemon-mode sender's reply still matches a self-mode receiver's echo. In
 // daemon mode the send is deferred to the daemon (single ratchet writer) via an
 // outbox job; in self mode we send directly. Returns { id, via }.
-// The peer conversation id to address a reply to: the from_session_uuid of the
-// buffered message we're replying to (correlated by in_reply_to). Lets a reply route
-// to the exact session that opened the thread WITHOUT the model handling uuids. Null
-// (→ fall back to label routing) if the original was already drained from the buffer.
+// The shared session id of the thread we're replying to: the wrapper_session_id of the
+// message being answered (correlated by in_reply_to). dispatchSend REUSES it as our own
+// wrapper_session_id, so both peers key the thread on ONE id WITHOUT the model handling
+// uuids. Null (→ mint a fresh id for a new thread) if the original already drained.
 function replyConvUuid(inReplyTo) {
   if (!inReplyTo || !session) return null;
   // Prefer the durable map (survives an inbox drain); fall back to a still-buffered msg.
@@ -335,17 +336,21 @@ function replyConvUuid(inReplyTo) {
 async function dispatchSend({ to, text, role, toSession, toSessionUuid, inReplyTo, auto }) {
   const s = requireActive();
   const id = newMessageId();
-  // This session's per-conversation id with `to` (minted once, stable) → wire as
-  // wrapper_session_id so the peer's reply routes back to us reuse-proof.
-  const conversationUuid = resolveConversationUuid(s.sessionUuid, to);
-  // Address the peer's conversation (explicit arg, else echo the replied-to message's).
-  const peerConvUuid = toSessionUuid ?? replyConvUuid(inReplyTo);
+  // Single shared session id per thread. A reply REUSES the id of the thread it
+  // answers — the peer's wrapper_session_id, carried as `toSessionUuid` on an
+  // explicitly-targeted reply or resolved from the replied-to message — so both
+  // sides key the conversation on the SAME id. Only a brand-new thread WE open mints
+  // a fresh id. It rides in scope.wrapper_session_id; there is no separate peer-id echo.
+  const threadUuid = toSessionUuid ?? replyConvUuid(inReplyTo);
+  const conversationUuid = threadUuid ?? resolveConversationUuid(s.sessionUuid, to);
+  // Adopt a peer-opened thread id into our conversation index so later inbound
+  // messages on it route to THIS session deterministically (not just via primary policy).
+  if (threadUuid) bindConversationUuid(threadUuid, s.sessionUuid, to);
   if (s.mode === "daemon") {
     writeOutboxJob(s.address, {
       id,
       to,
       toSession: toSession ?? null,
-      toSessionUuid: peerConvUuid ?? null,
       conversationUuid: conversationUuid ?? null,
       role: role ?? null,
       text,
@@ -362,7 +367,6 @@ async function dispatchSend({ to, text, role, toSession, toSessionUuid, inReplyT
     text,
     role,
     toSession,
-    toSessionUuid: peerConvUuid,
     conversationUuid,
     inReplyTo,
     auto,
@@ -407,8 +411,9 @@ async function buildClient(seedHex) {
 //   "auto"           — an auto-tagged reply; buffered only (loop guard: never answered)
 //   "needs-response" — a fresh peer DM buffered and awaiting a reply
 function deliverToSession(msg, { auto }) {
-  // Remember the sender's conversation uuid keyed by message id, so a later reply
-  // (in_reply_to) can echo it as to_session_uuid even after `inbox` drained buffer.
+  // Remember the thread's shared session id (the sender's wrapper_session_id) keyed by
+  // message id, so a later reply (in_reply_to) REUSES it as our own wrapper_session_id
+  // even after `inbox` drained the buffer — one shared id per thread, both directions.
   if (msg.fromSessionUuid && msg.id != null) {
     session.convByMsgId.set(String(msg.id), msg.fromSessionUuid);
     if (session.convByMsgId.size > 500) session.convByMsgId.delete(session.convByMsgId.keys().next().value);

--- a/sdk/plugin-tinyplace/mcp/server.mjs
+++ b/sdk/plugin-tinyplace/mcp/server.mjs
@@ -333,15 +333,14 @@ function replyConvUuid(inReplyTo) {
   return session.convByMsgId.get(String(inReplyTo)) ?? session.buffer.find((m) => String(m.id) === String(inReplyTo))?.fromSessionUuid ?? null;
 }
 
-async function dispatchSend({ to, text, role, toSession, toSessionUuid, inReplyTo, auto }) {
+async function dispatchSend({ to, text, role, toSession, inReplyTo, auto }) {
   const s = requireActive();
   const id = newMessageId();
   // Single shared session id per thread. A reply REUSES the id of the thread it
-  // answers — the peer's wrapper_session_id, carried as `toSessionUuid` on an
-  // explicitly-targeted reply or resolved from the replied-to message — so both
-  // sides key the conversation on the SAME id. Only a brand-new thread WE open mints
-  // a fresh id. It rides in scope.wrapper_session_id; there is no separate peer-id echo.
-  const threadUuid = toSessionUuid ?? replyConvUuid(inReplyTo);
+  // answers (resolved from the replied-to message via in_reply_to) so both sides key
+  // the conversation on the SAME id. Only a brand-new thread WE open mints a fresh id.
+  // It rides in scope.wrapper_session_id; there is no separate peer-id echo.
+  const threadUuid = replyConvUuid(inReplyTo);
   const conversationUuid = threadUuid ?? resolveConversationUuid(s.sessionUuid, to);
   // Adopt a peer-opened thread id into our conversation index so later inbound
   // messages on it route to THIS session deterministically (not just via primary policy).

--- a/sdk/plugin-tinyplace/registry-test.mjs
+++ b/sdk/plugin-tinyplace/registry-test.mjs
@@ -129,6 +129,25 @@ const again = reg.claimLabel(F, { harnessSessionId: "restart-me" });
 expect("claimLabel reuses same label for same harnessSessionId", again.label === "worker");
 expect("no duplicate label files after reclaim", reg.readSessions(F).filter((e) => e.label === "worker").length === 1);
 
+// ── bindConversationUuid: adopt a PEER-minted thread id (single shared id) ─────
+// A peer (e.g. OpenHuman) opens a thread with ITS wrapper_session_id "S". We never
+// minted it, so it isn't in our forward map — but once a local session replies on it
+// we bind it, and subsequent inbound "S" routes straight to that session.
+const G = "AgentGGGGGGGGGGGGGGGGGGGGGGGGGGGG";
+reg.writePresence(G, { label: "codex:1", harnessSessionId: "HG1", cwd: "/x", startedAt: now() });
+const suG = reg.resolveSessionUuid("HG1");
+reg.bindConversationUuid("peer-thread-S", suG, "openhuman");
+expect("adopted peer id resolves to its owning sessionUuid", reg.sessionUuidForConversation("peer-thread-S") === suG);
+expect("adopted peer id routes to the bound live session", reg.labelForConversationUuid(G, "peer-thread-S") === "codex:1");
+// Idempotent: re-adopting (every reply calls it) must NOT clobber the first owner.
+reg.bindConversationUuid("peer-thread-S", "some-other-sessionuuid", "openhuman");
+expect("bindConversationUuid keeps the first owner (idempotent)", reg.sessionUuidForConversation("peer-thread-S") === suG);
+// Unknown / empty ids: no route, no write, no throw.
+expect("unknown conversation id → null label", reg.labelForConversationUuid(G, "never-seen") === null);
+reg.bindConversationUuid("", suG, "openhuman");
+reg.bindConversationUuid("x", "", "openhuman");
+expect("bindConversationUuid no-ops on missing args", reg.sessionUuidForConversation("") === null);
+
 const failed = checks.filter((c) => !c.ok);
 console.log("\n" + (failed.length === 0 ? `ALL ${checks.length} CHECKS PASSED ✅` : `${failed.length} FAILED ❌`));
 process.exit(failed.length === 0 ? 0 : 1);

--- a/sdk/plugin-tinyplace/routing-test.mjs
+++ b/sdk/plugin-tinyplace/routing-test.mjs
@@ -100,11 +100,14 @@ const suE1 = reg.resolveSessionUuid("he1"); // codex:1's durable session anchor
 const convE = reg.resolveConversationUuid(suE1, "peerE"); // its wire-visible conversation id
 expect("resolveConversationUuid mints a uuid, indexed to the session", reg.sessionUuidForConversation(convE) === suE1);
 expect("resolveConversationUuid is idempotent per (session,peer)", reg.resolveConversationUuid(suE1, "peerE") === convE);
-const er1 = routing.enqueueRouted(E, { id: "e1", from: "peerE", text: "by conv uuid", toSession: "codex:1", toSessionUuid: convE });
-expect("conversation uuid of a live session → routed to its label", er1.target.kind === "session" && er1.target.labels[0] === "codex:1");
-const er2 = routing.enqueueRouted(E, { id: "e2", from: "peerE", text: "ghost", toSession: "codex:1", toSessionUuid: "00000000-0000-0000-0000-000000000000" });
-expect("unknown conversation uuid → unrouted even though the label is live", er2.target.kind === "unrouted");
-expect("no leak: live codex:1 did not get the unknown-uuid message", !existsSync(join(routing.sessionInboxDir(E, "codex:1"), "e2.json")));
+// A reply echoing the shared id (wrapper_session_id → fromSessionUuid) of a LIVE
+// session is delivered to it.
+const er1 = routing.enqueueRouted(E, { id: "e1", from: "peerE", text: "by shared id", fromSessionUuid: convE });
+expect("shared session id of a live session → routed to its label", er1.target.kind === "session" && er1.target.labels[0] === "codex:1");
+// An id we never minted (a brand-new thread) isn't in our index → it falls through to
+// policy routing (default primary → the live codex:1): first-contact delivery.
+const er2 = routing.enqueueRouted(E, { id: "e2", from: "peerE", text: "new thread", fromSessionUuid: "00000000-0000-0000-0000-000000000000" });
+expect("unknown shared id → falls through to policy (primary), not held", er2.target.kind === "session" && er2.target.labels[0] === "codex:1");
 
 // ── per-pair session-id routing (a peer like OpenHuman addresses a reply by the
 //    per-pair session id WE minted — the conversation uuid — carried back in
@@ -129,8 +132,10 @@ const suOld = reg.resolveSessionUuid("old-sess");
 const convOld = reg.resolveConversationUuid(suOld, "peerF"); // the old session's conversation with peerF
 reg.removePresence(F, "codex:1"); // old session closes → codex:1 frees
 reg.writePresence(F, { label: "codex:1", harnessSessionId: "new-sess", cwd: "/w", startedAt: new Date().toISOString() }); // stranger takes codex:1
-const fr = routing.enqueueRouted(F, { id: "f1", from: "peerF", text: "for the old one", toSession: "codex:1", toSessionUuid: convOld });
-expect("label reuse: old conversation uuid is NOT delivered to the reused label", fr.target.kind === "unrouted");
+// The peer echoes the OLD session's shared id; its owner is gone and the label was
+// reused by a stranger. Known-but-offline id → held (P1), never misdelivered.
+const fr = routing.enqueueRouted(F, { id: "f1", from: "peerF", text: "for the old one", fromSessionUuid: convOld });
+expect("label reuse: a shared id whose owner is gone is NOT delivered to the reused label", fr.target.kind === "unrouted");
 expect("reused codex:1 inbox did not receive the old thread", !existsSync(join(routing.sessionInboxDir(F, "codex:1"), "f1.json")));
 spawnSync("sleep", ["0.05"]);
 const fReap = routing.reapClosedTargets(F, { graceMs: 10 });

--- a/sdk/plugin-tinyplace/routing-test.mjs
+++ b/sdk/plugin-tinyplace/routing-test.mjs
@@ -106,6 +106,22 @@ const er2 = routing.enqueueRouted(E, { id: "e2", from: "peerE", text: "ghost", t
 expect("unknown conversation uuid → unrouted even though the label is live", er2.target.kind === "unrouted");
 expect("no leak: live codex:1 did not get the unknown-uuid message", !existsSync(join(routing.sessionInboxDir(E, "codex:1"), "e2.json")));
 
+// ── per-pair session-id routing (a peer like OpenHuman addresses a reply by the
+//    per-pair session id WE minted — the conversation uuid — carried back in
+//    wrapper_session_id / fromSessionUuid, with no separate to_session_uuid) ────
+const H = "AgentHHHHHHHHHHHHHHHHHHHHHHHHHHHH";
+reg.writePresence(H, { label: "codex:1", harnessSessionId: "hH1", cwd: "/w", startedAt: new Date().toISOString() });
+const suH1 = reg.resolveSessionUuid("hH1");
+const sid = reg.resolveConversationUuid(suH1, "openhuman"); // the per-pair session id we minted
+// The peer echoes that same per-pair id back in wrapper_session_id (→ fromSessionUuid).
+const hr1 = routing.enqueueRouted(H, { id: "h1s", from: "openhuman", text: "reply", fromSessionUuid: sid });
+expect("per-pair session id (no to_session) → routed to its session", hr1.target.kind === "session" && hr1.target.labels[0] === "codex:1");
+expect("per-pair reply landed in codex:1 inbox", existsSync(join(routing.sessionInboxDir(H, "codex:1"), "h1s.json")));
+// An id we never minted isn't in our conversation index → the per-pair path is a
+// no-op and the message falls through to normal policy routing (here `drop`).
+const hr2 = routing.enqueueRouted(H, { id: "h2s", from: "openhuman", text: "ghost", fromSessionUuid: "99999999-9999-9999-9999-999999999999" }, { policy: "drop" });
+expect("unknown id → not hijacked by the per-pair path (falls through to policy)", hr2.target.kind === "drop");
+
 // The crux: a label reused by a DIFFERENT session must not inherit the old thread.
 const F = "AgentFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 reg.writePresence(F, { label: "codex:1", harnessSessionId: "old-sess", cwd: "/w", startedAt: new Date().toISOString() });


### PR DESCRIPTION
## Summary

The plugin resolves a reply to a local session only through the per-conversation `convUuid` index. A peer that keys on **one common session id** — e.g. OpenHuman stores our `scope.harness_session_id` and carries that same id in the reply's `wrapper_session_id`, with **no** per-conversation `to_session_uuid` — misses that index, so the message falls through to primary/unrouted (and never threads back to the originating session).

There is no separate from/to session identity here: both sides key on the **one** shared `harness_session_id`.

## Fix

- `peekSessionUuidForHarness(id)` — a **read-only** reverse of `resolveSessionUuid`; unlike it, **never mints**, so an unknown/attacker-supplied id can't create a binding during inbound routing.
- `labelForSharedSessionId(agent, id)` — resolves a shared session id to the owning **live** local session.
- In `resolveBound`, when there's no `to_session_uuid`, route by the common session id carried in `fromSessionUuid` (`wrapper_session_id`). It matches **only our own** sessions, so an ordinary peer's wrapper `convUuid` (not one of our harness ids) resolves to null and falls through to the existing label/policy routing — unchanged.

Backward compatible: the `convUuid`/`to_session_uuid` path is tried first and untouched.

## Tests

`routing-test.mjs`: shared id → routed to its session + landed in the right inbox; `labelForSharedSessionId` resolves the live label; an unknown id is **not** hijacked (falls through to policy); `peek` of an unknown id returns null (no mint). **42/42 routing + 25/25 registry checks pass.**

## Context

Pairs with OpenHuman: its `SessionEnvelopeV1` already carries the one common id in `scope.harness_session_id`/`wrapper_session_id` — no extra `tp`/to/from fields needed. Useful on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded message routing to follow a shared conversation/thread ID across sessions, improving reply continuity.
  * Added the ability to adopt conversation IDs created by a peer to preserve ongoing threads.
* **Bug Fixes**
  * Improved routing when only a sender session identifier is available.
  * Kept closed-session notices and reply threading consistent under the new shared-thread model.
  * Prevented misdelivery and improved fallback behavior for unknown conversation IDs.
* **Tests**
  * Expanded/updated routing, envelope, and registry coverage for the new identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->