### PR TITLE
feat(cli): typed v2 harness session-event stream (capture + status + consumer + hooks)

### DIFF
--- a/sdk/typescript/src/cli/harness-consumer.ts
+++ b/sdk/typescript/src/cli/harness-consumer.ts
@@ -27,13 +27,38 @@ export function parseSessionEnvelope(
     return undefined;
   }
   const version = (record as { envelope_version?: unknown }).envelope_version;
-  if (
-    version === SESSION_ENVELOPE_VERSION_V2 ||
-    version === SESSION_ENVELOPE_VERSION_V1
-  ) {
+  // Inbound Signal DMs are untrusted: a version-tagged body with a missing or
+  // malformed `event` must be DROPPED, not cast through — otherwise the seq
+  // reads in applySessionEnvelope/foldSessionEnvelopes throw on `event.seq` and
+  // take down the whole fold. Shape-check the v2 event before trusting it.
+  if (version === SESSION_ENVELOPE_VERSION_V2) {
+    return hasUsableV2Event(record) ? (record as AnySessionEnvelope) : undefined;
+  }
+  if (version === SESSION_ENVELOPE_VERSION_V1) {
     return record as AnySessionEnvelope;
   }
   return undefined;
+}
+
+/**
+ * A v2 envelope is only foldable if it carries an `event` with a numeric `seq`
+ * and a string `id` — the two fields the fold reads. Both the parser and the
+ * fold path gate on this so a malformed body is dropped rather than throwing,
+ * whether it arrives via parseSessionEnvelope or is passed in pre-parsed.
+ */
+function hasUsableV2Event(envelope: unknown): boolean {
+  if (
+    envelope === null ||
+    typeof envelope !== "object" ||
+    (envelope as { envelope_version?: unknown }).envelope_version !==
+      SESSION_ENVELOPE_VERSION_V2
+  ) {
+    return false;
+  }
+  const event = (envelope as { event?: { seq?: unknown; id?: unknown } }).event;
+  return (
+    !!event && typeof event.seq === "number" && typeof event.id === "string"
+  );
 }
 
 export function isV2(
@@ -108,7 +133,7 @@ export function applySessionEnvelope(
   envelope: AnySessionEnvelope,
   limits: SessionViewLimits = DEFAULT_LIMITS,
 ): SessionView {
-  if (!isV2(envelope)) {
+  if (!isV2(envelope) || !hasUsableV2Event(envelope)) {
     return view;
   }
   const { event } = envelope;
@@ -140,6 +165,7 @@ export function foldSessionEnvelopes(
 ): SessionView {
   return [...envelopes]
     .filter(isV2)
+    .filter(hasUsableV2Event)
     .sort((a, b) => a.event.seq - b.event.seq)
     .reduce(
       (view, envelope) => applySessionEnvelope(view, envelope, limits),

--- a/sdk/typescript/src/cli/harness-consumer.ts
+++ b/sdk/typescript/src/cli/harness-consumer.ts
@@ -1,0 +1,254 @@
+// Consumer side of the v2 harness stream.
+//
+// The wrapper publishes SessionEnvelopeV2 packets over Signal DM; a receiver
+// (OpenHuman's Master Session, or any consumer) needs to fold that stream back
+// into live per-session state: what provider it is, what it's doing right now,
+// which tools ran, and a capped transcript feed. This module is that fold —
+// pure and framework-agnostic, so the receiver just parses each DM body and
+// applies it. UI/rendering lives downstream; this only maintains state.
+
+import {
+  SESSION_ENVELOPE_VERSION_V1,
+  SESSION_ENVELOPE_VERSION_V2,
+  type AnySessionEnvelope,
+  type HarnessProvider,
+  type HarnessSessionState,
+  type HarnessToolKind,
+  type SessionEnvelopeV2,
+} from "../types/harness.js";
+
+/** Safely decode a DM body into a typed envelope, or undefined if it is not one. */
+export function parseSessionEnvelope(
+  body: unknown,
+): AnySessionEnvelope | undefined {
+  const record =
+    typeof body === "string" ? tryParse(body) : (body as unknown);
+  if (!record || typeof record !== "object") {
+    return undefined;
+  }
+  const version = (record as { envelope_version?: unknown }).envelope_version;
+  if (
+    version === SESSION_ENVELOPE_VERSION_V2 ||
+    version === SESSION_ENVELOPE_VERSION_V1
+  ) {
+    return record as AnySessionEnvelope;
+  }
+  return undefined;
+}
+
+export function isV2(
+  envelope: AnySessionEnvelope,
+): envelope is SessionEnvelopeV2 {
+  return envelope.envelope_version === SESSION_ENVELOPE_VERSION_V2;
+}
+
+/** One tool invocation and (once it lands) its result. */
+export interface ToolActivity {
+  callId: string;
+  toolName: string;
+  toolKind: HarnessToolKind;
+  display: string;
+  startedSeq: number;
+  done: boolean;
+  ok?: boolean;
+  isError?: boolean;
+  outputBytes?: number;
+}
+
+/** One entry in the capped human-readable feed. */
+export interface FeedEntry {
+  seq: number;
+  ts: string;
+  role: "owner" | "agent";
+  kind: string;
+  text: string;
+}
+
+/** Live state for a single agent session — the Master Session's per-instance row. */
+export interface SessionView {
+  provider?: HarnessProvider;
+  wrapperSessionId?: string;
+  harnessSessionId?: string;
+  cwd?: string;
+  status: HarnessSessionState;
+  currentTask: string;
+  lastSeq: number;
+  lastEventId?: string;
+  lastActivityTs?: string;
+  /** most-recent tool activity, newest last, capped. */
+  tools: Array<ToolActivity>;
+  /** most-recent feed entries, newest last, capped. */
+  feed: Array<FeedEntry>;
+}
+
+export interface SessionViewLimits {
+  tools: number;
+  feed: number;
+}
+
+const DEFAULT_LIMITS: SessionViewLimits = { tools: 50, feed: 200 };
+
+export function initialSessionView(): SessionView {
+  return {
+    status: "idle",
+    currentTask: "idle",
+    lastSeq: -1,
+    tools: [],
+    feed: [],
+  };
+}
+
+/**
+ * Fold one envelope into the view. Ignores v1 (no typed events), out-of-order /
+ * duplicate packets (seq must advance), and returns the SAME reference when
+ * nothing changed so consumers can cheaply skip re-render.
+ */
+export function applySessionEnvelope(
+  view: SessionView,
+  envelope: AnySessionEnvelope,
+  limits: SessionViewLimits = DEFAULT_LIMITS,
+): SessionView {
+  if (!isV2(envelope)) {
+    return view;
+  }
+  const { event } = envelope;
+  if (event.seq <= view.lastSeq) {
+    return view; // duplicate or out-of-order resend
+  }
+
+  const next: SessionView = {
+    ...view,
+    provider: envelope.harness.provider,
+    wrapperSessionId: envelope.scope.wrapper_session_id,
+    harnessSessionId: envelope.scope.harness_session_id,
+    cwd: envelope.scope.cwd,
+    lastSeq: event.seq,
+    lastEventId: event.id,
+    lastActivityTs: event.ts,
+    tools: view.tools,
+    feed: view.feed,
+  };
+
+  applyEvent(next, envelope, limits);
+  return next;
+}
+
+/** Convenience: fold a batch (applied in seq order defensively). */
+export function foldSessionEnvelopes(
+  envelopes: Array<AnySessionEnvelope>,
+  limits: SessionViewLimits = DEFAULT_LIMITS,
+): SessionView {
+  return [...envelopes]
+    .filter(isV2)
+    .sort((a, b) => a.event.seq - b.event.seq)
+    .reduce(
+      (view, envelope) => applySessionEnvelope(view, envelope, limits),
+      initialSessionView(),
+    );
+}
+
+function applyEvent(
+  view: SessionView,
+  envelope: SessionEnvelopeV2,
+  limits: SessionViewLimits,
+): void {
+  const { event } = envelope;
+  switch (event.kind) {
+    case "tool_call": {
+      const activity: ToolActivity = {
+        callId: event.payload.call_id,
+        toolName: event.payload.tool_name,
+        toolKind: event.payload.tool_kind,
+        display: event.payload.display,
+        startedSeq: event.seq,
+        done: false,
+      };
+      view.tools = capEnd([...view.tools, activity], limits.tools);
+      view.status = "running_tool";
+      view.currentTask = `${event.payload.tool_name}: ${event.payload.display}`;
+      pushFeed(view, envelope, event.payload.display, limits.feed);
+      break;
+    }
+    case "tool_result": {
+      view.tools = view.tools.map((tool) =>
+        tool.callId === event.payload.call_id && !tool.done
+          ? {
+              ...tool,
+              done: true,
+              ok: event.payload.ok,
+              isError: event.payload.is_error,
+              outputBytes: event.payload.output_bytes,
+            }
+          : tool,
+      );
+      pushFeed(
+        view,
+        envelope,
+        event.payload.is_error ? "error" : "ok",
+        limits.feed,
+      );
+      break;
+    }
+    case "status": {
+      view.status = event.payload.state;
+      view.currentTask = event.payload.detail;
+      break;
+    }
+    case "approval_request": {
+      view.status = "waiting_approval";
+      view.currentTask = `approval: ${event.payload.display}`;
+      pushFeed(view, envelope, event.payload.display, limits.feed);
+      break;
+    }
+    case "error": {
+      if (event.payload.fatal) {
+        view.status = "errored";
+      }
+      pushFeed(view, envelope, event.payload.message, limits.feed);
+      break;
+    }
+    case "lifecycle": {
+      if (event.payload.phase === "session_end") {
+        view.status = "stopped";
+        view.currentTask = "stopped";
+      }
+      break;
+    }
+    case "user_prompt":
+    case "agent_message":
+    case "agent_thinking": {
+      pushFeed(view, envelope, event.payload.text, limits.feed);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function pushFeed(
+  view: SessionView,
+  envelope: SessionEnvelopeV2,
+  text: string,
+  cap: number,
+): void {
+  const entry: FeedEntry = {
+    seq: envelope.event.seq,
+    ts: envelope.event.ts,
+    role: envelope.event.role,
+    kind: envelope.event.kind,
+    text,
+  };
+  view.feed = capEnd([...view.feed, entry], cap);
+}
+
+function capEnd<T>(items: Array<T>, cap: number): Array<T> {
+  return items.length > cap ? items.slice(items.length - cap) : items;
+}
+
+function tryParse(body: string): unknown {
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}

--- a/sdk/typescript/src/cli/harness-envelope.ts
+++ b/sdk/typescript/src/cli/harness-envelope.ts
@@ -1,0 +1,127 @@
+// Builds a v2 SessionEnvelope from a parsed semantic event.
+//
+// Kept separate from the tailer so it is pure and unit-testable, and so it does
+// not collide with the in-flight bridge/tui work in `harness-wrapper.ts`. The
+// tailer already assembles these exact context fields for the v1 envelope; this
+// builder mirrors them, so wiring it in later is close to a 1:1 swap of the
+// `message`+`source` block for the typed `event` block.
+
+import { createHash } from "node:crypto";
+import type {
+  HarnessBucketUnit,
+  HarnessEnvelopeScope,
+  HarnessProvider,
+  SessionEnvelopeV2,
+} from "../types/harness.js";
+import {
+  SESSION_ENVELOPE_VERSION_V2,
+} from "../types/harness.js";
+import type { HarnessSemanticEvent } from "./harness-events.js";
+
+export interface EnvelopeContext {
+  provider: HarnessProvider;
+  command: string;
+  argv: Array<string>;
+  scopeType: HarnessEnvelopeScope;
+  scopeKey: string;
+  cwd: string;
+  wrapperSessionId: string;
+  harnessSessionId: string;
+  bucketUnit: HarnessBucketUnit;
+  /** transcript file the event was read from (for source.path). */
+  sourcePath: string;
+  turnId?: string;
+  model?: string;
+}
+
+export function buildEventEnvelopeV2(
+  ctx: EnvelopeContext,
+  semantic: HarnessSemanticEvent,
+  seq: number,
+): SessionEnvelopeV2 {
+  const at = usableDate(semantic.timestamp);
+  const start = floorBucket(at, ctx.bucketUnit);
+  const end = addBucket(start, ctx.bucketUnit);
+  const id = stableEventId(
+    ctx.wrapperSessionId,
+    semantic.recordType,
+    seq,
+    semantic.event.kind,
+  );
+
+  return {
+    envelope_version: SESSION_ENVELOPE_VERSION_V2,
+    version: 2,
+    bucket: {
+      unit: ctx.bucketUnit,
+      start: start.toISOString(),
+      end: end.toISOString(),
+    },
+    scope: {
+      type: ctx.scopeType,
+      key: ctx.scopeKey,
+      cwd: ctx.cwd,
+      wrapper_session_id: ctx.wrapperSessionId,
+      harness_session_id: ctx.harnessSessionId,
+    },
+    harness: {
+      provider: ctx.provider,
+      command: ctx.command,
+      argv: ctx.argv,
+    },
+    event: {
+      id,
+      seq,
+      ts: at.toISOString(),
+      ...(ctx.turnId ? { turn_id: ctx.turnId } : {}),
+      ...(ctx.model ? { model: ctx.model } : {}),
+      ...semantic.event,
+    },
+    source: {
+      path: ctx.sourcePath,
+      record_type: semantic.recordType,
+    },
+  };
+}
+
+function stableEventId(
+  wrapperSessionId: string,
+  recordType: string,
+  seq: number,
+  kind: string,
+): string {
+  return createHash("sha256")
+    .update(`${wrapperSessionId}\0${recordType}\0${seq}\0${kind}`)
+    .digest("hex");
+}
+
+function usableDate(value: Date): Date {
+  const ms = value.getTime();
+  return Number.isNaN(ms) || ms === 0 ? new Date() : value;
+}
+
+function floorBucket(value: Date, unit: HarnessBucketUnit): Date {
+  const out = new Date(value);
+  out.setUTCSeconds(0, 0);
+  if (unit === "minute") {
+    return out;
+  }
+  out.setUTCMinutes(0, 0, 0);
+  if (unit === "hour") {
+    return out;
+  }
+  out.setUTCHours(0, 0, 0, 0);
+  return out;
+}
+
+function addBucket(value: Date, unit: HarnessBucketUnit): Date {
+  const out = new Date(value);
+  if (unit === "minute") {
+    out.setUTCMinutes(out.getUTCMinutes() + 1);
+  } else if (unit === "hour") {
+    out.setUTCHours(out.getUTCHours() + 1);
+  } else {
+    out.setUTCDate(out.getUTCDate() + 1);
+  }
+  return out;
+}

--- a/sdk/typescript/src/cli/harness-envelope.ts
+++ b/sdk/typescript/src/cli/harness-envelope.ts
@@ -84,6 +84,11 @@ export function buildEventEnvelopeV2(
   };
 }
 
+// Deterministic id scoped to (wrapperSessionId, recordType, seq, kind) — NOT a
+// content hash of the payload. It is stable for a given event within one wrapper
+// run (so a resend carries the same id and the consumer dedups), and unique
+// across runs because wrapperSessionId is freshly minted per process — so seq
+// restarting at 0 after a relaunch cannot collide with a prior run's ids.
 function stableEventId(
   wrapperSessionId: string,
   recordType: string,

--- a/sdk/typescript/src/cli/harness-events.ts
+++ b/sdk/typescript/src/cli/harness-events.ts
@@ -572,11 +572,16 @@ function parseJsonObject(raw: string): Record<string, unknown> | undefined {
 }
 
 function parseTimestamp(value: unknown): Date {
+  // Default missing/invalid timestamps to receive time, not the Unix epoch.
+  // reduceStatus consumes this semantic timestamp; an epoch value never advances
+  // the activity clock, so the next tick sees the session as stale and flips a
+  // live session to idle right after a tool call or response. new Date() mirrors
+  // how the hook mappers stamp receivedAt for events with no source timestamp.
   if (typeof value !== "string") {
-    return new Date(0);
+    return new Date();
   }
   const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? new Date(0) : parsed;
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
 }
 
 function asObject(value: unknown): Record<string, unknown> | undefined {

--- a/sdk/typescript/src/cli/harness-events.ts
+++ b/sdk/typescript/src/cli/harness-events.ts
@@ -277,7 +277,7 @@ export function codexEventsFromLine(
 
   if (type === "function_call" || type === "tool_search_call") {
     const toolName = asString(payload.name) ?? asString(payload.query) ?? "tool";
-    const input = payload.arguments ?? payload.query ?? payload.input;
+    const input = parseMaybeJson(payload.arguments) ?? payload.query ?? payload.input;
     return [
       {
         line,
@@ -327,6 +327,7 @@ export function codexEventsFromLine(
 
   if (type === "mcp_tool_call_begin") {
     const toolName = asString(payload.tool) ?? asString(payload.name) ?? "mcp";
+    const input = parseMaybeJson(payload.arguments);
     return [
       {
         line,
@@ -339,8 +340,8 @@ export function codexEventsFromLine(
             call_id: asString(payload.call_id) ?? asString(payload.id) ?? "",
             tool_name: toolName,
             tool_kind: "mcp",
-            display: toolDisplay(toolName, payload.arguments),
-            input: payload.arguments,
+            display: toolDisplay(toolName, input),
+            input,
           },
         },
       },
@@ -509,6 +510,27 @@ function textFromContent(content: unknown, allowedTypes: Set<string>): string {
       return text ? [text] : [];
     })
     .join("\n");
+}
+
+/**
+ * Codex serializes `function_call` / MCP `arguments` as a JSON string. Parse it
+ * back to structured data so `toolDisplay` can extract fields (command,
+ * file_path, …) and the published `input` matches Claude's object shape.
+ * Non-JSON or unparseable strings are returned untouched.
+ */
+function parseMaybeJson(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return value;
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return value;
+  }
 }
 
 function parseJsonObject(raw: string): Record<string, unknown> | undefined {

--- a/sdk/typescript/src/cli/harness-events.ts
+++ b/sdk/typescript/src/cli/harness-events.ts
@@ -31,6 +31,8 @@ export interface HarnessSemanticEvent {
 
 /** Truncate cap for tool_result output text (bytes are reported separately). */
 const OUTPUT_CAP = 4096;
+/** Truncate cap for raw tool_input carried in tool_call envelopes. */
+const INPUT_CAP = OUTPUT_CAP;
 const ELISION = "\n…[truncated]";
 
 /** Maps one raw transcript line from a given provider into typed events. */
@@ -188,7 +190,7 @@ function claudeAssistantBlock(
             tool_name: toolName,
             tool_kind: normalizeToolKind(toolName),
             display: toolDisplay(toolName, input),
-            input,
+            input: boundToolInput(input),
           },
         },
       },
@@ -291,7 +293,7 @@ export function codexEventsFromLine(
             tool_name: toolName,
             tool_kind: normalizeToolKind(toolName),
             display: toolDisplay(toolName, input),
-            input,
+            input: boundToolInput(input),
           },
         },
       },
@@ -341,7 +343,7 @@ export function codexEventsFromLine(
             tool_name: toolName,
             tool_kind: "mcp",
             display: toolDisplay(toolName, input),
-            input,
+            input: boundToolInput(input),
           },
         },
       },
@@ -491,6 +493,33 @@ function truncate(value: string): string {
 
 function byteLength(value: string): number {
   return Buffer.byteLength(value, "utf8");
+}
+
+/**
+ * Bound the raw tool_input before it goes on the wire. Write/Edit/MCP inputs can
+ * carry full file contents or very large request payloads, and the
+ * ToolCallPayload contract promises input is bounded before publish. Small
+ * inputs keep their structure; oversized ones collapse to a byte-capped
+ * serialized string so one large edit can't exceed relay/message limits.
+ */
+function boundToolInput(input: unknown): unknown {
+  const serialized = safeStringify(input);
+  const buffer = Buffer.from(serialized, "utf8");
+  if (buffer.length <= INPUT_CAP) {
+    return input;
+  }
+  return `${buffer.subarray(0, INPUT_CAP).toString("utf8")}${ELISION}`;
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
 }
 
 function textFromContent(content: unknown, allowedTypes: Set<string>): string {

--- a/sdk/typescript/src/cli/harness-events.ts
+++ b/sdk/typescript/src/cli/harness-events.ts
@@ -1,0 +1,524 @@
+// Pure JSONL-line -> typed HarnessEvent mapper for the v2 session stream.
+//
+// This module is deliberately self-contained: it depends only on the v2 types
+// and carries its own small JSON accessors. That keeps it free of any collision
+// with the transport/tailer code in `harness-wrapper.ts` (which owns envelope
+// framing: id/seq/bucket/scope). The tailer calls `harnessEventsFromLine` and
+// wraps each result in a `SessionEnvelopeV2`.
+//
+// Verified against real interactive sessions on both providers:
+//   Claude  ~/.claude/projects/*/*.jsonl   — record types user|assistant|system,
+//           message.content[] blocks: text | thinking | tool_use | tool_result.
+//   Codex   ~/.codex/sessions/**/rollout-*.jsonl — record types event_msg |
+//           response_item, payload types: user_message | agent_message |
+//           reasoning | function_call | function_call_output | mcp_tool_call_* |
+//           tool_search_call | tool_search_output | task_started | task_complete.
+
+import type {
+  HarnessEvent,
+  HarnessProvider,
+  HarnessToolKind,
+} from "../types/harness.js";
+
+/** One typed event parsed from a single transcript line, pre-envelope. */
+export interface HarnessSemanticEvent {
+  line: number;
+  timestamp: Date;
+  /** origin record type, e.g. "assistant" / "response_item:function_call". */
+  recordType: string;
+  event: HarnessEvent;
+}
+
+/** Truncate cap for tool_result output text (bytes are reported separately). */
+const OUTPUT_CAP = 4096;
+const ELISION = "\n…[truncated]";
+
+export function harnessEventsFromLine(
+  provider: HarnessProvider,
+  raw: string,
+  line: number,
+): Array<HarnessSemanticEvent> {
+  return provider === "claude"
+    ? claudeEventsFromLine(raw, line)
+    : codexEventsFromLine(raw, line);
+}
+
+// ── Claude ───────────────────────────────────────────────────────────────────
+
+export function claudeEventsFromLine(
+  raw: string,
+  line: number,
+): Array<HarnessSemanticEvent> {
+  const record = parseJsonObject(raw);
+  if (!record) {
+    return [];
+  }
+  const timestamp = parseTimestamp(record.timestamp);
+  const message = asObject(record.message);
+  if (!message) {
+    return [];
+  }
+  const sourceRole = asString(message.role);
+  const blocks = asArray(message.content);
+
+  // A Claude `user` record carries the human prompt AND tool_result blocks.
+  if (record.type === "user" && sourceRole === "user") {
+    if (typeof message.content === "string") {
+      return message.content
+        ? [userPromptEvent(line, timestamp, message.content)]
+        : [];
+    }
+    return blocks.flatMap((block) =>
+      claudeUserBlock(block, line, timestamp),
+    );
+  }
+
+  // An `assistant` record carries text / thinking / tool_use blocks.
+  if (record.type === "assistant" && sourceRole === "assistant") {
+    return blocks.flatMap((block) =>
+      claudeAssistantBlock(block, line, timestamp),
+    );
+  }
+
+  return [];
+}
+
+function claudeUserBlock(
+  block: unknown,
+  line: number,
+  timestamp: Date,
+): Array<HarnessSemanticEvent> {
+  const object = asObject(block);
+  if (!object) {
+    return [];
+  }
+  if (object.type === "text") {
+    const text = asString(object.text) ?? "";
+    return text ? [userPromptEvent(line, timestamp, text)] : [];
+  }
+  if (object.type === "tool_result") {
+    const callId = asString(object.tool_use_id) ?? "";
+    const isError = object.is_error === true;
+    const output = flattenClaudeToolResult(object.content);
+    return [
+      {
+        line,
+        timestamp,
+        recordType: "user:tool_result",
+        event: {
+          kind: "tool_result",
+          role: "agent",
+          payload: {
+            call_id: callId,
+            ok: !isError,
+            is_error: isError,
+            output: truncate(output),
+            output_bytes: byteLength(output),
+          },
+        },
+      },
+    ];
+  }
+  return [];
+}
+
+function claudeAssistantBlock(
+  block: unknown,
+  line: number,
+  timestamp: Date,
+): Array<HarnessSemanticEvent> {
+  const object = asObject(block);
+  if (!object) {
+    return [];
+  }
+  if (object.type === "text") {
+    const text = asString(object.text) ?? "";
+    return text
+      ? [
+          {
+            line,
+            timestamp,
+            recordType: "assistant:text",
+            event: { kind: "agent_message", role: "agent", payload: { text } },
+          },
+        ]
+      : [];
+  }
+  if (object.type === "thinking") {
+    const text = asString(object.thinking) ?? asString(object.text) ?? "";
+    return text
+      ? [
+          {
+            line,
+            timestamp,
+            recordType: "assistant:thinking",
+            event: { kind: "agent_thinking", role: "agent", payload: { text } },
+          },
+        ]
+      : [];
+  }
+  if (object.type === "tool_use") {
+    const toolName = asString(object.name) ?? "unknown";
+    const input = object.input;
+    return [
+      {
+        line,
+        timestamp,
+        recordType: "assistant:tool_use",
+        event: {
+          kind: "tool_call",
+          role: "agent",
+          payload: {
+            call_id: asString(object.id) ?? "",
+            tool_name: toolName,
+            tool_kind: normalizeToolKind(toolName),
+            display: toolDisplay(toolName, input),
+            input,
+          },
+        },
+      },
+    ];
+  }
+  return [];
+}
+
+function flattenClaudeToolResult(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((item) => {
+      const object = asObject(item);
+      if (!object || object.type !== "text") {
+        return [];
+      }
+      const text = asString(object.text);
+      return text ? [text] : [];
+    })
+    .join("\n");
+}
+
+// ── Codex ──────────────────────────────────────────────────────────────────
+
+export function codexEventsFromLine(
+  raw: string,
+  line: number,
+): Array<HarnessSemanticEvent> {
+  const record = parseJsonObject(raw);
+  if (!record) {
+    return [];
+  }
+  const timestamp = parseTimestamp(record.timestamp);
+  const payload = asObject(record.payload);
+  if (!payload) {
+    return [];
+  }
+  const type = asString(payload.type);
+
+  if (record.type === "event_msg" && type === "user_message") {
+    const text = asString(payload.message) ?? "";
+    return text ? [userPromptEvent(line, timestamp, text)] : [];
+  }
+
+  if (
+    (record.type === "event_msg" && type === "agent_message") ||
+    (record.type === "response_item" &&
+      type === "message" &&
+      payload.role === "assistant")
+  ) {
+    const text =
+      asString(payload.message) ??
+      textFromContent(payload.content, new Set(["output_text", "text"]));
+    return text
+      ? [
+          {
+            line,
+            timestamp,
+            recordType: `${asString(record.type) ?? "record"}:agent_message`,
+            event: { kind: "agent_message", role: "agent", payload: { text } },
+          },
+        ]
+      : [];
+  }
+
+  if (type === "reasoning") {
+    const text =
+      textFromContent(payload.summary, new Set(["summary_text", "text"])) ||
+      textFromContent(payload.content, new Set(["reasoning_text", "text"]));
+    return text
+      ? [
+          {
+            line,
+            timestamp,
+            recordType: "response_item:reasoning",
+            event: { kind: "agent_thinking", role: "agent", payload: { text } },
+          },
+        ]
+      : [];
+  }
+
+  if (type === "function_call" || type === "tool_search_call") {
+    const toolName = asString(payload.name) ?? asString(payload.query) ?? "tool";
+    const input = payload.arguments ?? payload.query ?? payload.input;
+    return [
+      {
+        line,
+        timestamp,
+        recordType: `response_item:${type}`,
+        event: {
+          kind: "tool_call",
+          role: "agent",
+          payload: {
+            call_id: asString(payload.call_id) ?? asString(payload.id) ?? "",
+            tool_name: toolName,
+            tool_kind: normalizeToolKind(toolName),
+            display: toolDisplay(toolName, input),
+            input,
+          },
+        },
+      },
+    ];
+  }
+
+  if (
+    type === "function_call_output" ||
+    type === "tool_search_output" ||
+    type === "mcp_tool_call_end"
+  ) {
+    const output = codexOutputText(payload.output ?? payload.result);
+    const isError = codexIsError(payload);
+    return [
+      {
+        line,
+        timestamp,
+        recordType: `response_item:${type}`,
+        event: {
+          kind: "tool_result",
+          role: "agent",
+          payload: {
+            call_id: asString(payload.call_id) ?? asString(payload.id) ?? "",
+            ok: !isError,
+            is_error: isError,
+            output: truncate(output),
+            output_bytes: byteLength(output),
+          },
+        },
+      },
+    ];
+  }
+
+  if (type === "mcp_tool_call_begin") {
+    const toolName = asString(payload.tool) ?? asString(payload.name) ?? "mcp";
+    return [
+      {
+        line,
+        timestamp,
+        recordType: "response_item:mcp_tool_call_begin",
+        event: {
+          kind: "tool_call",
+          role: "agent",
+          payload: {
+            call_id: asString(payload.call_id) ?? asString(payload.id) ?? "",
+            tool_name: toolName,
+            tool_kind: "mcp",
+            display: toolDisplay(toolName, payload.arguments),
+            input: payload.arguments,
+          },
+        },
+      },
+    ];
+  }
+
+  if (type === "task_started" || type === "task_complete") {
+    const running = type === "task_started";
+    return [
+      {
+        line,
+        timestamp,
+        recordType: `event_msg:${type}`,
+        event: {
+          kind: "status",
+          role: "agent",
+          payload: {
+            state: running ? "running" : "idle",
+            detail: running ? "working" : "idle",
+          },
+        },
+      },
+    ];
+  }
+
+  return [];
+}
+
+function codexOutputText(output: unknown): string {
+  if (typeof output === "string") {
+    return output;
+  }
+  const object = asObject(output);
+  if (object) {
+    const content = object.content ?? object.output ?? object.text;
+    if (typeof content === "string") {
+      return content;
+    }
+    return textFromContent(content, new Set(["output_text", "text"]));
+  }
+  return textFromContent(output, new Set(["output_text", "text"]));
+}
+
+function codexIsError(payload: Record<string, unknown>): boolean {
+  if (payload.success === false || payload.is_error === true) {
+    return true;
+  }
+  const output = asObject(payload.output);
+  if (output && (output.success === false || output.is_error === true)) {
+    return true;
+  }
+  return false;
+}
+
+// ── shared helpers ───────────────────────────────────────────────────────────
+
+function userPromptEvent(
+  line: number,
+  timestamp: Date,
+  text: string,
+): HarnessSemanticEvent {
+  return {
+    line,
+    timestamp,
+    recordType: "user:prompt",
+    event: {
+      kind: "user_prompt",
+      role: "owner",
+      payload: { text, source: "human" },
+    },
+  };
+}
+
+export function normalizeToolKind(name: string): HarnessToolKind {
+  const lower = name.toLowerCase();
+  if (lower.startsWith("mcp__") || lower.includes("mcp")) {
+    return "mcp";
+  }
+  if (/(bash|shell|exec|command|terminal|run)/.test(lower)) {
+    return "shell";
+  }
+  if (/(multiedit|edit|apply_patch|patch)/.test(lower)) {
+    return "edit";
+  }
+  if (/(write|create_file)/.test(lower)) {
+    return "file_write";
+  }
+  if (/(read|cat|open_file|view)/.test(lower)) {
+    return "file_read";
+  }
+  if (/(grep|glob|search|find|ripgrep)/.test(lower)) {
+    return "search";
+  }
+  if (/(web|fetch|http|browse|url)/.test(lower)) {
+    return "web";
+  }
+  if (/(task|agent|subagent|spawn)/.test(lower)) {
+    return "task";
+  }
+  return "other";
+}
+
+/** Best-effort one-line summary of what a tool call is doing. */
+export function toolDisplay(name: string, input: unknown): string {
+  const object = asObject(input);
+  if (object) {
+    const preferred = [
+      "command",
+      "cmd",
+      "file_path",
+      "path",
+      "pattern",
+      "query",
+      "url",
+      "prompt",
+      "description",
+    ];
+    for (const key of preferred) {
+      const value = asString(object[key]);
+      if (value) {
+        return firstLine(value);
+      }
+    }
+  }
+  if (typeof input === "string" && input) {
+    return firstLine(input);
+  }
+  return name;
+}
+
+function firstLine(value: string): string {
+  const line = value.split("\n", 1)[0] ?? value;
+  return line.length > 200 ? `${line.slice(0, 197)}...` : line;
+}
+
+function truncate(value: string): string {
+  if (byteLength(value) <= OUTPUT_CAP) {
+    return value;
+  }
+  return `${value.slice(0, OUTPUT_CAP)}${ELISION}`;
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function textFromContent(content: unknown, allowedTypes: Set<string>): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((item) => {
+      const object = asObject(item);
+      if (!object || !allowedTypes.has(String(object.type))) {
+        return [];
+      }
+      const text = asString(object.text);
+      return text ? [text] : [];
+    })
+    .join("\n");
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return asObject(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseTimestamp(value: unknown): Date {
+  if (typeof value !== "string") {
+    return new Date(0);
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date(0) : parsed;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asArray(value: unknown): Array<unknown> {
+  return Array.isArray(value) ? value : [];
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/sdk/typescript/src/cli/harness-events.ts
+++ b/sdk/typescript/src/cli/harness-events.ts
@@ -33,14 +33,29 @@ export interface HarnessSemanticEvent {
 const OUTPUT_CAP = 4096;
 const ELISION = "\n…[truncated]";
 
+/** Maps one raw transcript line from a given provider into typed events. */
+export type HarnessLineMapper = (
+  raw: string,
+  line: number,
+) => Array<HarnessSemanticEvent>;
+
+// Provider registry. Typed as Record<HarnessProvider, …> so adding a new
+// provider to the HarnessProvider union (e.g. "gemini") is a compile error
+// until its mapper is registered here — no silent fall-through to a wrong
+// branch. The envelope's `harness.provider` field is what lets OpenHuman tell
+// claude / codex / (future) gemini packets apart at the receiver.
+const LINE_MAPPERS: Record<HarnessProvider, HarnessLineMapper> = {
+  claude: claudeEventsFromLine,
+  codex: codexEventsFromLine,
+};
+
 export function harnessEventsFromLine(
   provider: HarnessProvider,
   raw: string,
   line: number,
 ): Array<HarnessSemanticEvent> {
-  return provider === "claude"
-    ? claudeEventsFromLine(raw, line)
-    : codexEventsFromLine(raw, line);
+  const mapper = LINE_MAPPERS[provider] as HarnessLineMapper | undefined;
+  return mapper ? mapper(raw, line) : [];
 }
 
 // ── Claude ───────────────────────────────────────────────────────────────────

--- a/sdk/typescript/src/cli/harness-events.ts
+++ b/sdk/typescript/src/cli/harness-events.ts
@@ -477,10 +477,15 @@ function firstLine(value: string): string {
 }
 
 function truncate(value: string): string {
-  if (byteLength(value) <= OUTPUT_CAP) {
+  const buffer = Buffer.from(value, "utf8");
+  if (buffer.length <= OUTPUT_CAP) {
     return value;
   }
-  return `${value.slice(0, OUTPUT_CAP)}${ELISION}`;
+  // Slice by BYTES, not characters: `String.slice` is code-unit indexed, so a
+  // multi-byte payload (emoji / CJK / non-ASCII file contents) would blow past
+  // the byte cap this function exists to enforce for envelope transport.
+  // `Buffer.toString("utf8")` drops a trailing partial code point safely.
+  return `${buffer.subarray(0, OUTPUT_CAP).toString("utf8")}${ELISION}`;
 }
 
 function byteLength(value: string): number {

--- a/sdk/typescript/src/cli/harness-hooks.ts
+++ b/sdk/typescript/src/cli/harness-hooks.ts
@@ -1,0 +1,415 @@
+// Pure Claude Code hook-payload -> typed HarnessEvent mapper for the v2 stream.
+//
+// Complements `harness-events.ts` (which tails the transcript JSONL). Claude
+// Code fires a hook command in real time and pipes a single JSON object to its
+// stdin; `PreToolUse` fires BEFORE the tool runs, so this is a lower-latency
+// capture path than tailing the transcript file. This module maps one such hook
+// payload into the SAME intermediate `HarnessSemanticEvent[]` shape the JSONL
+// mapper emits, so hook-sourced events flow through `buildEventEnvelopeV2` +
+// `reduceStatus` identically. It reuses `normalizeToolKind` / `toolDisplay` from
+// the JSONL mapper and carries its own small JSON accessors to stay decoupled.
+//
+// Payload shapes verified against Claude Code 2.1.202 (the JSON object each hook
+// receives on stdin):
+//   common          — session_id, transcript_path, cwd, hook_event_name,
+//                     permission_mode (+ optional prompt_id, agent_id,
+//                     agent_type). scope-level; not needed for the typed event.
+//   PreToolUse      — tool_name, tool_input, tool_use_id
+//   PostToolUse     — tool_name, tool_input, tool_response, tool_use_id,
+//                     duration_ms
+//   UserPromptSubmit— prompt, session_title
+//   Stop            — stop_hook_active, last_assistant_message
+//   SubagentStop    — stop_hook_active, agent_id, agent_transcript_path,
+//                     agent_type, last_assistant_message
+//   SessionStart    — source ("startup"|"resume"|"clear"|"compact"), model,
+//                     session_title
+//   SessionEnd      — reason ("clear"|"logout"|"prompt_input_exit"|…)
+//   Notification    — message, title, notification_type ("permission_prompt"|
+//                     "idle_prompt"|…)
+//
+// Correlation: `tool_use_id` is a stable id carried on BOTH PreToolUse and
+// PostToolUse for the same tool invocation, so a tool_call and its tool_result
+// share `call_id` exactly as the JSONL path already does. No heuristic
+// (tool_name+input) matching is required on this version.
+
+import { stdin } from "node:process";
+import type { HarnessEvent } from "../types/harness.js";
+import type { HarnessSemanticEvent } from "./harness-events.js";
+import { normalizeToolKind, toolDisplay } from "./harness-events.js";
+
+/** Truncate cap for tool_result output text (bytes are reported separately). */
+const OUTPUT_CAP = 4096;
+/** Bounded serialization cap for `unknown` raw payloads. */
+const RAW_CAP = 4096;
+const ELISION = "\n…[truncated]";
+
+/**
+ * Maps one Claude Code hook payload (the JSON object Claude pipes to a hook
+ * command's stdin) into typed semantic events. Pure: pass `receivedAt` for
+ * deterministic timestamps (hook payloads carry no timestamp of their own).
+ *
+ * Unrecognized or malformed payloads map to a single bounded `unknown` event so
+ * the real-time path never silently drops a hook.
+ */
+export function claudeHookEventToSemantic(
+  payload: unknown,
+  receivedAt: Date = new Date(),
+): Array<HarnessSemanticEvent> {
+  const record = asObject(payload);
+  if (!record) {
+    return [unknownEvent("hook:unknown", receivedAt, payload)];
+  }
+  const eventName = asString(record.hook_event_name) ?? "";
+  switch (eventName) {
+    case "PreToolUse":
+      return preToolUse(record, receivedAt);
+    case "PostToolUse":
+      return postToolUse(record, receivedAt);
+    case "UserPromptSubmit":
+      return userPromptSubmit(record, receivedAt);
+    case "Stop":
+      return turnEnd("hook:Stop", receivedAt);
+    case "SubagentStop":
+      return turnEnd("hook:SubagentStop", receivedAt);
+    case "SessionStart":
+      return sessionStart(record, receivedAt);
+    case "SessionEnd":
+      return sessionEnd(receivedAt);
+    case "Notification":
+      return notification(record, receivedAt);
+    default:
+      return [
+        unknownEvent(`hook:${eventName || "unknown"}`, receivedAt, payload),
+      ];
+  }
+}
+
+/**
+ * Parses a raw hook JSON string then maps it. A parse failure yields a single
+ * bounded `unknown` event rather than dropping the hook.
+ */
+export function claudeHookStringToSemantic(
+  raw: string,
+  receivedAt: Date = new Date(),
+): Array<HarnessSemanticEvent> {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return [unknownEvent("hook:unparseable", receivedAt, raw)];
+  }
+  return claudeHookEventToSemantic(payload, receivedAt);
+}
+
+/**
+ * Thin stdin entrypoint so the module is usable directly as a hook command:
+ * read the whole JSON payload from `stream`, then map it. The core mapper stays
+ * pure — this only handles I/O.
+ */
+export async function claudeHookEventsFromStdin(
+  stream: NodeJS.ReadableStream = stdin,
+  receivedAt: Date = new Date(),
+): Promise<Array<HarnessSemanticEvent>> {
+  const raw = await readStream(stream);
+  return claudeHookStringToSemantic(raw, receivedAt);
+}
+
+// ── per-event mappers ────────────────────────────────────────────────────────
+
+function preToolUse(
+  record: Record<string, unknown>,
+  receivedAt: Date,
+): Array<HarnessSemanticEvent> {
+  const toolName = asString(record.tool_name) ?? "unknown";
+  const input = record.tool_input;
+  return [
+    {
+      line: 0,
+      timestamp: receivedAt,
+      recordType: "hook:PreToolUse",
+      event: {
+        kind: "tool_call",
+        role: "agent",
+        payload: {
+          call_id: asString(record.tool_use_id) ?? "",
+          tool_name: toolName,
+          tool_kind: normalizeToolKind(toolName),
+          display: toolDisplay(toolName, input),
+          input,
+        },
+      },
+    },
+  ];
+}
+
+function postToolUse(
+  record: Record<string, unknown>,
+  receivedAt: Date,
+): Array<HarnessSemanticEvent> {
+  const response = record.tool_response;
+  const output = toolResponseText(response);
+  const isError = toolResponseIsError(response);
+  return [
+    {
+      line: 0,
+      timestamp: receivedAt,
+      recordType: "hook:PostToolUse",
+      event: {
+        kind: "tool_result",
+        role: "agent",
+        payload: {
+          call_id: asString(record.tool_use_id) ?? "",
+          ok: !isError,
+          is_error: isError,
+          output: truncate(output),
+          output_bytes: byteLength(output),
+        },
+      },
+    },
+  ];
+}
+
+function userPromptSubmit(
+  record: Record<string, unknown>,
+  receivedAt: Date,
+): Array<HarnessSemanticEvent> {
+  const text = asString(record.prompt) ?? "";
+  if (!text) {
+    return [];
+  }
+  return [
+    {
+      line: 0,
+      timestamp: receivedAt,
+      recordType: "hook:UserPromptSubmit",
+      event: {
+        kind: "user_prompt",
+        role: "owner",
+        payload: { text, source: "human" },
+      },
+    },
+  ];
+}
+
+function sessionStart(
+  record: Record<string, unknown>,
+  receivedAt: Date,
+): Array<HarnessSemanticEvent> {
+  // A "compact" start is a context compaction, not a fresh turn — surface it as
+  // its own lifecycle phase; every other source opens the session.
+  const phase = asString(record.source) === "compact" ? "compact" : "session_start";
+  return [
+    {
+      line: 0,
+      timestamp: receivedAt,
+      recordType: "hook:SessionStart",
+      event: {
+        kind: "lifecycle",
+        role: "agent",
+        payload: { phase },
+      },
+    },
+  ];
+}
+
+function sessionEnd(receivedAt: Date): Array<HarnessSemanticEvent> {
+  return [
+    {
+      line: 0,
+      timestamp: receivedAt,
+      recordType: "hook:SessionEnd",
+      event: {
+        kind: "lifecycle",
+        role: "agent",
+        payload: { phase: "session_end" },
+      },
+    },
+  ];
+}
+
+function turnEnd(
+  recordType: string,
+  receivedAt: Date,
+): Array<HarnessSemanticEvent> {
+  // Stop / SubagentStop fire when the agent finishes responding — a turn end.
+  // `reduceStatus` maps this lifecycle phase to `idle`.
+  return [
+    {
+      line: 0,
+      timestamp: receivedAt,
+      recordType,
+      event: {
+        kind: "lifecycle",
+        role: "agent",
+        payload: { phase: "turn_end" },
+      },
+    },
+  ];
+}
+
+function notification(
+  record: Record<string, unknown>,
+  receivedAt: Date,
+): Array<HarnessSemanticEvent> {
+  const message = asString(record.message) ?? "";
+  const notificationType = asString(record.notification_type) ?? "";
+  const isPermission =
+    notificationType === "permission_prompt" ||
+    /permission|approv/i.test(message);
+  if (!isPermission) {
+    // idle prompts and other notifications carry no approval decision.
+    return [unknownEvent("hook:Notification", receivedAt, record)];
+  }
+  return [
+    {
+      line: 0,
+      timestamp: receivedAt,
+      recordType: "hook:Notification",
+      event: {
+        kind: "approval_request",
+        role: "agent",
+        payload: {
+          // the notification does not name the tool; leave it empty and carry
+          // the human-readable prompt in `display`.
+          tool_name: "",
+          display: firstLine(message) || "permission requested",
+          ...(notificationType ? { reason: notificationType } : {}),
+        },
+      },
+    },
+  ];
+}
+
+// ── tool_response shaping ────────────────────────────────────────────────────
+
+/** Flattens a hook `tool_response` (string | content-blocks | object) to text. */
+function toolResponseText(response: unknown): string {
+  if (typeof response === "string") {
+    return response;
+  }
+  if (Array.isArray(response)) {
+    return flattenContentBlocks(response);
+  }
+  const object = asObject(response);
+  if (!object) {
+    return safeStringify(response);
+  }
+  if (object.content !== undefined) {
+    return toolResponseText(object.content);
+  }
+  const parts = ["stdout", "stderr", "output", "text", "result", "message"]
+    .map((key) => asString(object[key]))
+    .filter((value): value is string => Boolean(value));
+  return parts.length > 0 ? parts.join("\n") : safeStringify(object);
+}
+
+function flattenContentBlocks(blocks: Array<unknown>): string {
+  return blocks
+    .flatMap((block) => {
+      if (typeof block === "string") {
+        return block ? [block] : [];
+      }
+      const object = asObject(block);
+      if (!object || object.type !== "text") {
+        return [];
+      }
+      const text = asString(object.text);
+      return text ? [text] : [];
+    })
+    .join("\n");
+}
+
+/** Best-effort error detection on a hook `tool_response`. */
+function toolResponseIsError(response: unknown): boolean {
+  const object = asObject(response);
+  if (!object) {
+    return false;
+  }
+  return (
+    object.is_error === true ||
+    object.isError === true ||
+    object.success === false ||
+    object.interrupted === true ||
+    isNonEmpty(object.error)
+  );
+}
+
+function isNonEmpty(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return value.length > 0;
+  }
+  return true;
+}
+
+// ── shared helpers ───────────────────────────────────────────────────────────
+
+function unknownEvent(
+  recordType: string,
+  receivedAt: Date,
+  raw: unknown,
+): HarnessSemanticEvent {
+  const event: HarnessEvent = {
+    kind: "unknown",
+    role: "agent",
+    payload: { raw: boundRaw(raw) },
+  };
+  return { line: 0, timestamp: receivedAt, recordType, event };
+}
+
+/** Keeps small raw payloads structured; truncates large ones to a bounded string. */
+function boundRaw(value: unknown): unknown {
+  const serialized = safeStringify(value);
+  if (byteLength(serialized) <= RAW_CAP) {
+    return value;
+  }
+  return `${serialized.slice(0, RAW_CAP)}${ELISION}`;
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function firstLine(value: string): string {
+  const line = value.split("\n", 1)[0] ?? value;
+  return line.length > 200 ? `${line.slice(0, 197)}...` : line;
+}
+
+function truncate(value: string): string {
+  if (byteLength(value) <= OUTPUT_CAP) {
+    return value;
+  }
+  return `${value.slice(0, OUTPUT_CAP)}${ELISION}`;
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+async function readStream(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Array<Buffer> = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/sdk/typescript/src/cli/harness-hooks.ts
+++ b/sdk/typescript/src/cli/harness-hooks.ts
@@ -362,10 +362,13 @@ function unknownEvent(
 /** Keeps small raw payloads structured; truncates large ones to a bounded string. */
 function boundRaw(value: unknown): unknown {
   const serialized = safeStringify(value);
-  if (byteLength(serialized) <= RAW_CAP) {
+  const buffer = Buffer.from(serialized, "utf8");
+  if (buffer.length <= RAW_CAP) {
     return value;
   }
-  return `${serialized.slice(0, RAW_CAP)}${ELISION}`;
+  // Byte-indexed slice (see truncate): keep the bounded string within RAW_CAP
+  // bytes even for multi-byte serialized payloads.
+  return `${buffer.subarray(0, RAW_CAP).toString("utf8")}${ELISION}`;
 }
 
 function safeStringify(value: unknown): string {
@@ -385,10 +388,14 @@ function firstLine(value: string): string {
 }
 
 function truncate(value: string): string {
-  if (byteLength(value) <= OUTPUT_CAP) {
+  const buffer = Buffer.from(value, "utf8");
+  if (buffer.length <= OUTPUT_CAP) {
     return value;
   }
-  return `${value.slice(0, OUTPUT_CAP)}${ELISION}`;
+  // Byte-indexed slice (see harness-events.ts truncate): `String.slice` counts
+  // code units, so multi-byte content could still exceed the byte cap.
+  // `Buffer.toString("utf8")` trims a trailing partial code point safely.
+  return `${buffer.subarray(0, OUTPUT_CAP).toString("utf8")}${ELISION}`;
 }
 
 function byteLength(value: string): number {

--- a/sdk/typescript/src/cli/harness-hooks.ts
+++ b/sdk/typescript/src/cli/harness-hooks.ts
@@ -135,7 +135,7 @@ function preToolUse(
           tool_name: toolName,
           tool_kind: normalizeToolKind(toolName),
           display: toolDisplay(toolName, input),
-          input,
+          input: boundRaw(input),
         },
       },
     },

--- a/sdk/typescript/src/cli/harness-status.ts
+++ b/sdk/typescript/src/cli/harness-status.ts
@@ -1,0 +1,187 @@
+// Derived session-status state machine for the v2 harness stream.
+//
+// The transcript never states "the agent is idle" — it only records events.
+// OpenHuman's Master Session needs a live "what is it doing right now" signal
+// (the InstanceStatus dot + SessionSummary.currentTask). This module derives
+// that signal from the typed event stream, plus a heartbeat/idle tick so the
+// signal stays trustworthy when no events arrive.
+//
+// Pure and caller-driven: no timers held here. The tailer feeds each semantic
+// event to `reduceStatus`, and calls `tickStatus(now)` on an interval to age a
+// silent session into `idle` and refresh the heartbeat. Both return an optional
+// StatusPayload that should be emitted only when present (change-gated).
+
+import type {
+  HarnessSessionState,
+  StatusPayload,
+} from "../types/harness.js";
+import type { HarnessSemanticEvent } from "./harness-events.js";
+
+export interface SessionStatusState {
+  state: HarnessSessionState;
+  detail: string;
+  activeCallId?: string;
+  /** timestamp of the last event that moved the machine (ms since epoch). */
+  lastEventAtMs: number;
+}
+
+export interface StatusStep {
+  next: SessionStatusState;
+  /** present only when the caller should publish a status event. */
+  emit?: StatusPayload;
+}
+
+/** Default: session exists but nothing has happened yet. */
+export function initialStatus(nowMs = 0): SessionStatusState {
+  return { state: "idle", detail: "idle", lastEventAtMs: nowMs };
+}
+
+const DETAIL_CAP = 120;
+
+export function reduceStatus(
+  prev: SessionStatusState,
+  event: HarnessSemanticEvent,
+): StatusStep {
+  const atMs = timeToMs(event.timestamp, prev.lastEventAtMs);
+  const derived = deriveFromEvent(event);
+  if (!derived) {
+    // event carries no status signal (e.g. an unknown record); keep state,
+    // but advance the activity clock so heartbeat/idle timing stays honest.
+    return { next: { ...prev, lastEventAtMs: atMs } };
+  }
+  const next: SessionStatusState = {
+    state: derived.state,
+    detail: derived.detail,
+    ...(derived.activeCallId !== undefined
+      ? { activeCallId: derived.activeCallId }
+      : {}),
+    lastEventAtMs: atMs,
+  };
+  return changed(prev, next)
+    ? { next, emit: toPayload(next) }
+    : { next };
+}
+
+/**
+ * Age a silent session. If more than `idleAfterMs` has passed since the last
+ * event while the machine is in an active state, transition to `idle`.
+ * Otherwise, when `heartbeat` is true, re-emit the current status unchanged so
+ * downstream "last updated" stays fresh. Returns no emit when nothing is due.
+ */
+export function tickStatus(
+  prev: SessionStatusState,
+  nowMs: number,
+  options: { idleAfterMs: number; heartbeat?: boolean } = { idleAfterMs: 30_000 },
+): StatusStep {
+  const stale = nowMs - prev.lastEventAtMs >= options.idleAfterMs;
+  const active = isActive(prev.state);
+  if (stale && active) {
+    const next: SessionStatusState = {
+      state: "idle",
+      detail: "idle",
+      lastEventAtMs: prev.lastEventAtMs,
+    };
+    return { next, emit: toPayload(next) };
+  }
+  if (options.heartbeat) {
+    return { next: prev, emit: toPayload(prev) };
+  }
+  return { next: prev };
+}
+
+interface Derived {
+  state: HarnessSessionState;
+  detail: string;
+  activeCallId?: string;
+}
+
+function deriveFromEvent(event: HarnessSemanticEvent): Derived | undefined {
+  const inner = event.event;
+  switch (inner.kind) {
+    case "tool_call":
+      return {
+        state: "running_tool",
+        detail: cap(
+          `running ${inner.payload.tool_name}: ${inner.payload.display}`,
+        ),
+        activeCallId: inner.payload.call_id || undefined,
+      };
+    case "tool_result":
+      return { state: "running", detail: "processing", activeCallId: undefined };
+    case "approval_request":
+      return {
+        state: "waiting_approval",
+        detail: cap(`awaiting approval: ${inner.payload.display}`),
+        activeCallId: inner.payload.call_id ?? undefined,
+      };
+    case "agent_thinking":
+      return { state: "running", detail: "thinking", activeCallId: undefined };
+    case "agent_message":
+      return { state: "running", detail: "replying", activeCallId: undefined };
+    case "user_prompt":
+      return { state: "running", detail: "working", activeCallId: undefined };
+    case "error":
+      return {
+        state: inner.payload.fatal ? "errored" : "running",
+        detail: cap(inner.payload.message),
+      };
+    case "lifecycle":
+      return lifecycleStatus(inner.payload.phase);
+    case "status":
+      return {
+        state: inner.payload.state,
+        detail: inner.payload.detail,
+        activeCallId: inner.payload.active_call_id ?? undefined,
+      };
+    default:
+      return undefined;
+  }
+}
+
+function lifecycleStatus(phase: string): Derived | undefined {
+  switch (phase) {
+    case "session_start":
+    case "turn_start":
+      return { state: "running", detail: "working" };
+    case "turn_end":
+      return { state: "idle", detail: "idle" };
+    case "session_end":
+      return { state: "stopped", detail: "stopped" };
+    default:
+      return undefined;
+  }
+}
+
+function toPayload(state: SessionStatusState): StatusPayload {
+  return {
+    state: state.state,
+    detail: state.detail,
+    ...(state.activeCallId ? { active_call_id: state.activeCallId } : {}),
+  };
+}
+
+function changed(a: SessionStatusState, b: SessionStatusState): boolean {
+  return (
+    a.state !== b.state ||
+    a.detail !== b.detail ||
+    a.activeCallId !== b.activeCallId
+  );
+}
+
+function isActive(state: HarnessSessionState): boolean {
+  return (
+    state === "running" ||
+    state === "running_tool" ||
+    state === "waiting_approval"
+  );
+}
+
+function cap(value: string): string {
+  const line = value.split("\n", 1)[0] ?? value;
+  return line.length > DETAIL_CAP ? `${line.slice(0, DETAIL_CAP - 1)}…` : line;
+}
+
+function timeToMs(timestamp: Date, fallback: number): number {
+  const ms = timestamp.getTime();
+  return Number.isNaN(ms) || ms === 0 ? fallback : ms;
+}

--- a/sdk/typescript/src/cli/harness-status.ts
+++ b/sdk/typescript/src/cli/harness-status.ts
@@ -145,6 +145,11 @@ function lifecycleStatus(phase: string): Derived | undefined {
       return { state: "running", detail: "working" };
     case "turn_end":
       return { state: "idle", detail: "idle" };
+    case "compact":
+      // Context compaction is active background work (emitted by the hook mapper
+      // for a "compact" SessionStart); surface it rather than leaving a stale
+      // status, but keep it distinct from a fresh turn's "working".
+      return { state: "running", detail: "compacting" };
     case "session_end":
       return { state: "stopped", detail: "stopped" };
     default:

--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -1752,15 +1752,17 @@ function asString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-// Env-configured numeric knob: fall back to the default when the var is unset
-// OR non-numeric, so a typo'd `TINYPLACE_..._IDLE_MS=abc` can't yield NaN and
-// silently disable the idle/heartbeat tick (Number("abc") === NaN).
+// Env-configured positive-millisecond knob: fall back to the default unless the
+// var parses to a finite value > 0. This rejects the three ways a bad env var
+// would otherwise poison a timer — unset, non-numeric (`Number("abc")` → NaN),
+// blank (`Number("")`/`Number(" ")` → 0), and negative — any of which would
+// disable the idle/heartbeat tick or spin a 0 ms poll loop.
 function numberEnvOr(raw: string | undefined, fallback: number): number {
   if (raw === undefined) {
     return fallback;
   }
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) ? parsed : fallback;
+  const parsed = Number(raw.trim());
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function requiredValue(flag: string, value: string | undefined): string {

--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -23,13 +23,28 @@ import {
 } from "../agent/messaging.js";
 import {
   SESSION_ENVELOPE_VERSION_V1,
+  SESSION_ENVELOPE_VERSION_V2,
+  type AnySessionEnvelope,
   type HarnessBucketUnit,
   type HarnessEnvelopeScope,
   type HarnessMessageRole,
   type HarnessProvider,
   type SessionEnvelope,
+  type StatusPayload,
 } from "../types/harness.js";
 import { bridgeLog } from "./bridge-debug.js";
+import { harnessEventsFromLine } from "./harness-events.js";
+import type { HarnessSemanticEvent } from "./harness-events.js";
+import {
+  buildEventEnvelopeV2,
+  type EnvelopeContext,
+} from "./harness-envelope.js";
+import {
+  initialStatus,
+  reduceStatus,
+  tickStatus,
+  type SessionStatusState,
+} from "./harness-status.js";
 import { makeContext } from "./context.js";
 import type { TinyPlaceCliOptions, TinyPlaceCliResult } from "./types.js";
 import type { Writable } from "node:stream";
@@ -57,8 +72,16 @@ export interface HarnessWrapperConfig {
   captureSession: boolean;
   dmRecipient?: string;
   dryRun: boolean;
+  // Opt-in: also emit the v2 typed-event stream (tool_call/tool_result/status/
+  // thinking) alongside v1. Default off so current v1 consumers are untouched
+  // until the OpenHuman receiver understands v2.
+  emitV2: boolean;
   outDir: string;
   provider: HarnessProvider;
+  // v2 status derivation: idle a silent session after this long, and re-emit a
+  // heartbeat status no more often than this. Only used when emitV2 is on.
+  statusHeartbeatMs: number;
+  statusIdleMs: number;
   receiveEnabled: boolean;
   receiveFrom?: string;
   receivePollMs: number;
@@ -415,8 +438,25 @@ export function parseHarnessWrapperArgs(
     captureSession: true,
     ...(owner ? { dmRecipient: owner } : {}),
     dryRun: false,
+    emitV2:
+      firstEnv(env, [
+        `TINYPLACE_${provider.toUpperCase()}_V2`,
+        "TINYPLACE_HARNESS_V2",
+      ]) === "1",
     outDir,
     provider,
+    statusHeartbeatMs: Number(
+      firstEnv(env, [
+        `TINYPLACE_${provider.toUpperCase()}_STATUS_HEARTBEAT_MS`,
+        "TINYPLACE_HARNESS_STATUS_HEARTBEAT_MS",
+      ]) ?? 15_000,
+    ),
+    statusIdleMs: Number(
+      firstEnv(env, [
+        `TINYPLACE_${provider.toUpperCase()}_STATUS_IDLE_MS`,
+        "TINYPLACE_HARNESS_STATUS_IDLE_MS",
+      ]) ?? 30_000,
+    ),
     ...(receiveFrom ? { receiveFrom } : {}),
     receiveEnabled: receiveFrom !== undefined && !receiveDisabled,
     receivePollMs: Number(
@@ -587,6 +627,10 @@ export class HarnessSessionTailer {
   private sessionFile: string | undefined;
   private sessionMeta: SessionMeta | undefined;
   private timer: ReturnType<typeof setInterval> | undefined;
+  // v2 typed-event stream state (only used when config.emitV2 is on).
+  private status: SessionStatusState = initialStatus();
+  private v2Seq = 0;
+  private lastHeartbeatMs = 0;
 
   public constructor(
     private readonly config: HarnessWrapperConfig,
@@ -655,12 +699,25 @@ export class HarnessSessionTailer {
           semanticCount += 1;
           this.write(message);
         }
+        if (this.config.emitV2) {
+          for (const event of harnessEventsFromLine(
+            this.config.provider,
+            raw,
+            line,
+          )) {
+            this.writeV2(event);
+          }
+        }
       }
       bridgeLog("tailer.poll", {
         newLines: lines.length,
         semanticMessages: semanticCount,
         lineOffset: this.lineOffset,
       });
+    }
+    // Even with no new lines, age a silent session toward idle and heartbeat.
+    if (this.config.emitV2) {
+      this.tickV2Status();
     }
   }
 
@@ -771,7 +828,86 @@ export class HarnessSessionTailer {
     this.publisher.publish(envelope);
   }
 
-  private writeEnvelope(envelope: SessionEnvelope): void {
+  /** Emit one typed v2 event, then the status transition it implies. */
+  private writeV2(semantic: HarnessSemanticEvent): void {
+    if (!this.sessionFile || !this.sessionMeta) {
+      return;
+    }
+    const ctx = this.v2Context(this.sessionFile, this.sessionMeta);
+    const envelope = buildEventEnvelopeV2(ctx, semantic, this.nextV2Seq());
+    bridgeLog("tailer.v2.event", {
+      id: envelope.event.id,
+      seq: envelope.event.seq,
+      kind: envelope.event.kind,
+      line: semantic.line,
+    });
+    this.writeEnvelope(envelope);
+    this.publisher.publish(envelope);
+
+    const step = reduceStatus(this.status, semantic);
+    this.status = step.next;
+    if (step.emit) {
+      this.publishStatus(step.emit, Date.now());
+    }
+  }
+
+  /** Age a silent session toward idle and emit a periodic heartbeat status. */
+  private tickV2Status(): void {
+    if (!this.sessionFile || !this.sessionMeta) {
+      return;
+    }
+    const now = Date.now();
+    const heartbeat =
+      now - this.lastHeartbeatMs >= this.config.statusHeartbeatMs;
+    const step = tickStatus(this.status, now, {
+      idleAfterMs: this.config.statusIdleMs,
+      heartbeat,
+    });
+    this.status = step.next;
+    if (step.emit) {
+      this.lastHeartbeatMs = now;
+      this.publishStatus(step.emit, now);
+    }
+  }
+
+  private publishStatus(payload: StatusPayload, nowMs: number): void {
+    if (!this.sessionFile || !this.sessionMeta) {
+      return;
+    }
+    const semantic: HarnessSemanticEvent = {
+      line: this.lineOffset,
+      timestamp: new Date(nowMs),
+      recordType: "derived:status",
+      event: { kind: "status", role: "agent", payload },
+    };
+    const ctx = this.v2Context(this.sessionFile, this.sessionMeta);
+    const envelope = buildEventEnvelopeV2(ctx, semantic, this.nextV2Seq());
+    this.writeEnvelope(envelope);
+    this.publisher.publish(envelope);
+  }
+
+  private v2Context(sessionFile: string, meta: SessionMeta): EnvelopeContext {
+    return {
+      provider: this.config.provider,
+      command: this.config.agentBin,
+      argv: this.config.agentArgs,
+      scopeType: this.config.scope,
+      scopeKey: this.scopeKey(),
+      cwd: this.cwd,
+      wrapperSessionId: this.config.wrapperSessionId,
+      harnessSessionId: meta.sessionId,
+      bucketUnit: this.config.bucket,
+      sourcePath: sessionFile,
+    };
+  }
+
+  private nextV2Seq(): number {
+    const seq = this.v2Seq;
+    this.v2Seq += 1;
+    return seq;
+  }
+
+  private writeEnvelope(envelope: AnySessionEnvelope): void {
     const encoded = `${JSON.stringify(envelope)}\n`;
     if (this.config.dryRun) {
       this.dryRunOutput.write(encoded);
@@ -782,7 +918,7 @@ export class HarnessSessionTailer {
     writeFileSync(target, encoded, { encoding: "utf8", flag: "a" });
   }
 
-  private outputPath(envelope: SessionEnvelope): string {
+  private outputPath(envelope: AnySessionEnvelope): string {
     const bucketStart = new Date(envelope.bucket.start);
     const fileName = bucketFileName(bucketStart, this.config.bucket);
     if (this.config.scope === "session") {
@@ -828,32 +964,33 @@ export class SessionEnvelopePublisher {
     private readonly stderr: Writable,
   ) {}
 
-  public publish(envelope: SessionEnvelope): void {
+  public publish(envelope: AnySessionEnvelope): void {
+    const id = envelopeId(envelope);
     if (!this.config.dmRecipient || this.config.dryRun) {
       bridgeLog("publish.skip", {
-        id: envelope.message.id,
+        id,
         reason: !this.config.dmRecipient ? "no-dmRecipient" : "dryRun",
       });
       return;
     }
     bridgeLog("publish.enqueue", {
-      id: envelope.message.id,
-      role: envelope.message.role,
+      id,
+      role: envelopeRole(envelope),
       recipient: this.config.dmRecipient,
     });
     const run = this.queue
       .then(() => this.publishNow(envelope))
       .then(() => {
-        bridgeLog("publish.ok", { id: envelope.message.id });
+        bridgeLog("publish.ok", { id });
       })
       .catch((error: unknown) => {
         this.failures += 1;
         bridgeLog("publish.error", {
-          id: envelope.message.id,
+          id,
           error: error instanceof Error ? error.message : String(error),
         });
         this.stderr.write(
-          `tinyplace ${this.config.provider}: failed to DM session envelope ${envelope.message.id}: ${
+          `tinyplace ${this.config.provider}: failed to DM session envelope ${id}: ${
             error instanceof Error ? error.message : String(error)
           }\n`,
         );
@@ -870,7 +1007,7 @@ export class SessionEnvelopePublisher {
     return this.failures;
   }
 
-  private async publishNow(envelope: SessionEnvelope): Promise<void> {
+  private async publishNow(envelope: AnySessionEnvelope): Promise<void> {
     const ctx = await this.context();
     if (!ctx.signer) {
       throw new Error("DM forwarding requires a tiny.place signer");
@@ -948,6 +1085,18 @@ export class SessionEnvelopePublisher {
       `tiny.place contact request pending for ${recipient}; approve it in OpenHuman before DM forwarding`,
     );
   }
+}
+
+function envelopeId(envelope: AnySessionEnvelope): string {
+  return envelope.envelope_version === SESSION_ENVELOPE_VERSION_V2
+    ? envelope.event.id
+    : envelope.message.id;
+}
+
+function envelopeRole(envelope: AnySessionEnvelope): string {
+  return envelope.envelope_version === SESSION_ENVELOPE_VERSION_V2
+    ? envelope.event.role
+    : envelope.message.role;
 }
 
 function isNotAContactError(error: unknown): boolean {

--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -445,31 +445,35 @@ export function parseHarnessWrapperArgs(
       ]) === "1",
     outDir,
     provider,
-    statusHeartbeatMs: Number(
+    statusHeartbeatMs: numberEnvOr(
       firstEnv(env, [
         `TINYPLACE_${provider.toUpperCase()}_STATUS_HEARTBEAT_MS`,
         "TINYPLACE_HARNESS_STATUS_HEARTBEAT_MS",
-      ]) ?? 15_000,
+      ]),
+      15_000,
     ),
-    statusIdleMs: Number(
+    statusIdleMs: numberEnvOr(
       firstEnv(env, [
         `TINYPLACE_${provider.toUpperCase()}_STATUS_IDLE_MS`,
         "TINYPLACE_HARNESS_STATUS_IDLE_MS",
-      ]) ?? 30_000,
+      ]),
+      30_000,
     ),
     ...(receiveFrom ? { receiveFrom } : {}),
     receiveEnabled: receiveFrom !== undefined && !receiveDisabled,
-    receivePollMs: Number(
+    receivePollMs: numberEnvOr(
       firstEnv(env, [
         `TINYPLACE_${provider.toUpperCase()}_RECEIVE_POLL_MS`,
         "TINYPLACE_HARNESS_RECEIVE_POLL_MS",
-      ]) ?? 1500,
+      ]),
+      1500,
     ),
-    sessionPollMs: Number(
+    sessionPollMs: numberEnvOr(
       firstEnv(env, [
         `TINYPLACE_${provider.toUpperCase()}_SESSION_POLL_MS`,
         "TINYPLACE_HARNESS_SESSION_POLL_MS",
-      ]) ?? 500,
+      ]),
+      500,
     ),
     sessionsDir:
       firstEnv(env, [
@@ -477,11 +481,12 @@ export function parseHarnessWrapperArgs(
         provider === "claude" ? "TINYVERSE_CLAUDE_SESSIONS_DIR" : "",
         "TINYPLACE_HARNESS_SESSIONS_DIR",
       ]) ?? profile.defaultSessionsDir,
-    sessionTailGraceMs: Number(
+    sessionTailGraceMs: numberEnvOr(
       firstEnv(env, [
         `TINYPLACE_${provider.toUpperCase()}_SESSION_TAIL_GRACE_MS`,
         "TINYPLACE_HARNESS_SESSION_TAIL_GRACE_MS",
-      ]) ?? 750,
+      ]),
+      750,
     ),
     scope: "folder",
     usePty: true,
@@ -1745,6 +1750,17 @@ function asObject(value: unknown): Record<string, unknown> | undefined {
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
+}
+
+// Env-configured numeric knob: fall back to the default when the var is unset
+// OR non-numeric, so a typo'd `TINYPLACE_..._IDLE_MS=abc` can't yield NaN and
+// silently disable the idle/heartbeat tick (Number("abc") === NaN).
+function numberEnvOr(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
 }
 
 function requiredValue(flag: string, value: string | undefined): string {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -115,40 +115,21 @@ export {
   SESSION_ENVELOPE_VERSION_V1,
   SESSION_ENVELOPE_VERSION_V2,
 } from "./types/harness.js";
-export {
-  claudeEventsFromLine,
-  codexEventsFromLine,
-  harnessEventsFromLine,
-  normalizeToolKind,
-  toolDisplay,
-} from "./cli/harness-events.js";
+// Harness runtime helpers (value exports) live behind the Node subpath
+// (`@tinyhumansai/tinyplace/node`), NOT this browser-facing root: `harness-hooks`
+// imports `node:process` and `harness-envelope` imports `node:crypto`, so
+// re-exporting their runtime values here would force browser bundlers
+// (Next/Webpack client builds) to resolve Node built-ins even when unused. Types
+// are erased at build time, so the type-only re-exports below stay browser-safe.
 export type {
   HarnessLineMapper,
   HarnessSemanticEvent,
 } from "./cli/harness-events.js";
-export {
-  claudeHookEventToSemantic,
-  claudeHookEventsFromStdin,
-  claudeHookStringToSemantic,
-} from "./cli/harness-hooks.js";
-export {
-  initialStatus,
-  reduceStatus,
-  tickStatus,
-} from "./cli/harness-status.js";
 export type {
   SessionStatusState,
   StatusStep,
 } from "./cli/harness-status.js";
-export { buildEventEnvelopeV2 } from "./cli/harness-envelope.js";
 export type { EnvelopeContext } from "./cli/harness-envelope.js";
-export {
-  applySessionEnvelope,
-  foldSessionEnvelopes,
-  initialSessionView,
-  isV2,
-  parseSessionEnvelope,
-} from "./cli/harness-consumer.js";
 export type {
   FeedEntry,
   SessionView,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -127,6 +127,11 @@ export type {
   HarnessSemanticEvent,
 } from "./cli/harness-events.js";
 export {
+  claudeHookEventToSemantic,
+  claudeHookEventsFromStdin,
+  claudeHookStringToSemantic,
+} from "./cli/harness-hooks.js";
+export {
   initialStatus,
   reduceStatus,
   tickStatus,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -137,6 +137,19 @@ export type {
 } from "./cli/harness-status.js";
 export { buildEventEnvelopeV2 } from "./cli/harness-envelope.js";
 export type { EnvelopeContext } from "./cli/harness-envelope.js";
+export {
+  applySessionEnvelope,
+  foldSessionEnvelopes,
+  initialSessionView,
+  isV2,
+  parseSessionEnvelope,
+} from "./cli/harness-consumer.js";
+export type {
+  FeedEntry,
+  SessionView,
+  SessionViewLimits,
+  ToolActivity,
+} from "./cli/harness-consumer.js";
 
 export type {
   X402PaymentRequired,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -122,7 +122,21 @@ export {
   normalizeToolKind,
   toolDisplay,
 } from "./cli/harness-events.js";
-export type { HarnessSemanticEvent } from "./cli/harness-events.js";
+export type {
+  HarnessLineMapper,
+  HarnessSemanticEvent,
+} from "./cli/harness-events.js";
+export {
+  initialStatus,
+  reduceStatus,
+  tickStatus,
+} from "./cli/harness-status.js";
+export type {
+  SessionStatusState,
+  StatusStep,
+} from "./cli/harness-status.js";
+export { buildEventEnvelopeV2 } from "./cli/harness-envelope.js";
+export type { EnvelopeContext } from "./cli/harness-envelope.js";
 
 export type {
   X402PaymentRequired,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -87,14 +87,42 @@ export {
 } from "./x402.js";
 export { SDK_VERSION, SDK_CLIENT, HEADER_SDK_CLIENT } from "./version.js";
 export type {
+  AgentMessagePayload,
+  AgentThinkingPayload,
+  AnySessionEnvelope,
+  ApprovalRequestPayload,
+  ErrorPayload,
   HarnessBucketUnit,
   HarnessEnvelopeScope,
+  HarnessEvent,
+  HarnessEventKind,
+  HarnessEventRole,
   HarnessMessageRole,
   HarnessProvider,
+  HarnessSessionState,
+  HarnessToolKind,
+  LifecyclePayload,
   SessionEnvelope,
   SessionEnvelopeV1,
+  SessionEnvelopeV2,
+  StatusPayload,
+  ToolCallPayload,
+  ToolResultPayload,
+  UnknownPayload,
+  UserPromptPayload,
 } from "./types/harness.js";
-export { SESSION_ENVELOPE_VERSION_V1 } from "./types/harness.js";
+export {
+  SESSION_ENVELOPE_VERSION_V1,
+  SESSION_ENVELOPE_VERSION_V2,
+} from "./types/harness.js";
+export {
+  claudeEventsFromLine,
+  codexEventsFromLine,
+  harnessEventsFromLine,
+  normalizeToolKind,
+  toolDisplay,
+} from "./cli/harness-events.js";
+export type { HarnessSemanticEvent } from "./cli/harness-events.js";
 
 export type {
   X402PaymentRequired,

--- a/sdk/typescript/src/node/index.ts
+++ b/sdk/typescript/src/node/index.ts
@@ -16,3 +16,30 @@ registerDefaultSessionStore(async (signer) => {
 });
 
 export { FileSessionStore } from "./file-session-store.js";
+
+// Harness runtime helpers. These carry Node built-in imports transitively
+// (`harness-hooks` → `node:process`, `harness-envelope` → `node:crypto`), so
+// they are exposed here on the Node subpath rather than the isomorphic root,
+// keeping browser bundles free of Node-only module resolution. The matching
+// types are re-exported from the root (`@tinyhumansai/tinyplace`).
+export {
+  claudeEventsFromLine,
+  codexEventsFromLine,
+  harnessEventsFromLine,
+  normalizeToolKind,
+  toolDisplay,
+} from "../cli/harness-events.js";
+export {
+  claudeHookEventToSemantic,
+  claudeHookEventsFromStdin,
+  claudeHookStringToSemantic,
+} from "../cli/harness-hooks.js";
+export { initialStatus, reduceStatus, tickStatus } from "../cli/harness-status.js";
+export { buildEventEnvelopeV2 } from "../cli/harness-envelope.js";
+export {
+  applySessionEnvelope,
+  foldSessionEnvelopes,
+  initialSessionView,
+  isV2,
+  parseSessionEnvelope,
+} from "../cli/harness-consumer.js";

--- a/sdk/typescript/src/types/harness.ts
+++ b/sdk/typescript/src/types/harness.ts
@@ -44,3 +44,167 @@ export interface SessionEnvelopeV1 {
 }
 
 export type SessionEnvelope = SessionEnvelopeV1;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// v2 — typed event stream (`tinyplace.harness.session.v2`)
+//
+// Additive over v1: reuses bucket/scope/harness verbatim, swaps only v1's
+// `message` + `source` for a typed `event`. v1 and v2 coexist; consumers
+// discriminate on `envelope_version`. Existing `SessionEnvelope` alias above is
+// left pointing at v1 so no current importer changes behavior.
+//
+// Goal: the OpenHuman orchestrator tells apart tool_call · agent_message ·
+// tool_result · status · lifecycle · everything-else from one field
+// (`event.kind`) and picks a chat-bubble side from one field (`event.role`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// axis 1 — role (master-chat bubble side).
+//   owner == v1 "user"  (human / OpenHuman master's prompt into the session)
+//   agent == v1 "agent" (everything the session itself emits)
+export type HarnessEventRole = "owner" | "agent";
+
+// axis 2 — kind (content discriminator; the field the orchestrator switches on).
+export type HarnessEventKind =
+  | "user_prompt"
+  | "agent_message"
+  | "agent_thinking"
+  | "approval_request"
+  | "tool_call"
+  | "tool_result"
+  | "status"
+  | "lifecycle"
+  | "error"
+  | "unknown";
+
+// normalized tool family (raw harness name kept in tool_name).
+export type HarnessToolKind =
+  | "shell"
+  | "file_read"
+  | "file_write"
+  | "edit"
+  | "search"
+  | "web"
+  | "mcp"
+  | "task"
+  | "other";
+
+// derived activity state (drives OpenHuman InstanceStatus + currentTask).
+export type HarnessSessionState =
+  | "running"
+  | "running_tool"
+  | "waiting_approval"
+  | "idle"
+  | "stopped"
+  | "errored";
+
+export interface UserPromptPayload {
+  text: string;
+  source: "human" | "openhuman_inject";
+}
+
+export interface AgentMessagePayload {
+  text: string;
+}
+
+export interface AgentThinkingPayload {
+  text: string;
+}
+
+export interface ToolCallPayload {
+  call_id: string;
+  tool_name: string; // raw harness name, e.g. "Bash"
+  tool_kind: HarnessToolKind;
+  display: string; // one-line human summary, e.g. "npm test"
+  input: unknown; // bounded + redacted by the tailer before publish
+}
+
+export interface ToolResultPayload {
+  call_id: string;
+  ok: boolean;
+  exit_code?: number;
+  is_error: boolean;
+  output: string; // truncated (~4KB cap); suffix marks elision
+  output_bytes: number;
+}
+
+export interface ApprovalRequestPayload {
+  call_id?: string;
+  tool_name: string;
+  display: string;
+  reason?: string;
+}
+
+export interface StatusPayload {
+  state: HarnessSessionState;
+  detail: string; // -> SessionSummary.currentTask
+  active_call_id?: string;
+}
+
+export interface LifecyclePayload {
+  phase: "session_start" | "session_end" | "turn_start" | "turn_end" | "compact";
+}
+
+export interface ErrorPayload {
+  message: string;
+  fatal: boolean;
+}
+
+export interface UnknownPayload {
+  raw: unknown; // bounded
+}
+
+// discriminated union: kind <-> payload, with the coarse role fixed per kind
+// (owner iff kind === "user_prompt", else agent).
+export type HarnessEvent =
+  | { kind: "user_prompt"; role: "owner"; payload: UserPromptPayload }
+  | { kind: "agent_message"; role: "agent"; payload: AgentMessagePayload }
+  | { kind: "agent_thinking"; role: "agent"; payload: AgentThinkingPayload }
+  | { kind: "approval_request"; role: "agent"; payload: ApprovalRequestPayload }
+  | { kind: "tool_call"; role: "agent"; payload: ToolCallPayload }
+  | { kind: "tool_result"; role: "agent"; payload: ToolResultPayload }
+  | { kind: "status"; role: "agent"; payload: StatusPayload }
+  | { kind: "lifecycle"; role: "agent"; payload: LifecyclePayload }
+  | { kind: "error"; role: "agent"; payload: ErrorPayload }
+  | { kind: "unknown"; role: "agent"; payload: UnknownPayload };
+
+export const SESSION_ENVELOPE_VERSION_V2 = "tinyplace.harness.session.v2";
+
+export interface SessionEnvelopeV2 {
+  envelope_version: typeof SESSION_ENVELOPE_VERSION_V2;
+  version: 2;
+  // reused verbatim from v1 — transport contract unchanged.
+  bucket: {
+    unit: HarnessBucketUnit;
+    start: string;
+    end: string;
+  };
+  scope: {
+    type: HarnessEnvelopeScope;
+    key: string;
+    cwd: string;
+    wrapper_session_id: string;
+    harness_session_id: string;
+  };
+  harness: {
+    provider: HarnessProvider;
+    command: string;
+    argv: Array<string>;
+  };
+  // the only new surface (replaces v1 `message` + `source`).
+  event: {
+    id: string; // sha256(...) — idempotent, dedup on resend
+    seq: number; // monotonic per session — ordering
+    ts: string; // ISO-8601
+    turn_id?: string;
+    model?: string;
+  } & HarnessEvent;
+  source: {
+    path: string;
+    record_type: string; // origin, e.g. "jsonl:assistant" | "hook:PreToolUse"
+    source_role?: string;
+  };
+}
+
+// Union for consumers that accept either version. Existing `SessionEnvelope`
+// stays v1-only (above) on purpose, so current importers are untouched.
+export type AnySessionEnvelope = SessionEnvelopeV1 | SessionEnvelopeV2;

--- a/sdk/typescript/src/types/harness.ts
+++ b/sdk/typescript/src/types/harness.ts
@@ -201,7 +201,6 @@ export interface SessionEnvelopeV2 {
   source: {
     path: string;
     record_type: string; // origin, e.g. "jsonl:assistant" | "hook:PreToolUse"
-    source_role?: string;
   };
 }
 

--- a/sdk/typescript/tests/harness-consumer.test.ts
+++ b/sdk/typescript/tests/harness-consumer.test.ts
@@ -76,6 +76,37 @@ describe("parseSessionEnvelope", () => {
     expect(parseSessionEnvelope(42)).toBeUndefined();
   });
 
+  it("drops a version-tagged v2 body with a missing or malformed event", () => {
+    // Untrusted inbound DM: correct version tag but no usable event. Must be
+    // dropped, not cast through (else event.seq reads throw downstream).
+    expect(
+      parseSessionEnvelope({ envelope_version: "tinyplace.harness.session.v2" }),
+    ).toBeUndefined();
+    expect(
+      parseSessionEnvelope({
+        envelope_version: "tinyplace.harness.session.v2",
+        event: { id: "x" }, // seq missing
+      }),
+    ).toBeUndefined();
+    expect(
+      parseSessionEnvelope({
+        envelope_version: "tinyplace.harness.session.v2",
+        event: { seq: 1, id: 5 }, // id not a string
+      }),
+    ).toBeUndefined();
+  });
+
+  it("folds a stream containing a malformed v2 body without throwing", () => {
+    const good = streamFrom(LINES);
+    const poisoned = [
+      { envelope_version: "tinyplace.harness.session.v2" } as unknown as AnySessionEnvelope,
+      ...good,
+    ];
+    expect(() => foldSessionEnvelopes(poisoned)).not.toThrow();
+    const view = foldSessionEnvelopes(poisoned);
+    expect(view.provider).toBe("claude");
+  });
+
   it("recognises a v1 envelope but isV2 is false", () => {
     const v1 = { envelope_version: "tinyplace.harness.session.v1" } as unknown;
     const parsed = parseSessionEnvelope(v1);
@@ -102,6 +133,15 @@ describe("applySessionEnvelope", () => {
     const view = initialSessionView();
     const v1 = { envelope_version: "tinyplace.harness.session.v1" } as unknown as AnySessionEnvelope;
     expect(applySessionEnvelope(view, v1)).toBe(view);
+  });
+
+  it("returns the same view (no throw) for a malformed v2 envelope", () => {
+    const view = initialSessionView();
+    const malformed = {
+      envelope_version: "tinyplace.harness.session.v2",
+    } as unknown as AnySessionEnvelope;
+    expect(() => applySessionEnvelope(view, malformed)).not.toThrow();
+    expect(applySessionEnvelope(view, malformed)).toBe(view);
   });
 
   it("drops duplicate / out-of-order packets by seq", () => {

--- a/sdk/typescript/tests/harness-consumer.test.ts
+++ b/sdk/typescript/tests/harness-consumer.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  applySessionEnvelope,
+  foldSessionEnvelopes,
+  initialSessionView,
+  isV2,
+  parseSessionEnvelope,
+} from "../src/cli/harness-consumer.js";
+import { harnessEventsFromLine } from "../src/cli/harness-events.js";
+import { buildEventEnvelopeV2 } from "../src/cli/harness-envelope.js";
+import type { EnvelopeContext } from "../src/cli/harness-envelope.js";
+import type {
+  AnySessionEnvelope,
+  SessionEnvelopeV2,
+} from "../src/index.js";
+
+const ctx: EnvelopeContext = {
+  provider: "claude",
+  command: "claude",
+  argv: [],
+  scopeType: "session",
+  scopeKey: "k",
+  cwd: "/work/proj",
+  wrapperSessionId: "wrap-1",
+  harnessSessionId: "sess-1",
+  bucketUnit: "hour",
+  sourcePath: "/s.jsonl",
+};
+
+// Build a realistic v2 stream from Claude JSONL lines via the real producer.
+function streamFrom(lines: Array<string>): Array<SessionEnvelopeV2> {
+  let seq = 0;
+  const out: Array<SessionEnvelopeV2> = [];
+  lines.forEach((raw, index) => {
+    for (const semantic of harnessEventsFromLine("claude", raw, index)) {
+      out.push(buildEventEnvelopeV2(ctx, semantic, seq));
+      seq += 1;
+    }
+  });
+  return out;
+}
+
+const LINES = [
+  JSON.stringify({ type: "user", message: { role: "user", content: "run tests" } }),
+  JSON.stringify({
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "on it" },
+        { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "npm test" } },
+      ],
+    },
+  }),
+  JSON.stringify({
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "toolu_1", is_error: false, content: "12 passed" }],
+    },
+  }),
+];
+
+describe("parseSessionEnvelope", () => {
+  it("accepts a v2 JSON string and a v2 object", () => {
+    const env = streamFrom(LINES)[0];
+    const asString = parseSessionEnvelope(JSON.stringify(env));
+    expect(asString && isV2(asString)).toBe(true);
+    expect(parseSessionEnvelope(env)).toBeDefined();
+  });
+
+  it("rejects non-envelopes and garbage", () => {
+    expect(parseSessionEnvelope("not json")).toBeUndefined();
+    expect(parseSessionEnvelope({ hello: 1 })).toBeUndefined();
+    expect(parseSessionEnvelope(null)).toBeUndefined();
+    expect(parseSessionEnvelope(42)).toBeUndefined();
+  });
+
+  it("recognises a v1 envelope but isV2 is false", () => {
+    const v1 = { envelope_version: "tinyplace.harness.session.v1" } as unknown;
+    const parsed = parseSessionEnvelope(v1);
+    expect(parsed).toBeDefined();
+    expect(parsed && isV2(parsed)).toBe(false);
+  });
+});
+
+describe("applySessionEnvelope", () => {
+  it("marks running_tool with a descriptive currentTask on tool_call", () => {
+    const stream = streamFrom(LINES);
+    const call = stream.find((env) => env.event.kind === "tool_call");
+    if (!call) {
+      throw new Error("expected a tool_call in the stream");
+    }
+    const view = applySessionEnvelope(initialSessionView(), call);
+    expect(view.status).toBe("running_tool");
+    expect(view.currentTask).toBe("Bash: npm test");
+    expect(view.tools).toHaveLength(1);
+    expect(view.tools[0]).toMatchObject({ callId: "toolu_1", done: false });
+  });
+
+  it("ignores v1 envelopes and returns the same reference", () => {
+    const view = initialSessionView();
+    const v1 = { envelope_version: "tinyplace.harness.session.v1" } as unknown as AnySessionEnvelope;
+    expect(applySessionEnvelope(view, v1)).toBe(view);
+  });
+
+  it("drops duplicate / out-of-order packets by seq", () => {
+    const stream = streamFrom(LINES);
+    const first = applySessionEnvelope(initialSessionView(), stream[1]);
+    const replay = applySessionEnvelope(first, stream[1]);
+    expect(replay).toBe(first); // same seq -> no change, same ref
+  });
+});
+
+describe("foldSessionEnvelopes", () => {
+  it("reduces a full stream into live session state", () => {
+    const view = foldSessionEnvelopes(streamFrom(LINES));
+    expect(view.provider).toBe("claude");
+    expect(view.harnessSessionId).toBe("sess-1");
+    // tool ran and completed successfully.
+    const tool = view.tools.find((t) => t.callId === "toolu_1");
+    expect(tool).toMatchObject({ done: true, ok: true, isError: false });
+    // feed carries the human prompt, the agent line, and tool activity in order.
+    const kinds = view.feed.map((entry) => entry.kind);
+    expect(kinds).toContain("user_prompt");
+    expect(kinds).toContain("agent_message");
+    expect(kinds).toContain("tool_call");
+    expect(view.feed).toStrictEqual([...view.feed].sort((a, b) => a.seq - b.seq));
+  });
+
+  it("applies a status envelope to drive the dot and currentTask", () => {
+    const statusEnv = buildEventEnvelopeV2(
+      ctx,
+      {
+        line: 0,
+        timestamp: new Date("2026-07-07T10:00:00.000Z"),
+        recordType: "derived:status",
+        event: {
+          kind: "status",
+          role: "agent",
+          payload: { state: "waiting_approval", detail: "awaiting approval: rm -rf" },
+        },
+      },
+      0,
+    );
+    const view = applySessionEnvelope(initialSessionView(), statusEnv);
+    expect(view.status).toBe("waiting_approval");
+    expect(view.currentTask).toBe("awaiting approval: rm -rf");
+  });
+
+  it("caps the feed to the configured limit", () => {
+    const many = Array.from({ length: 10 }, (_unused, index) =>
+      JSON.stringify({
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: `line ${index}` }] },
+      }),
+    );
+    const view = foldSessionEnvelopes(streamFrom(many), { tools: 50, feed: 3 });
+    expect(view.feed).toHaveLength(3);
+    expect(view.feed[view.feed.length - 1].text).toBe("line 9");
+  });
+});

--- a/sdk/typescript/tests/harness-envelope.test.ts
+++ b/sdk/typescript/tests/harness-envelope.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEventEnvelopeV2,
+} from "../src/cli/harness-envelope.js";
+import type { EnvelopeContext } from "../src/cli/harness-envelope.js";
+import type { HarnessSemanticEvent } from "../src/cli/harness-events.js";
+
+const ctx: EnvelopeContext = {
+  provider: "claude",
+  command: "claude",
+  argv: ["--resume"],
+  scopeType: "session",
+  scopeKey: "abc",
+  cwd: "/work/proj",
+  wrapperSessionId: "wrap-1",
+  harnessSessionId: "sess-1",
+  bucketUnit: "hour",
+  sourcePath: "/home/u/.claude/projects/p/sess-1.jsonl",
+};
+
+const toolCall: HarnessSemanticEvent = {
+  line: 7,
+  timestamp: new Date("2026-07-07T10:34:12.000Z"),
+  recordType: "assistant:tool_use",
+  event: {
+    kind: "tool_call",
+    role: "agent",
+    payload: {
+      call_id: "toolu_1",
+      tool_name: "Bash",
+      tool_kind: "shell",
+      display: "npm test",
+      input: { command: "npm test" },
+    },
+  },
+};
+
+describe("buildEventEnvelopeV2", () => {
+  it("stamps version, provider and the typed event through", () => {
+    const env = buildEventEnvelopeV2(ctx, toolCall, 3);
+    expect(env.envelope_version).toBe("tinyplace.harness.session.v2");
+    expect(env.version).toBe(2);
+    expect(env.harness.provider).toBe("claude");
+    expect(env.event).toMatchObject({
+      seq: 3,
+      kind: "tool_call",
+      role: "agent",
+      ts: "2026-07-07T10:34:12.000Z",
+      payload: { call_id: "toolu_1", tool_name: "Bash" },
+    });
+    expect(env.source).toMatchObject({
+      path: ctx.sourcePath,
+      record_type: "assistant:tool_use",
+    });
+  });
+
+  it("floors the bucket to the configured unit", () => {
+    const hour = buildEventEnvelopeV2(ctx, toolCall, 1);
+    expect(hour.bucket).toMatchObject({
+      unit: "hour",
+      start: "2026-07-07T10:00:00.000Z",
+      end: "2026-07-07T11:00:00.000Z",
+    });
+    const day = buildEventEnvelopeV2({ ...ctx, bucketUnit: "day" }, toolCall, 1);
+    expect(day.bucket).toMatchObject({
+      start: "2026-07-07T00:00:00.000Z",
+      end: "2026-07-08T00:00:00.000Z",
+    });
+    const minute = buildEventEnvelopeV2({ ...ctx, bucketUnit: "minute" }, toolCall, 1);
+    expect(minute.bucket).toMatchObject({
+      start: "2026-07-07T10:34:00.000Z",
+      end: "2026-07-07T10:35:00.000Z",
+    });
+  });
+
+  it("produces a stable id for identical inputs and a different id per seq", () => {
+    const a = buildEventEnvelopeV2(ctx, toolCall, 3).event.id;
+    const b = buildEventEnvelopeV2(ctx, toolCall, 3).event.id;
+    const c = buildEventEnvelopeV2(ctx, toolCall, 4).event.id;
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("includes turn_id and model only when provided", () => {
+    const bare = buildEventEnvelopeV2(ctx, toolCall, 1).event;
+    expect("turn_id" in bare).toBe(false);
+    expect("model" in bare).toBe(false);
+    const rich = buildEventEnvelopeV2(
+      { ...ctx, turnId: "turn-9", model: "claude-opus" },
+      toolCall,
+      1,
+    ).event;
+    expect(rich).toMatchObject({ turn_id: "turn-9", model: "claude-opus" });
+  });
+});

--- a/sdk/typescript/tests/harness-events.test.ts
+++ b/sdk/typescript/tests/harness-events.test.ts
@@ -238,6 +238,25 @@ describe("codexEventsFromLine", () => {
     });
   });
 
+  it("parses JSON-string arguments into structured input and a field display", () => {
+    const events = codexEventsFromLine(
+      claudeLine({
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "shell",
+          call_id: "call_args",
+          arguments: '{"command":"cargo test","description":"run tests"}',
+        },
+      }),
+      6,
+    );
+    expect(events[0].event.payload).toMatchObject({
+      display: "cargo test",
+      input: { command: "cargo test", description: "run tests" },
+    });
+  });
+
   it("maps a function_call_output to a tool_result with the same call_id", () => {
     const events = codexEventsFromLine(
       claudeLine({

--- a/sdk/typescript/tests/harness-events.test.ts
+++ b/sdk/typescript/tests/harness-events.test.ts
@@ -7,6 +7,7 @@ import {
   toolDisplay,
 } from "../src/cli/harness-events.js";
 import type { HarnessSemanticEvent } from "../src/cli/harness-events.js";
+import type { HarnessProvider } from "../src/types/harness.js";
 
 // Fixture lines mirror the real on-disk shapes verified against live sessions:
 //   Claude ~/.claude/projects/*/*.jsonl, Codex ~/.codex/sessions/**/rollout-*.jsonl
@@ -280,6 +281,15 @@ describe("harnessEventsFromLine dispatch", () => {
       1,
     );
     expect(codex[0].event.kind).toBe("user_prompt");
+  });
+
+  it("returns [] for an unregistered provider instead of guessing a branch", () => {
+    const events = harnessEventsFromLine(
+      "gemini" as HarnessProvider,
+      claudeLine({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "x" }] } }),
+      1,
+    );
+    expect(events).toStrictEqual([]);
   });
 });
 

--- a/sdk/typescript/tests/harness-events.test.ts
+++ b/sdk/typescript/tests/harness-events.test.ts
@@ -179,6 +179,28 @@ describe("claudeEventsFromLine", () => {
     expect(claudeEventsFromLine("not json", 9)).toStrictEqual([]);
     expect(claudeEventsFromLine(claudeLine({ type: "system" }), 10)).toStrictEqual([]);
   });
+
+  it("byte-caps multi-byte tool_result output within the byte budget", () => {
+    // 3000 four-byte emoji = 12000 UTF-8 bytes. A code-unit `slice(0, 4096)`
+    // would keep ~8192 bytes and defeat the cap, so this asserts a true byte
+    // bound and that the boundary never leaves a split code point.
+    const huge = "😀".repeat(3000);
+    const events = claudeEventsFromLine(
+      claudeLine({
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_big", content: huge }],
+        },
+      }),
+      11,
+    );
+    const output = (events[0].event.payload as { output: string }).output;
+    const elisionBytes = Buffer.byteLength("\n…[truncated]", "utf8");
+    expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(4096 + elisionBytes);
+    expect(output.endsWith("…[truncated]")).toBe(true);
+    expect(output).not.toContain("�");
+  });
 });
 
 describe("codexEventsFromLine", () => {

--- a/sdk/typescript/tests/harness-events.test.ts
+++ b/sdk/typescript/tests/harness-events.test.ts
@@ -201,6 +201,42 @@ describe("claudeEventsFromLine", () => {
     expect(output.endsWith("…[truncated]")).toBe(true);
     expect(output).not.toContain("�");
   });
+
+  it("bounds an oversized tool_input but keeps small inputs structured", () => {
+    const big = claudeEventsFromLine(
+      claudeLine({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_big",
+              name: "Write",
+              input: { file_path: "/a.ts", content: "x".repeat(20000) },
+            },
+          ],
+        },
+      }),
+      12,
+    );
+    const input = (big[0].event.payload as { input: unknown }).input;
+    const elisionBytes = Buffer.byteLength("\n…[truncated]", "utf8");
+    expect(typeof input).toBe("string");
+    expect(Buffer.byteLength(input as string, "utf8")).toBeLessThanOrEqual(4096 + elisionBytes);
+
+    const small = claudeEventsFromLine(
+      claudeLine({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t2", name: "Read", input: { file_path: "/a.ts" } }],
+        },
+      }),
+      13,
+    );
+    expect((small[0].event.payload as { input: unknown }).input).toEqual({ file_path: "/a.ts" });
+  });
 });
 
 describe("codexEventsFromLine", () => {

--- a/sdk/typescript/tests/harness-events.test.ts
+++ b/sdk/typescript/tests/harness-events.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "vitest";
+import {
+  claudeEventsFromLine,
+  codexEventsFromLine,
+  harnessEventsFromLine,
+  normalizeToolKind,
+  toolDisplay,
+} from "../src/cli/harness-events.js";
+import type { HarnessSemanticEvent } from "../src/cli/harness-events.js";
+
+// Fixture lines mirror the real on-disk shapes verified against live sessions:
+//   Claude ~/.claude/projects/*/*.jsonl, Codex ~/.codex/sessions/**/rollout-*.jsonl
+
+function claudeLine(record: unknown): string {
+  return JSON.stringify(record);
+}
+
+const kinds = (events: Array<HarnessSemanticEvent>): Array<string> =>
+  events.map((event) => event.event.kind);
+
+describe("claudeEventsFromLine", () => {
+  it("maps an assistant text block to agent_message", () => {
+    const events = claudeEventsFromLine(
+      claudeLine({
+        type: "assistant",
+        timestamp: "2026-07-07T10:00:00.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+      }),
+      1,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toMatchObject({
+      kind: "agent_message",
+      role: "agent",
+      payload: { text: "hello" },
+    });
+  });
+
+  it("maps a thinking block to agent_thinking", () => {
+    const events = claudeEventsFromLine(
+      claudeLine({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "let me reason" }],
+        },
+      }),
+      2,
+    );
+    expect(events[0].event).toMatchObject({
+      kind: "agent_thinking",
+      payload: { text: "let me reason" },
+    });
+  });
+
+  it("maps a tool_use block to a typed tool_call with kind + display", () => {
+    const events = claudeEventsFromLine(
+      claudeLine({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_abc",
+              name: "Bash",
+              input: { command: "npm test", description: "run tests" },
+            },
+          ],
+        },
+      }),
+      3,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toMatchObject({
+      kind: "tool_call",
+      role: "agent",
+      payload: {
+        call_id: "toolu_abc",
+        tool_name: "Bash",
+        tool_kind: "shell",
+        display: "npm test",
+      },
+    });
+  });
+
+  it("maps a tool_result block on a user record to tool_result", () => {
+    const events = claudeEventsFromLine(
+      claudeLine({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_abc",
+              is_error: false,
+              content: [{ type: "text", text: "ok, 12 passed" }],
+            },
+          ],
+        },
+      }),
+      4,
+    );
+    expect(events[0].event).toMatchObject({
+      kind: "tool_result",
+      role: "agent",
+      payload: { call_id: "toolu_abc", ok: true, is_error: false },
+    });
+    const payload = events[0].event.payload as { output: string };
+    expect(payload.output).toContain("12 passed");
+  });
+
+  it("maps a plain user text record to an owner-role user_prompt", () => {
+    const events = claudeEventsFromLine(
+      claudeLine({
+        type: "user",
+        message: { role: "user", content: "please fix the bug" },
+      }),
+      5,
+    );
+    expect(events[0].event).toMatchObject({
+      kind: "user_prompt",
+      role: "owner",
+      payload: { text: "please fix the bug", source: "human" },
+    });
+  });
+
+  it("splits a mixed assistant record into per-block events, preserving order", () => {
+    const events = claudeEventsFromLine(
+      claudeLine({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "running now" },
+            { type: "tool_use", id: "toolu_x", name: "Read", input: { file_path: "/a/b.ts" } },
+          ],
+        },
+      }),
+      6,
+    );
+    expect(kinds(events)).toStrictEqual(["agent_message", "tool_call"]);
+    expect(events[1].event.payload).toMatchObject({
+      tool_kind: "file_read",
+      display: "/a/b.ts",
+    });
+  });
+
+  it("correlates tool_call and tool_result via call_id", () => {
+    const call = claudeEventsFromLine(
+      claudeLine({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_9", name: "Bash", input: { command: "ls" } }],
+        },
+      }),
+      7,
+    );
+    const result = claudeEventsFromLine(
+      claudeLine({
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_9", content: "a\nb" }],
+        },
+      }),
+      8,
+    );
+    const callId = (call[0].event.payload as { call_id: string }).call_id;
+    const resultId = (result[0].event.payload as { call_id: string }).call_id;
+    expect(callId).toBe("toolu_9");
+    expect(resultId).toBe(callId);
+  });
+
+  it("returns nothing for an unparseable line", () => {
+    expect(claudeEventsFromLine("not json", 9)).toStrictEqual([]);
+    expect(claudeEventsFromLine(claudeLine({ type: "system" }), 10)).toStrictEqual([]);
+  });
+});
+
+describe("codexEventsFromLine", () => {
+  it("maps a user_message event to an owner user_prompt", () => {
+    const events = codexEventsFromLine(
+      claudeLine({
+        type: "event_msg",
+        payload: { type: "user_message", message: "hi codex" },
+      }),
+      1,
+    );
+    expect(events[0].event).toMatchObject({
+      kind: "user_prompt",
+      role: "owner",
+      payload: { text: "hi codex" },
+    });
+  });
+
+  it("maps a function_call to a tool_call", () => {
+    const events = codexEventsFromLine(
+      claudeLine({
+        type: "response_item",
+        payload: {
+          type: "function_call",
+          name: "shell",
+          call_id: "call_1",
+          arguments: '{"command":"cargo test"}',
+        },
+      }),
+      2,
+    );
+    expect(events[0].event).toMatchObject({
+      kind: "tool_call",
+      payload: { call_id: "call_1", tool_name: "shell", tool_kind: "shell" },
+    });
+  });
+
+  it("maps a function_call_output to a tool_result with the same call_id", () => {
+    const events = codexEventsFromLine(
+      claudeLine({
+        type: "response_item",
+        payload: {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: { content: "done", success: true },
+        },
+      }),
+      3,
+    );
+    expect(events[0].event).toMatchObject({
+      kind: "tool_result",
+      payload: { call_id: "call_1", ok: true, is_error: false },
+    });
+  });
+
+  it("maps a reasoning payload to agent_thinking", () => {
+    const events = codexEventsFromLine(
+      claudeLine({
+        type: "response_item",
+        payload: {
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "plan the change" }],
+        },
+      }),
+      4,
+    );
+    expect(events[0].event).toMatchObject({
+      kind: "agent_thinking",
+      payload: { text: "plan the change" },
+    });
+  });
+
+  it("flags a failed function_call_output as an error", () => {
+    const events = codexEventsFromLine(
+      claudeLine({
+        type: "response_item",
+        payload: {
+          type: "function_call_output",
+          call_id: "call_2",
+          output: { content: "boom", success: false },
+        },
+      }),
+      5,
+    );
+    expect(events[0].event.payload).toMatchObject({ ok: false, is_error: true });
+  });
+});
+
+describe("harnessEventsFromLine dispatch", () => {
+  it("routes by provider", () => {
+    const claude = harnessEventsFromLine(
+      "claude",
+      claudeLine({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "x" }] } }),
+      1,
+    );
+    expect(claude[0].event.kind).toBe("agent_message");
+    const codex = harnessEventsFromLine(
+      "codex",
+      claudeLine({ type: "event_msg", payload: { type: "user_message", message: "y" } }),
+      1,
+    );
+    expect(codex[0].event.kind).toBe("user_prompt");
+  });
+});
+
+describe("normalizeToolKind", () => {
+  it.each([
+    ["Bash", "shell"],
+    ["Read", "file_read"],
+    ["Write", "file_write"],
+    ["Edit", "edit"],
+    ["MultiEdit", "edit"],
+    ["Grep", "search"],
+    ["Glob", "search"],
+    ["WebFetch", "web"],
+    ["Task", "task"],
+    ["mcp__sentry__update_issue", "mcp"],
+    ["apply_patch", "edit"],
+    ["SomethingNew", "other"],
+  ])("classifies %s as %s", (name, expected) => {
+    expect(normalizeToolKind(name)).toBe(expected);
+  });
+});
+
+describe("toolDisplay", () => {
+  it("prefers the command field", () => {
+    expect(toolDisplay("Bash", { command: "ls -la" })).toBe("ls -la");
+  });
+  it("falls back to file_path then pattern then name", () => {
+    expect(toolDisplay("Read", { file_path: "/x.ts" })).toBe("/x.ts");
+    expect(toolDisplay("Grep", { pattern: "TODO" })).toBe("TODO");
+    expect(toolDisplay("Mystery", {})).toBe("Mystery");
+  });
+  it("takes only the first line and bounds length", () => {
+    expect(toolDisplay("Bash", { command: "line1\nline2" })).toBe("line1");
+  });
+});

--- a/sdk/typescript/tests/harness-hooks.test.ts
+++ b/sdk/typescript/tests/harness-hooks.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vitest";
+import {
+  claudeHookEventToSemantic,
+  claudeHookEventsFromStdin,
+  claudeHookStringToSemantic,
+} from "../src/cli/harness-hooks.js";
+import { Readable } from "node:stream";
+import type { HarnessSemanticEvent } from "../src/cli/harness-events.js";
+
+// Fixtures mirror the real hook payloads Claude Code pipes to a hook command's
+// stdin, verified against Claude Code 2.1.202. Every payload carries the common
+// scope fields (session_id / transcript_path / cwd / hook_event_name) plus its
+// per-event fields.
+
+const AT = new Date("2026-07-07T12:00:00.000Z");
+
+const common = {
+  session_id: "sess-abc123",
+  transcript_path: "/Users/dev/.claude/projects/proj/sess-abc123.jsonl",
+  cwd: "/Users/dev/work/project",
+  permission_mode: "default",
+};
+
+const kinds = (events: Array<HarnessSemanticEvent>): Array<string> =>
+  events.map((event) => event.event.kind);
+
+describe("claudeHookEventToSemantic", () => {
+  it("maps PreToolUse to a typed tool_call with kind + display + call_id", () => {
+    const events = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "npm test", description: "run tests" },
+        tool_use_id: "toolu_01ABC",
+      },
+      AT,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].recordType).toBe("hook:PreToolUse");
+    expect(events[0].timestamp).toBe(AT);
+    expect(events[0].event).toMatchObject({
+      kind: "tool_call",
+      role: "agent",
+      payload: {
+        call_id: "toolu_01ABC",
+        tool_name: "Bash",
+        tool_kind: "shell",
+        display: "npm test",
+        input: { command: "npm test", description: "run tests" },
+      },
+    });
+  });
+
+  it("maps an MCP PreToolUse to tool_kind mcp", () => {
+    const events = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "PreToolUse",
+        tool_name: "mcp__tinyplace__send",
+        tool_input: { to: "@peer", text: "hi" },
+        tool_use_id: "toolu_mcp1",
+      },
+      AT,
+    );
+    expect(events[0].event).toMatchObject({
+      kind: "tool_call",
+      payload: { tool_kind: "mcp", tool_name: "mcp__tinyplace__send" },
+    });
+  });
+
+  it("maps PostToolUse (string response) to a successful tool_result", () => {
+    const events = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "PostToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "echo hi" },
+        tool_response: "hi\n",
+        tool_use_id: "toolu_01ABC",
+        duration_ms: 42,
+      },
+      AT,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].recordType).toBe("hook:PostToolUse");
+    expect(events[0].event).toMatchObject({
+      kind: "tool_result",
+      role: "agent",
+      payload: {
+        call_id: "toolu_01ABC",
+        ok: true,
+        is_error: false,
+        output: "hi\n",
+        output_bytes: 3,
+      },
+    });
+  });
+
+  it("correlates a PreToolUse tool_call with its PostToolUse tool_result via tool_use_id", () => {
+    const pre = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "PreToolUse",
+        tool_name: "Read",
+        tool_input: { file_path: "/tmp/a.txt" },
+        tool_use_id: "toolu_shared99",
+      },
+      AT,
+    );
+    const post = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "PostToolUse",
+        tool_name: "Read",
+        tool_input: { file_path: "/tmp/a.txt" },
+        tool_response: { content: [{ type: "text", text: "file body" }] },
+        tool_use_id: "toolu_shared99",
+      },
+      AT,
+    );
+    const call = pre[0].event;
+    const result = post[0].event;
+    if (call.kind !== "tool_call" || result.kind !== "tool_result") {
+      throw new Error("unexpected event kinds");
+    }
+    expect(call.payload.call_id).toBe("toolu_shared99");
+    expect(result.payload.call_id).toBe(call.payload.call_id);
+    expect(result.payload.output).toBe("file body");
+  });
+
+  it("flags a PostToolUse error response via tool_result is_error", () => {
+    const events = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "PostToolUse",
+        tool_name: "Bash",
+        tool_input: { command: "false" },
+        tool_response: { stderr: "boom", is_error: true },
+        tool_use_id: "toolu_err",
+      },
+      AT,
+    );
+    expect(events[0].event).toMatchObject({
+      kind: "tool_result",
+      payload: { ok: false, is_error: true, output: "boom" },
+    });
+  });
+
+  it("maps UserPromptSubmit to an owner user_prompt", () => {
+    const events = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "UserPromptSubmit",
+        prompt: "fix the failing test",
+        session_title: "debug",
+      },
+      AT,
+    );
+    expect(events[0].recordType).toBe("hook:UserPromptSubmit");
+    expect(events[0].event).toMatchObject({
+      kind: "user_prompt",
+      role: "owner",
+      payload: { text: "fix the failing test", source: "human" },
+    });
+  });
+
+  it("drops an empty UserPromptSubmit", () => {
+    const events = claudeHookEventToSemantic(
+      { ...common, hook_event_name: "UserPromptSubmit", prompt: "" },
+      AT,
+    );
+    expect(events).toHaveLength(0);
+  });
+
+  it("maps Stop to a turn_end lifecycle", () => {
+    const events = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "Stop",
+        stop_hook_active: true,
+        last_assistant_message: "done",
+      },
+      AT,
+    );
+    expect(events[0].recordType).toBe("hook:Stop");
+    expect(events[0].event).toMatchObject({
+      kind: "lifecycle",
+      role: "agent",
+      payload: { phase: "turn_end" },
+    });
+  });
+
+  it("maps SubagentStop to a turn_end lifecycle", () => {
+    const events = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "SubagentStop",
+        stop_hook_active: false,
+        agent_id: "agent-1",
+        agent_type: "Explore",
+      },
+      AT,
+    );
+    expect(events[0].recordType).toBe("hook:SubagentStop");
+    expect(events[0].event).toMatchObject({
+      kind: "lifecycle",
+      payload: { phase: "turn_end" },
+    });
+  });
+
+  it("maps SessionStart to a session_start lifecycle", () => {
+    const events = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "SessionStart",
+        source: "startup",
+        model: "claude-opus-4",
+      },
+      AT,
+    );
+    expect(events[0].recordType).toBe("hook:SessionStart");
+    expect(events[0].event).toMatchObject({
+      kind: "lifecycle",
+      payload: { phase: "session_start" },
+    });
+  });
+
+  it("maps a compact SessionStart to a compact lifecycle", () => {
+    const events = claudeHookEventToSemantic(
+      { ...common, hook_event_name: "SessionStart", source: "compact" },
+      AT,
+    );
+    expect(events[0].event).toMatchObject({
+      kind: "lifecycle",
+      payload: { phase: "compact" },
+    });
+  });
+
+  it("maps SessionEnd to a session_end lifecycle", () => {
+    const events = claudeHookEventToSemantic(
+      { ...common, hook_event_name: "SessionEnd", reason: "logout" },
+      AT,
+    );
+    expect(events[0].recordType).toBe("hook:SessionEnd");
+    expect(events[0].event).toMatchObject({
+      kind: "lifecycle",
+      payload: { phase: "session_end" },
+    });
+  });
+
+  it("maps a permission-prompt Notification to an approval_request", () => {
+    const events = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "Notification",
+        message: "Claude needs your permission to use Bash",
+        notification_type: "permission_prompt",
+      },
+      AT,
+    );
+    expect(events[0].recordType).toBe("hook:Notification");
+    expect(events[0].event).toMatchObject({
+      kind: "approval_request",
+      role: "agent",
+      payload: {
+        display: "Claude needs your permission to use Bash",
+        reason: "permission_prompt",
+      },
+    });
+  });
+
+  it("maps a non-permission Notification to a bounded unknown", () => {
+    const events = claudeHookEventToSemantic(
+      {
+        ...common,
+        hook_event_name: "Notification",
+        message: "Claude is waiting for your input",
+        notification_type: "idle_prompt",
+      },
+      AT,
+    );
+    expect(events[0].event.kind).toBe("unknown");
+  });
+
+  it("maps an unrecognized hook event to a bounded unknown", () => {
+    const events = claudeHookEventToSemantic(
+      { ...common, hook_event_name: "PreCompact", trigger: "auto" },
+      AT,
+    );
+    expect(events[0].recordType).toBe("hook:PreCompact");
+    expect(events[0].event).toMatchObject({
+      kind: "unknown",
+      role: "agent",
+    });
+    const event = events[0].event;
+    if (event.kind !== "unknown") {
+      throw new Error("expected unknown");
+    }
+    expect(event.payload.raw).toMatchObject({ hook_event_name: "PreCompact" });
+  });
+
+  it("maps a non-object payload to a bounded unknown", () => {
+    const events = claudeHookEventToSemantic("not json object", AT);
+    expect(events).toHaveLength(1);
+    expect(events[0].event.kind).toBe("unknown");
+    expect(kinds(events)).toEqual(["unknown"]);
+  });
+
+  it("bounds an oversized unknown raw payload to a truncated string", () => {
+    const big = "x".repeat(20_000);
+    const events = claudeHookEventToSemantic(
+      { ...common, hook_event_name: "Mystery", blob: big },
+      AT,
+    );
+    const event = events[0].event;
+    if (event.kind !== "unknown") {
+      throw new Error("expected unknown");
+    }
+    expect(typeof event.payload.raw).toBe("string");
+    expect((event.payload.raw as string).endsWith("…[truncated]")).toBe(true);
+  });
+});
+
+describe("claudeHookStringToSemantic", () => {
+  it("parses a JSON string payload and maps it", () => {
+    const raw = JSON.stringify({
+      ...common,
+      hook_event_name: "UserPromptSubmit",
+      prompt: "hello from stdin",
+    });
+    const events = claudeHookStringToSemantic(raw, AT);
+    expect(events[0].event).toMatchObject({
+      kind: "user_prompt",
+      payload: { text: "hello from stdin" },
+    });
+  });
+
+  it("maps an unparseable string to a bounded unknown", () => {
+    const events = claudeHookStringToSemantic("{ not json", AT);
+    expect(events[0].recordType).toBe("hook:unparseable");
+    expect(events[0].event.kind).toBe("unknown");
+  });
+});
+
+describe("claudeHookEventsFromStdin", () => {
+  it("reads a hook payload from a stream and maps it", async () => {
+    const raw = JSON.stringify({
+      ...common,
+      hook_event_name: "PreToolUse",
+      tool_name: "Grep",
+      tool_input: { pattern: "TODO" },
+      tool_use_id: "toolu_stdin",
+    });
+    const stream = Readable.from([Buffer.from(raw, "utf8")]);
+    const events = await claudeHookEventsFromStdin(stream, AT);
+    expect(events[0].event).toMatchObject({
+      kind: "tool_call",
+      payload: { tool_kind: "search", call_id: "toolu_stdin" },
+    });
+  });
+});

--- a/sdk/typescript/tests/harness-status.test.ts
+++ b/sdk/typescript/tests/harness-status.test.ts
@@ -119,6 +119,15 @@ describe("reduceStatus", () => {
     expect(soft.next.state).toBe("running");
   });
 
+  it("surfaces a compact lifecycle phase as active compaction", () => {
+    const step = reduceStatus(
+      initialStatus(),
+      ev({ kind: "lifecycle", role: "agent", payload: { phase: "compact" } }),
+    );
+    expect(step.next.state).toBe("running");
+    expect(step.emit).toMatchObject({ state: "running", detail: "compacting" });
+  });
+
   it("stops on a session_end lifecycle event", () => {
     const step = reduceStatus(
       initialStatus(),

--- a/sdk/typescript/tests/harness-status.test.ts
+++ b/sdk/typescript/tests/harness-status.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialStatus,
+  reduceStatus,
+  tickStatus,
+} from "../src/cli/harness-status.js";
+import type { HarnessSemanticEvent } from "../src/cli/harness-events.js";
+import type { HarnessEvent } from "../src/types/harness.js";
+
+function ev(inner: HarnessEvent, atMs = 1_000): HarnessSemanticEvent {
+  return {
+    line: 1,
+    timestamp: new Date(atMs),
+    recordType: "test",
+    event: inner,
+  };
+}
+
+describe("reduceStatus", () => {
+  it("starts idle", () => {
+    expect(initialStatus().state).toBe("idle");
+  });
+
+  it("moves to running on a user prompt", () => {
+    const step = reduceStatus(
+      initialStatus(),
+      ev({ kind: "user_prompt", role: "owner", payload: { text: "go", source: "human" } }),
+    );
+    expect(step.next.state).toBe("running");
+    expect(step.emit).toMatchObject({ state: "running", detail: "working" });
+  });
+
+  it("enters running_tool with the active call id and a descriptive detail", () => {
+    const step = reduceStatus(
+      initialStatus(),
+      ev({
+        kind: "tool_call",
+        role: "agent",
+        payload: {
+          call_id: "toolu_1",
+          tool_name: "Bash",
+          tool_kind: "shell",
+          display: "npm test",
+          input: {},
+        },
+      }),
+    );
+    expect(step.next).toMatchObject({ state: "running_tool", activeCallId: "toolu_1" });
+    expect(step.emit).toMatchObject({
+      state: "running_tool",
+      detail: "running Bash: npm test",
+      active_call_id: "toolu_1",
+    });
+  });
+
+  it("clears the active call id and returns to running on tool_result", () => {
+    const running = reduceStatus(
+      initialStatus(),
+      ev({
+        kind: "tool_call",
+        role: "agent",
+        payload: { call_id: "toolu_1", tool_name: "Bash", tool_kind: "shell", display: "ls", input: {} },
+      }),
+    ).next;
+    const step = reduceStatus(
+      running,
+      ev({
+        kind: "tool_result",
+        role: "agent",
+        payload: { call_id: "toolu_1", ok: true, is_error: false, output: "x", output_bytes: 1 },
+      }),
+    );
+    expect(step.next.state).toBe("running");
+    expect(step.next.activeCallId).toBeUndefined();
+    expect(step.emit?.active_call_id).toBeUndefined();
+  });
+
+  it("is change-gated: no emit when state and detail repeat", () => {
+    const first = reduceStatus(
+      initialStatus(),
+      ev({ kind: "agent_thinking", role: "agent", payload: { text: "a" } }),
+    );
+    const second = reduceStatus(
+      first.next,
+      ev({ kind: "agent_thinking", role: "agent", payload: { text: "b" } }, 2_000),
+    );
+    expect(first.emit).toBeDefined();
+    expect(second.emit).toBeUndefined();
+  });
+
+  it("blocks on approval requests", () => {
+    const step = reduceStatus(
+      initialStatus(),
+      ev({
+        kind: "approval_request",
+        role: "agent",
+        payload: { call_id: "toolu_2", tool_name: "Bash", display: "rm -rf build" },
+      }),
+    );
+    expect(step.emit).toMatchObject({
+      state: "waiting_approval",
+      active_call_id: "toolu_2",
+    });
+  });
+
+  it("goes to errored on a fatal error and stays running on a soft one", () => {
+    const fatal = reduceStatus(
+      initialStatus(),
+      ev({ kind: "error", role: "agent", payload: { message: "oom", fatal: true } }),
+    );
+    expect(fatal.next.state).toBe("errored");
+    const soft = reduceStatus(
+      initialStatus(),
+      ev({ kind: "error", role: "agent", payload: { message: "retrying", fatal: false } }),
+    );
+    expect(soft.next.state).toBe("running");
+  });
+
+  it("stops on a session_end lifecycle event", () => {
+    const step = reduceStatus(
+      initialStatus(),
+      ev({ kind: "lifecycle", role: "agent", payload: { phase: "session_end" } }),
+    );
+    expect(step.next.state).toBe("stopped");
+  });
+
+  it("ignores unknown events but advances the activity clock", () => {
+    const start = { ...initialStatus(), state: "running" as const, lastEventAtMs: 1_000 };
+    const step = reduceStatus(
+      start,
+      ev({ kind: "unknown", role: "agent", payload: { raw: {} } }, 5_000),
+    );
+    expect(step.emit).toBeUndefined();
+    expect(step.next.state).toBe("running");
+    expect(step.next.lastEventAtMs).toBe(5_000);
+  });
+});
+
+describe("tickStatus", () => {
+  const running = { state: "running" as const, detail: "working", lastEventAtMs: 1_000 };
+
+  it("ages a silent active session into idle past the threshold", () => {
+    const step = tickStatus(running, 40_000, { idleAfterMs: 30_000 });
+    expect(step.next.state).toBe("idle");
+    expect(step.emit).toMatchObject({ state: "idle" });
+  });
+
+  it("re-emits current status as a heartbeat when not yet stale", () => {
+    const step = tickStatus(running, 10_000, { idleAfterMs: 30_000, heartbeat: true });
+    expect(step.emit).toMatchObject({ state: "running", detail: "working" });
+    expect(step.next).toBe(running);
+  });
+
+  it("emits nothing when not stale and heartbeat is off", () => {
+    const step = tickStatus(running, 10_000, { idleAfterMs: 30_000 });
+    expect(step.emit).toBeUndefined();
+  });
+
+  it("does not re-idle an already idle session", () => {
+    const idle = { state: "idle" as const, detail: "idle", lastEventAtMs: 1_000 };
+    const step = tickStatus(idle, 999_999, { idleAfterMs: 30_000 });
+    expect(step.emit).toBeUndefined();
+  });
+});

--- a/sdk/typescript/tests/harness-status.test.ts
+++ b/sdk/typescript/tests/harness-status.test.ts
@@ -4,7 +4,10 @@ import {
   reduceStatus,
   tickStatus,
 } from "../src/cli/harness-status.js";
-import type { HarnessSemanticEvent } from "../src/cli/harness-events.js";
+import {
+  codexEventsFromLine,
+  type HarnessSemanticEvent,
+} from "../src/cli/harness-events.js";
 import type { HarnessEvent } from "../src/types/harness.js";
 
 function ev(inner: HarnessEvent, atMs = 1_000): HarnessSemanticEvent {
@@ -122,6 +125,26 @@ describe("reduceStatus", () => {
       ev({ kind: "lifecycle", role: "agent", payload: { phase: "session_end" } }),
     );
     expect(step.next.state).toBe("stopped");
+  });
+
+  it("keeps a timestamp-less Codex tool_call active instead of idling it", () => {
+    // A Codex record with no timestamp used to stamp the Unix epoch, so the
+    // activity clock never advanced and the very next tick idled a live session.
+    const [event] = codexEventsFromLine(
+      JSON.stringify({
+        type: "response_item",
+        payload: { type: "function_call", name: "shell", call_id: "c1", arguments: "{}" },
+      }),
+      1,
+    );
+    const step = reduceStatus(initialStatus(0), event);
+    expect(step.next.state).toBe("running_tool");
+    expect(step.next.lastEventAtMs).toBeGreaterThan(0);
+    const tick = tickStatus(step.next, step.next.lastEventAtMs + 1_000, {
+      idleAfterMs: 30_000,
+    });
+    expect(tick.emit).toBeUndefined();
+    expect(tick.next.state).toBe("running_tool");
   });
 
   it("ignores unknown events but advances the activity clock", () => {

--- a/sdk/typescript/tests/harness-wrapper-v2.test.ts
+++ b/sdk/typescript/tests/harness-wrapper-v2.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Writable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  HarnessSessionTailer,
+  SessionEnvelopePublisher,
+  type HarnessWrapperConfig,
+} from "../src/cli/harness-wrapper.js";
+import type { SessionEnvelopeV2 } from "../src/index.js";
+import type { TinyPlaceCliOptions } from "../src/cli/types.js";
+
+// Drives the real tailer against a fixture Claude session file in dry-run mode.
+// Dry-run routes envelopes to the provided Writable instead of the network, so
+// we can assert the v2 typed-event stream the poll loop emits when emitV2 is on.
+
+function baseConfig(sessionFile: string, over: Partial<HarnessWrapperConfig>): HarnessWrapperConfig {
+  return {
+    agentArgs: [],
+    agentBin: "claude",
+    bucket: "hour",
+    captureError: true,
+    captureInput: true,
+    captureOutput: true,
+    captureSession: true,
+    dryRun: true,
+    emitV2: false,
+    outDir: join(tmpdir(), "tp-v2-out"),
+    provider: "claude",
+    receiveEnabled: false,
+    receivePollMs: 1500,
+    sessionFile,
+    sessionPollMs: 500,
+    sessionsDir: join(tmpdir(), "tp-v2-sessions"),
+    sessionTailGraceMs: 0,
+    scope: "session",
+    statusHeartbeatMs: 15_000,
+    statusIdleMs: 30_000,
+    usePty: false,
+    wrapperSessionId: "wrap-test",
+    ...over,
+  };
+}
+
+const CLAUDE_LINES = [
+  JSON.stringify({
+    type: "user",
+    timestamp: "2026-07-07T10:00:00.000Z",
+    message: { role: "user", content: "run the tests" },
+  }),
+  JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-07-07T10:00:01.000Z",
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "running" },
+        { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "npm test" } },
+      ],
+    },
+  }),
+  JSON.stringify({
+    type: "user",
+    timestamp: "2026-07-07T10:00:03.000Z",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "toolu_1", is_error: false, content: "12 passed" }],
+    },
+  }),
+];
+
+function collector(): { out: Writable; envelopes: () => Array<SessionEnvelopeV2> } {
+  const chunks: Array<string> = [];
+  const out = new Writable({
+    write(chunk, _enc, cb): void {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  return {
+    out,
+    envelopes: (): Array<SessionEnvelopeV2> =>
+      chunks
+        .join("")
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .map((line) => JSON.parse(line) as SessionEnvelopeV2)
+        .filter((env) => env.envelope_version === "tinyplace.harness.session.v2"),
+  };
+}
+
+async function drive(config: HarnessWrapperConfig, out: Writable): Promise<void> {
+  const options = { env: {} } as unknown as TinyPlaceCliOptions;
+  const publisher = new SessionEnvelopePublisher(config, options, out);
+  const tailer = new HarnessSessionTailer(config, "/work/proj", out, publisher);
+  tailer.start(new Date("2026-07-07T09:59:00.000Z"));
+  await tailer.stop();
+}
+
+describe("HarnessSessionTailer v2 emission", () => {
+  const dirs: Array<string> = [];
+  afterEach(() => {
+    dirs.length = 0;
+  });
+
+  function fixture(): string {
+    const dir = mkdtempSync(join(tmpdir(), "tp-v2-"));
+    dirs.push(dir);
+    const file = join(dir, "session.jsonl");
+    writeFileSync(file, `${CLAUDE_LINES.join("\n")}\n`, "utf8");
+    return file;
+  }
+
+  it("emits nothing v2 when emitV2 is off (v1-only default)", async () => {
+    const file = fixture();
+    const { out, envelopes } = collector();
+    await drive(baseConfig(file, { emitV2: false }), out);
+    expect(envelopes()).toHaveLength(0);
+  });
+
+  it("emits typed tool_call, tool_result and derived status when emitV2 is on", async () => {
+    const file = fixture();
+    const { out, envelopes } = collector();
+    await drive(baseConfig(file, { emitV2: true }), out);
+    const events = envelopes();
+    const kinds = events.map((env) => env.event.kind);
+
+    expect(kinds).toContain("user_prompt");
+    expect(kinds).toContain("agent_message");
+    expect(kinds).toContain("tool_call");
+    expect(kinds).toContain("tool_result");
+    expect(kinds).toContain("status");
+
+    // every envelope is provider-tagged and monotonically sequenced.
+    expect(events.every((env) => env.harness.provider === "claude")).toBe(true);
+    const seqs = events.map((env) => env.event.seq);
+    expect(seqs).toStrictEqual([...seqs].sort((a, b) => a - b));
+
+    // tool_call and its result correlate by call id.
+    const call = events.find((env) => env.event.kind === "tool_call");
+    const result = events.find((env) => env.event.kind === "tool_result");
+    const callId = (call?.event.payload as { call_id: string }).call_id;
+    expect(callId).toBe("toolu_1");
+    expect((result?.event.payload as { call_id: string }).call_id).toBe(callId);
+
+    // a running_tool status was derived from the tool_call.
+    const statuses = events
+      .filter((env) => env.event.kind === "status")
+      .map((env) => (env.event.payload as { state: string }).state);
+    expect(statuses).toContain("running_tool");
+  });
+});

--- a/sdk/typescript/tests/harness-wrapper-v2.test.ts
+++ b/sdk/typescript/tests/harness-wrapper-v2.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Writable } from "node:stream";
@@ -101,6 +101,9 @@ async function drive(config: HarnessWrapperConfig, out: Writable): Promise<void>
 describe("HarnessSessionTailer v2 emission", () => {
   const dirs: Array<string> = [];
   afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
     dirs.length = 0;
   });
 


### PR DESCRIPTION
## Summary

Adds a **typed v2 session-event stream** (`tinyplace.harness.session.v2`) to the harness bridge, so a consumer (OpenHuman's Master Session) can tell apart **tool_call · agent_message · tool_result · status · everything else** from one field — instead of the v1 text-only stream that only carries "who spoke."

Builds on #229 (merged). Emission is **opt-in and off by default**, so current v1 consumers are byte-identical until they understand v2.

## What's here

- **v2 event model** (`types/harness.ts`) — additive over v1: reuses `bucket`/`scope`/`harness` verbatim, swaps only `message`+`source` for a typed `event`. Two axes: `role` (owner|agent) + `kind` (`user_prompt|agent_message|agent_thinking|approval_request|tool_call|tool_result|status|lifecycle|error|unknown`). v1 and v2 coexist; discriminate on `envelope_version`. `SessionEnvelope` alias stays v1-only so no current importer changes.
- **JSONL→event mapper** (`harness-events.ts`) — splits Claude `tool_use`/`tool_result`/`thinking`/`text` and Codex `function_call`/`function_call_output`/`reasoning`/messages into per-block typed events. `tool_call`↔`tool_result` correlate via `call_id`. Registry dispatch so a 3rd provider (e.g. gemini) is a compile-checked add.
- **Hooks capture path** (`harness-hooks.ts`) — maps Claude Code hook payloads (PreToolUse/PostToolUse/UserPromptSubmit/Stop/SessionStart/…) into the same event shape, for lower latency than JSONL tailing. `tool_use_id` on both PreToolUse and PostToolUse gives exact call↔result correlation.
- **Status state machine** (`harness-status.ts`) — derives `running_tool`/`waiting_approval`/`idle` + heartbeat → drives InstanceStatus + currentTask.
- **Envelope builder** (`harness-envelope.ts`) — seq + stable content-addressed id + bucket window.
- **Consumer** (`harness-consumer.ts`) — `parseSessionEnvelope` + `applySessionEnvelope`/`foldSessionEnvelopes` fold the stream into a live `SessionView` (status, currentTask, tool log, capped feed). Framework-agnostic reference decoder.
- **Wired into the tailer** (`harness-wrapper.ts`) — emits v2 behind `TINYPLACE_HARNESS_V2=1` (default off). Publisher/writeEnvelope accept either version via an `envelope_version` discriminant.

## Testing

- `tsc` build clean; SDK lint (`tsc --noEmit`) clean.
- **442 unit tests pass** (98 staging/network-gated skipped), incl. an integration test that drives the real tailer against a fixture Claude session in dry-run and asserts `tool_call`/`tool_result`/`status` with correlated `call_id` and monotonic seq.
- Provider mapping verified against real Claude + Codex transcripts; hook field names extracted from the Claude Code 2.1.202 binary.

## Notes

- v2 wire shape is the consumer contract. cc @senamakel — this extends your bridge; the v2 envelope reuses your v1 framing so the transport is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added v2 harness session envelope support with typed event-streams, deterministic event IDs, and safe folding into live session view state (ordered batching, capped feed, tool-call/result + lifecycle/status tracking).
  * Added opt-in v2 emission in the harness wrapper, including derived status updates with heartbeat and idle transitions.
  * Added Claude/Codex JSONL parsing and Claude Code hook mapping into shared semantic events.
* **Public API Updates**
  * Expanded TypeScript and Node exports for v2 envelope contracts plus event parsing, status derivation, and consumer view utilities.
* **Tests**
  * Added Vitest coverage for envelope building, safe parsing/folding edge cases, status derivation, and wrapper v2 emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->