### PR TITLE
feat: session_info intro event (TS SDK schema + contact-gated plugin emit)

### DIFF
--- a/sdk/plugin-tinyplace/hooks/agent-daemon.mjs
+++ b/sdk/plugin-tinyplace/hooks/agent-daemon.mjs
@@ -33,7 +33,7 @@ import {
 import { enqueueRouted, redeliverUnrouted, reapClosedTargets } from "../mcp/routing.mjs";
 import { claimOutboxJobs, writeOutboxJob } from "../mcp/outbox.mjs";
 import { acquireLock, heartbeatLock, releaseLock } from "../mcp/daemon-lock.mjs";
-import { toCryptoId } from "../mcp/address.mjs";
+import { isCryptoId, toCryptoId } from "../mcp/address.mjs";
 import { harnessDataDir } from "../mcp/harness.mjs";
 import { foregroundInject } from "../mcp/foreground-inject.mjs";
 import { loadWallets } from "../mcp/wallets.mjs";
@@ -279,10 +279,15 @@ async function serviceSessionInfo() {
   sessionInfoBusy = true;
   try {
     if (ownerCryptoId === undefined) {
-      try { ownerCryptoId = (await toCryptoId(client, OWNER_RAW)) || null; } catch { return; }
+      // toCryptoId returns the original @handle unchanged when a directory lookup
+      // fails (owner not registered yet / transient), so only CACHE a real base58
+      // id; otherwise leave it unresolved and retry next tick.
+      let resolved;
+      try { resolved = await toCryptoId(client, OWNER_RAW); } catch { return; }
+      if (!isCryptoId(resolved)) return; // not resolvable yet — retry next tick
+      ownerCryptoId = resolved;
     }
     const owner = ownerCryptoId;
-    if (!owner) return;
 
     // Contact gate: request once, then wait for the owner to accept.
     let status;
@@ -316,11 +321,12 @@ async function serviceSessionInfo() {
     // FLUSH: one session_info per pending session (resumed:false fresh /
     // resumed:true on reconnect). Mark sent only on a successful send so a
     // transient failure retries next tick.
+    let sentAny = false;
     for (const plan of plans) {
       const session = live.find((s) => s.sessionUuid === plan.sessionUuid);
       if (!session) continue;
       const convUuid = resolveConversationUuid(plan.sessionUuid, owner);
-      const { repo, branch } = gitInfo(session.cwd);
+      const { repo, branch } = await gitInfo(session.cwd);
       const body = buildSessionInfoEnvelope({
         agentAddress: AGENT,
         wrapperSessionId: convUuid,
@@ -341,10 +347,18 @@ async function serviceSessionInfo() {
         await sendMessage(client, signer, owner, body);
         sessionInfoSent.add(plan.sessionUuid);
         priorEmitted.add(plan.sessionUuid);
-        persistEmitted(AGENT, priorEmitted);
+        sentAny = true;
       } catch {
         // 403 (contact race) / transient / resolve-then-404 — retry next tick.
       }
+    }
+    // Persist once per flush (not per send). Prune to currently-live sessions so
+    // the record stays bounded — a dead session never needs a resumed re-emit
+    // (a resumed harness keeps its sessionUuid and is live again on restart).
+    if (sentAny) {
+      const liveSet = new Set(live.map((s) => s.sessionUuid));
+      for (const uuid of priorEmitted) if (!liveSet.has(uuid)) priorEmitted.delete(uuid);
+      persistEmitted(AGENT, priorEmitted);
     }
   } finally {
     sessionInfoBusy = false;

--- a/sdk/plugin-tinyplace/hooks/agent-daemon.mjs
+++ b/sdk/plugin-tinyplace/hooks/agent-daemon.mjs
@@ -19,7 +19,17 @@ import { FileSessionStore } from "@tinyhumansai/tinyplace/node";
 import { sendMessage, readMessages, publishKeys } from "@tinyhumansai/tinyplace/agent";
 
 import { buildEnvelope, decodeBody } from "../mcp/format.mjs";
-import { liveSessions, sessionUuidForConversation } from "../mcp/registry.mjs";
+import { liveSessions, resolveConversationUuid, sessionUuidForConversation } from "../mcp/registry.mjs";
+import {
+  DEFAULT_CAPABILITIES,
+  buildSessionInfoEnvelope,
+  gitInfo,
+  loadEmitted,
+  ownerAddress,
+  persistEmitted,
+  planSessionInfoEmit,
+  sessionTitle,
+} from "../mcp/session-info.mjs";
 import { enqueueRouted, redeliverUnrouted, reapClosedTargets } from "../mcp/routing.mjs";
 import { claimOutboxJobs, writeOutboxJob } from "../mcp/outbox.mjs";
 import { acquireLock, heartbeatLock, releaseLock } from "../mcp/daemon-lock.mjs";
@@ -220,6 +230,127 @@ async function drainOutbound() {
   }
 }
 
+// ── session_info emit (contact-gated intro) ──────────────────────────────────
+// Announce each live session to the agent's owner (the OpenHuman "Master") the
+// moment it inits, so the owner registers + renders the session before it acts.
+// A single relationship (contacts are per-identity) covers ALL sessions, so this
+// sends ONE contact request per identity, then flushes one session_info per
+// pending session on accept. See mcp/session-info.mjs + spec §3. Feature is OFF
+// (pure no-op) unless TINYPLACE_OWNER_ADDRESS names the owner.
+const OWNER_RAW = ownerAddress();
+// Read once: plugin version (harness_version) + the agent's @handle (best-effort).
+let pluginVersion = "";
+try {
+  pluginVersion = JSON.parse(readFileSync(join(PLUGIN_ROOT, "package.json"), "utf8"))?.version ?? "";
+} catch { /* omit harness_version */ }
+let agentHandle = null; // "@name" or null; resolved lazily on first service tick
+let ownerCryptoId; // undefined = unresolved, null = unresolvable, else the cryptoId
+let ownerContactRequested = false; // one contact_add per identity (never per session)
+let prekeyBackoffUntil = 0; // contact-accepted ≠ messageable: back off until prekeys land
+let prekeyBackoffMs = 0;
+const sessionInfoSent = new Set(); // sessionUuids announced THIS daemon run
+const priorEmitted = loadEmitted(AGENT); // announced in a PRIOR run → re-emit resumed:true
+let sessionInfoBusy = false;
+
+// The owner has a usable prekey bundle (so a first DM can run X3DH). getBundle
+// 404s when none is provisioned yet — the resolve-then-404 gap — so a throw here
+// means "not messageable yet, back off". A resolved bundle means go.
+async function ownerMessageable(owner) {
+  try {
+    const bundle = await client.keys.getBundle(owner);
+    return !!(bundle && bundle.identityKey && bundle.signedPreKey);
+  } catch {
+    return false;
+  }
+}
+
+async function serviceSessionInfo() {
+  if (!OWNER_RAW || sessionInfoBusy) return;
+  const live = liveSessions(AGENT).filter((s) => s.sessionUuid);
+  if (live.length === 0) return; // nothing to announce yet
+  // Compute the pending set BEFORE any network call so steady-state (every live
+  // session already announced this run) is a pure no-op — no per-tick relay chatter.
+  const plans = planSessionInfoEmit({
+    liveSessionUuids: live.map((s) => s.sessionUuid),
+    priorEmitted,
+    sentThisRun: sessionInfoSent,
+  });
+  if (plans.length === 0) return;
+  sessionInfoBusy = true;
+  try {
+    if (ownerCryptoId === undefined) {
+      try { ownerCryptoId = (await toCryptoId(client, OWNER_RAW)) || null; } catch { return; }
+    }
+    const owner = ownerCryptoId;
+    if (!owner) return;
+
+    // Contact gate: request once, then wait for the owner to accept.
+    let status;
+    try { status = (await client.contacts.status(owner))?.status; } catch { return; }
+    if (status !== "accepted") {
+      if (!ownerContactRequested) {
+        ownerContactRequested = true;
+        try { await client.contacts.request(owner); } catch { ownerContactRequested = false; }
+      }
+      return; // REQUESTED — flush deferred until accept
+    }
+
+    // Prekey presence (accepted ≠ messageable) with exponential backoff.
+    if (Date.now() < prekeyBackoffUntil) return;
+    if (!(await ownerMessageable(owner))) {
+      prekeyBackoffMs = Math.min(prekeyBackoffMs ? prekeyBackoffMs * 2 : POLL_INTERVAL_MS, 60_000);
+      prekeyBackoffUntil = Date.now() + prekeyBackoffMs;
+      return;
+    }
+    prekeyBackoffMs = 0;
+    prekeyBackoffUntil = 0;
+
+    // Resolve the agent's own @handle once (UI metadata; best-effort).
+    if (agentHandle === null) {
+      try {
+        const card = await client.directory.getAgent(AGENT);
+        if (card?.username) agentHandle = `@${card.username}`;
+      } catch { /* omit handle */ }
+    }
+
+    // FLUSH: one session_info per pending session (resumed:false fresh /
+    // resumed:true on reconnect). Mark sent only on a successful send so a
+    // transient failure retries next tick.
+    for (const plan of plans) {
+      const session = live.find((s) => s.sessionUuid === plan.sessionUuid);
+      if (!session) continue;
+      const convUuid = resolveConversationUuid(plan.sessionUuid, owner);
+      const { repo, branch } = gitInfo(session.cwd);
+      const body = buildSessionInfoEnvelope({
+        agentAddress: AGENT,
+        wrapperSessionId: convUuid,
+        harnessSessionId: session.harnessSessionId,
+        cwd: session.cwd,
+        label: session.label,
+        handle: agentHandle ?? undefined,
+        title: sessionTitle({ cwd: session.cwd, branch, repo, label: session.label }),
+        repo: repo ?? undefined,
+        branch: branch ?? undefined,
+        harnessVersion: pluginVersion || undefined,
+        capabilities: DEFAULT_CAPABILITIES,
+        resumed: plan.resumed,
+        seq: plan.seq,
+        startedAt: session.startedAt,
+      });
+      try {
+        await sendMessage(client, signer, owner, body);
+        sessionInfoSent.add(plan.sessionUuid);
+        priorEmitted.add(plan.sessionUuid);
+        persistEmitted(AGENT, priorEmitted);
+      } catch {
+        // 403 (contact race) / transient / resolve-then-404 — retry next tick.
+      }
+    }
+  } finally {
+    sessionInfoBusy = false;
+  }
+}
+
 // ── closed-session notices ───────────────────────────────────────────────────
 // A message addressed to a specific session (to_session) that never came (back)
 // live within the grace window is abandoned. Send the sender ONE auto-tagged
@@ -279,6 +410,7 @@ const pollTimer = setInterval(() => {
     await drainInbound();
     notifyClosedTargets(); // reap+notify mail bound to a session that stayed gone
     await drainOutbound(); // sends the notices just enqueued
+    await serviceSessionInfo(); // announce new/reconnected sessions to the owner
     if (checkIdle()) shutdown(0);
   })();
 }, POLL_INTERVAL_MS);
@@ -290,4 +422,4 @@ const heartbeatTimer = setInterval(() => {
 for (const sig of ["SIGINT", "SIGTERM"]) process.on(sig, () => shutdown(0));
 
 // Kick an immediate cycle so a just-started session sees prompt service.
-void (async () => { await drainOutbound(); await drainInbound(); })();
+void (async () => { await drainOutbound(); await drainInbound(); await serviceSessionInfo(); })();

--- a/sdk/plugin-tinyplace/mcp/address.mjs
+++ b/sdk/plugin-tinyplace/mcp/address.mjs
@@ -7,6 +7,13 @@ const BASE58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 const CRYPTO_ID_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 const B64KEY_RE = /^[A-Za-z0-9+/]{43}=$/;
 
+// True if `value` is already a base58 cryptoId (the form the contacts/keys APIs
+// key on). Lets callers distinguish a real resolution from toCryptoId's fallback,
+// which returns the original @handle/string unchanged when a lookup fails.
+export function isCryptoId(value) {
+  return typeof value === "string" && CRYPTO_ID_RE.test(value);
+}
+
 export function bytesToBase58(bytes) {
   let n = 0n;
   for (const b of bytes) n = (n << 8n) + BigInt(b);

--- a/sdk/plugin-tinyplace/mcp/session-info.mjs
+++ b/sdk/plugin-tinyplace/mcp/session-info.mjs
@@ -1,0 +1,227 @@
+// session_info emit — the contact-gated session intro/announce.
+//
+// The moment a wrapped session is initialized, the daemon announces it to the
+// agent's owner (the OpenHuman "Master") over a Signal DM, so the owner can
+// register + render the session before it does anything. Delivery is gated on a
+// contact relationship: the relay drops a DM to a peer that hasn't accepted a
+// contact request, so the intro can't be sent until the owner is a contact.
+//
+// This module is the pure, SDK-free core (envelope builder + emit planner +
+// per-agent emitted store) so it runs in the offline test suite; the daemon
+// (hooks/agent-daemon.mjs) owns the network side (contacts / prekeys / send) and
+// the state-machine wiring. It emits a `SessionEnvelopeV2` (schema
+// `tinyplace.harness.session.v2`, see sdk/typescript/src/types/harness.ts) whose
+// `event.kind` is `session_info` — byte-compatible with the SDK's v2 emitter.
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import { activeAdapter, harnessDataDir } from "./harness.mjs";
+
+// v2 schema id (kept as a literal, mirrors SESSION_ENVELOPE_VERSION_V2 in the SDK).
+export const SESSION_ENVELOPE_VERSION_V2 = "tinyplace.harness.session.v2";
+
+// The record_type stamped on a session_info envelope's source frame — it is
+// emitted from the daemon on session init (the SessionStart moment), not tailed
+// from a transcript line. Part of the stable event id (see stableEventId).
+export const SESSION_INFO_RECORD_TYPE = "hook:SessionStart";
+
+// Event kinds a wrapped session advertises it will emit (feature-gate the owner's
+// UI). Mirrors the wire example in the spec; excludes `session_info` itself and
+// `unknown`. Kept as plain strings so the module stays free of SDK type imports.
+export const DEFAULT_CAPABILITIES = [
+  "user_prompt",
+  "agent_message",
+  "agent_thinking",
+  "approval_request",
+  "tool_call",
+  "tool_result",
+  "status",
+  "lifecycle",
+  "error",
+];
+
+// Owner (OpenHuman Master) address this agent announces its sessions to. Contacts
+// are per-identity, so this is a single relationship covering ALL of the agent's
+// sessions. Unset => the feature is OFF (no session_info emitted, no contact
+// request sent), which keeps the wire byte-compatible with the plain v2 emitter.
+// The raw value may be a base58 cryptoId, a base64 messaging key, or an @handle;
+// the daemon resolves it to the cryptoId the contacts/keys APIs expect.
+export function ownerAddress(env = process.env) {
+  return env.TINYPLACE_OWNER_ADDRESS?.trim() || null;
+}
+
+// The minute-window bucket a timestamp falls in (SessionEnvelope requires it).
+// Matches mcp/format.mjs so v1 and v2 frames bucket identically.
+function minuteBucket(date) {
+  const start = new Date(date);
+  start.setUTCSeconds(0, 0);
+  const end = new Date(start.getTime() + 60_000);
+  return { unit: "minute", start: start.toISOString(), end: end.toISOString() };
+}
+
+// Deterministic id scoped to (wrapperSessionId, recordType, seq, kind) — NOT a
+// content hash. Identical to the SDK's stableEventId (harness-envelope.ts) so a
+// session_info the daemon builds carries the same id the SDK would mint: a retry
+// (same seq) reuses the id and the receiver dedups, while a resumed re-emit
+// (distinct seq) gets a distinct id so the receiver upserts rather than drops it.
+export function stableEventId(wrapperSessionId, recordType, seq, kind) {
+  return createHash("sha256")
+    .update(`${wrapperSessionId}\0${recordType}\0${seq}\0${kind}`)
+    .digest("hex");
+}
+
+// Build a SessionEnvelopeV2 body (JSON string) carrying a `session_info` event.
+// Thin payload by design: provider/cwd/session-ids ride on the frame (scope/
+// harness), so the payload only confirms identity + adds UI metadata + advertises
+// capabilities + carries resume/idempotency signals. Optional payload fields are
+// omitted (not null) when empty, matching the SDK interface's `?:` optionals.
+export function buildSessionInfoEnvelope(opts) {
+  const adapter = activeAdapter();
+  const now = new Date();
+  const startedAt = opts.startedAt ? new Date(opts.startedAt) : now;
+  const at = Number.isNaN(startedAt.getTime()) ? now : startedAt;
+  const seq = Number.isInteger(opts.seq) ? opts.seq : 0;
+  const wrapperSessionId =
+    opts.wrapperSessionId || opts.harnessSessionId || `${opts.agentAddress ?? "agent"}`;
+
+  const payload = { agent_address: String(opts.agentAddress ?? "") };
+  if (opts.handle) payload.handle = opts.handle;
+  if (opts.title) payload.title = opts.title;
+  if (opts.repo) payload.repo = opts.repo;
+  if (opts.branch) payload.branch = opts.branch;
+  if (opts.model) payload.model = opts.model;
+  if (opts.harnessVersion) payload.harness_version = opts.harnessVersion;
+  payload.capabilities = Array.isArray(opts.capabilities)
+    ? opts.capabilities
+    : DEFAULT_CAPABILITIES;
+  payload.resumed = opts.resumed === true;
+  payload.started_at = at.toISOString();
+
+  const envelope = {
+    envelope_version: SESSION_ENVELOPE_VERSION_V2,
+    version: 2,
+    bucket: minuteBucket(now),
+    scope: {
+      type: "session",
+      key: `${opts.agentAddress ?? "agent"}:${opts.label ?? wrapperSessionId}`,
+      cwd: opts.cwd ?? process.cwd(),
+      wrapper_session_id: wrapperSessionId,
+      harness_session_id: opts.harnessSessionId ?? "",
+    },
+    harness: {
+      provider: adapter.provider,
+      command: adapter.harness.command,
+      argv: adapter.harness.argv ?? [],
+    },
+    event: {
+      id: stableEventId(wrapperSessionId, SESSION_INFO_RECORD_TYPE, seq, "session_info"),
+      seq,
+      ts: now.toISOString(),
+      ...(opts.model ? { model: opts.model } : {}),
+      kind: "session_info",
+      role: "agent",
+      payload,
+    },
+    source: { path: "plugin", record_type: SESSION_INFO_RECORD_TYPE },
+  };
+  return JSON.stringify(envelope);
+}
+
+// Pure planner for the flush step of the emit state machine. Given the live
+// session ids, which ids were emitted in a PRIOR daemon run (loaded from the
+// store) and which have already been sent THIS run, decide what to (re-)emit:
+//   - a session never announced before  → { resumed:false, seq:0 } (fresh spawn)
+//   - a session announced in a prior run → { resumed:true,  seq:1 } (reconnect)
+//   - a session already sent this run    → skipped (idempotent)
+// seq is 0 for fresh / 1 for resumed so a retry reuses its id (idempotent) while
+// a fresh→resumed transition mints a distinct id (upsert, not dedup-drop).
+export function planSessionInfoEmit({ liveSessionUuids, priorEmitted, sentThisRun }) {
+  const prior = priorEmitted instanceof Set ? priorEmitted : new Set(priorEmitted ?? []);
+  const sent = sentThisRun instanceof Set ? sentThisRun : new Set(sentThisRun ?? []);
+  const emits = [];
+  const seen = new Set();
+  for (const uuid of liveSessionUuids ?? []) {
+    if (!uuid || seen.has(uuid) || sent.has(uuid)) continue;
+    seen.add(uuid);
+    const resumed = prior.has(uuid);
+    emits.push({ sessionUuid: uuid, resumed, seq: resumed ? 1 : 0 });
+  }
+  return emits;
+}
+
+// ── per-agent emitted store (survives daemon restart) ────────────────────────
+// Records which sessions this agent has already announced, so a restart re-emits
+// with resumed:true (reconnect) instead of resumed:false (fresh). Best-effort
+// JSON file; a missing/corrupt file just means "nothing announced yet".
+function emittedFile(agentAddress) {
+  return join(harnessDataDir(), "session-info", encodeURIComponent(String(agentAddress)) + ".json");
+}
+
+export function loadEmitted(agentAddress) {
+  try {
+    const raw = JSON.parse(readFileSync(emittedFile(agentAddress), "utf8"));
+    return new Set(Array.isArray(raw?.sessions) ? raw.sessions : []);
+  } catch {
+    return new Set();
+  }
+}
+
+export function persistEmitted(agentAddress, sessionUuids) {
+  const path = emittedFile(agentAddress);
+  try {
+    mkdirSync(join(harnessDataDir(), "session-info"), { recursive: true });
+    const sessions = Array.from(sessionUuids instanceof Set ? sessionUuids : sessionUuids ?? []);
+    writeFileSync(path, JSON.stringify({ sessions }) + "\n", { mode: 0o600 });
+  } catch {
+    /* best-effort — a lost record just re-announces a session as fresh next run */
+  }
+}
+
+// Best-effort git repo slug + branch for a session's cwd. Both are privacy-
+// sensitive (spec §5.7) and OPTIONAL — only sent to the owner, never broadcast —
+// so any failure (not a repo, no git, detached HEAD) silently yields nulls. The
+// repo slug is derived from the origin remote url (`org/repo`); the branch is the
+// current symbolic ref. Short-timeout, no throw.
+export function gitInfo(cwd) {
+  const run = (args) => {
+    try {
+      return execFileSync("git", ["-C", cwd, ...args], {
+        encoding: "utf8",
+        timeout: 2000,
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      return "";
+    }
+  };
+  if (!cwd) return { repo: null, branch: null };
+  const branch = run(["rev-parse", "--abbrev-ref", "HEAD"]);
+  const remote = run(["remote", "get-url", "origin"]);
+  return {
+    repo: remote ? repoSlugFromRemote(remote) : null,
+    branch: branch && branch !== "HEAD" ? branch : null,
+  };
+}
+
+// Reduce a git remote url (ssh or https) to an `org/repo` slug; null if it can't
+// be parsed. `git@host:org/repo.git`, `https://host/org/repo.git`, and trailing
+// `.git` are all handled.
+export function repoSlugFromRemote(remote) {
+  if (typeof remote !== "string" || !remote) return null;
+  const stripped = remote.trim().replace(/\.git$/, "");
+  const scp = /^[^/@]+@[^:]+:(.+)$/.exec(stripped); // git@host:org/repo
+  const path = scp ? scp[1] : stripped.replace(/^[a-z]+:\/\/[^/]+\//i, ""); // strip scheme+host
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length < 2) return null;
+  return parts.slice(-2).join("/");
+}
+
+// A human-friendly session title for the owner's UI header. Prefers
+// `<repo-or-cwd-basename> · <branch>`, falling back to the routing label.
+export function sessionTitle({ cwd, branch, repo, label }) {
+  const base = repo ? repo.split("/").pop() : cwd ? basename(cwd) : null;
+  const head = base || label || "session";
+  return branch ? `${head} · ${branch}` : head;
+}

--- a/sdk/plugin-tinyplace/mcp/session-info.mjs
+++ b/sdk/plugin-tinyplace/mcp/session-info.mjs
@@ -12,10 +12,13 @@
 // the state-machine wiring. It emits a `SessionEnvelopeV2` (schema
 // `tinyplace.harness.session.v2`, see sdk/typescript/src/types/harness.ts) whose
 // `event.kind` is `session_info` — byte-compatible with the SDK's v2 emitter.
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 import { activeAdapter, harnessDataDir } from "./harness.mjs";
 
@@ -183,22 +186,22 @@ export function persistEmitted(agentAddress, sessionUuids) {
 // sensitive (spec §5.7) and OPTIONAL — only sent to the owner, never broadcast —
 // so any failure (not a repo, no git, detached HEAD) silently yields nulls. The
 // repo slug is derived from the origin remote url (`org/repo`); the branch is the
-// current symbolic ref. Short-timeout, no throw.
-export function gitInfo(cwd) {
-  const run = (args) => {
+// current symbolic ref. Async (non-blocking execFile) so it never stalls the
+// daemon's poll loop; short-timeout, no throw. The two git calls run in parallel.
+export async function gitInfo(cwd) {
+  const run = async (args) => {
     try {
-      return execFileSync("git", ["-C", cwd, ...args], {
-        encoding: "utf8",
-        timeout: 2000,
-        stdio: ["ignore", "pipe", "ignore"],
-      }).trim();
+      const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], { timeout: 2000 });
+      return stdout.trim();
     } catch {
       return "";
     }
   };
   if (!cwd) return { repo: null, branch: null };
-  const branch = run(["rev-parse", "--abbrev-ref", "HEAD"]);
-  const remote = run(["remote", "get-url", "origin"]);
+  const [branch, remote] = await Promise.all([
+    run(["rev-parse", "--abbrev-ref", "HEAD"]),
+    run(["remote", "get-url", "origin"]),
+  ]);
   return {
     repo: remote ? repoSlugFromRemote(remote) : null,
     branch: branch && branch !== "HEAD" ? branch : null,

--- a/sdk/plugin-tinyplace/package.json
+++ b/sdk/plugin-tinyplace/package.json
@@ -11,7 +11,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "test": "node harness-test.mjs && node adapter-contract-test.mjs && node branch-test.mjs && node envelope-test.mjs && node registry-test.mjs && node routing-test.mjs && node lock-test.mjs && node inject-test.mjs && node hooks-test.mjs && node mcp-smoke.mjs",
+    "test": "node harness-test.mjs && node adapter-contract-test.mjs && node branch-test.mjs && node envelope-test.mjs && node session-info-test.mjs && node registry-test.mjs && node routing-test.mjs && node lock-test.mjs && node inject-test.mjs && node hooks-test.mjs && node mcp-smoke.mjs",
     "test:smoke": "node mcp-smoke.mjs"
   },
   "dependencies": {

--- a/sdk/plugin-tinyplace/session-info-test.mjs
+++ b/sdk/plugin-tinyplace/session-info-test.mjs
@@ -1,0 +1,138 @@
+// Offline, deterministic test of the session_info emit core (mcp/session-info.mjs):
+// owner-address gating, the SessionEnvelopeV2 builder (byte-shape + stable id),
+// the emit planner (fresh / resumed / skip), the per-agent emitted store, and the
+// git-info/title helpers. No network, no MCP server, no daemon — pure functions.
+//
+// Runs under the mock adapter (TINYPLACE_HARNESS=mock) with a throwaway data dir
+// so the store round-trip touches only a temp directory.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+
+process.env.TINYPLACE_HARNESS = "mock";
+const DATA_DIR = mkdtempSync(join(tmpdir(), "tp-session-info-"));
+process.env.TINYPLACE_MOCK_HOME = DATA_DIR;
+
+const {
+  SESSION_ENVELOPE_VERSION_V2,
+  SESSION_INFO_RECORD_TYPE,
+  DEFAULT_CAPABILITIES,
+  ownerAddress,
+  buildSessionInfoEnvelope,
+  stableEventId,
+  planSessionInfoEmit,
+  loadEmitted,
+  persistEmitted,
+  repoSlugFromRemote,
+  sessionTitle,
+  gitInfo,
+} = await import("./mcp/session-info.mjs");
+
+const checks = [];
+const expect = (label, cond) => {
+  checks.push({ label, ok: !!cond });
+  console.log((cond ? "PASS " : "FAIL ") + label);
+};
+
+// 1. ownerAddress: env-gated, trimmed, unset → null (feature off).
+expect("ownerAddress: unset → null (feature off)", ownerAddress({}) === null);
+expect("ownerAddress: blank/whitespace → null", ownerAddress({ TINYPLACE_OWNER_ADDRESS: "   " }) === null);
+expect("ownerAddress: trims the configured value", ownerAddress({ TINYPLACE_OWNER_ADDRESS: "  Master123  " }) === "Master123");
+
+// 2. buildSessionInfoEnvelope: full v2 frame + typed session_info event.
+const CONV = "11111111-2222-3333-4444-555555555555";
+const body = buildSessionInfoEnvelope({
+  agentAddress: "ELQUJvq27tYx",
+  wrapperSessionId: CONV,
+  harnessSessionId: "hsid-xyz",
+  cwd: "/work/myrepo",
+  label: "mock:1",
+  handle: "@alice",
+  title: "myrepo · feat/x",
+  repo: "org/myrepo",
+  branch: "feat/x",
+  model: "claude-opus-4-8",
+  harnessVersion: "1.4.2",
+  capabilities: DEFAULT_CAPABILITIES,
+  resumed: false,
+  seq: 0,
+  startedAt: "2026-07-07T10:34:12.000Z",
+});
+const env = JSON.parse(body);
+expect("envelope_version is the v2 schema", env.envelope_version === SESSION_ENVELOPE_VERSION_V2);
+expect("version === 2", env.version === 2);
+expect("valid v2 shape: bucket/scope/harness/event/source present", !!env.bucket && !!env.scope && !!env.harness && !!env.event && !!env.source);
+expect("scope carries the wrapper/harness session ids + cwd", env.scope.wrapper_session_id === CONV && env.scope.harness_session_id === "hsid-xyz" && env.scope.cwd === "/work/myrepo");
+expect("scope.type === session", env.scope.type === "session");
+expect("harness.provider stamped from the active (mock) adapter", env.harness.provider === "mock" && env.harness.command === "tinyplace-mock");
+expect("event.kind === session_info, role === agent", env.event.kind === "session_info" && env.event.role === "agent");
+expect("event.seq === 0", env.event.seq === 0);
+expect("event.model rides on the frame when provided", env.event.model === "claude-opus-4-8");
+expect("source.record_type === hook:SessionStart", env.source.record_type === SESSION_INFO_RECORD_TYPE);
+const p = env.event.payload;
+expect("payload.agent_address confirms identity", p.agent_address === "ELQUJvq27tYx");
+expect("payload optionals (handle/title/repo/branch/model/harness_version) carried", p.handle === "@alice" && p.title === "myrepo · feat/x" && p.repo === "org/myrepo" && p.branch === "feat/x" && p.model === "claude-opus-4-8" && p.harness_version === "1.4.2");
+expect("payload.capabilities is the advertised kind list", Array.isArray(p.capabilities) && p.capabilities.includes("tool_call") && !p.capabilities.includes("session_info"));
+expect("payload.resumed === false (fresh spawn)", p.resumed === false);
+expect("payload.started_at is the ISO session start", p.started_at === "2026-07-07T10:34:12.000Z");
+
+// 3. Stable id: matches the SDK algorithm; idempotent per seq; distinct per seq.
+const NUL = String.fromCharCode(0);
+const expectedId = createHash("sha256").update([CONV, SESSION_INFO_RECORD_TYPE, 0, "session_info"].join(NUL)).digest("hex");
+expect("event.id matches sha256(wrapper\\0record\\0seq\\0kind)", env.event.id === expectedId);
+expect("stableEventId helper agrees with the built id", stableEventId(CONV, SESSION_INFO_RECORD_TYPE, 0, "session_info") === env.event.id);
+const resumedBody = JSON.parse(buildSessionInfoEnvelope({ agentAddress: "ELQUJvq27tYx", wrapperSessionId: CONV, resumed: true, seq: 1 }));
+expect("resumed re-emit (seq 1) → distinct id (upsert, not dedup-drop)", resumedBody.event.id !== env.event.id);
+expect("resumed re-emit sets payload.resumed === true", resumedBody.event.payload.resumed === true);
+const again = JSON.parse(buildSessionInfoEnvelope({ agentAddress: "ELQUJvq27tYx", wrapperSessionId: CONV, resumed: false, seq: 0 }));
+expect("same (wrapper, seq) → same id (idempotent retry)", again.event.id === env.event.id);
+
+// 4. Optional payload fields are OMITTED (not null) when empty — matches the SDK `?:`.
+const minimal = JSON.parse(buildSessionInfoEnvelope({ agentAddress: "Addr", wrapperSessionId: CONV, resumed: false, seq: 0 }));
+expect("minimal: no handle/title/repo/branch/model/harness_version keys", !("handle" in minimal.event.payload) && !("title" in minimal.event.payload) && !("repo" in minimal.event.payload) && !("model" in minimal.event.payload));
+expect("minimal: no event.model when omitted", !("model" in minimal.event));
+expect("minimal: capabilities defaults to DEFAULT_CAPABILITIES", minimal.event.payload.capabilities.length === DEFAULT_CAPABILITIES.length);
+expect("minimal: required agent_address/resumed/started_at always present", minimal.event.payload.agent_address === "Addr" && minimal.event.payload.resumed === false && typeof minimal.event.payload.started_at === "string");
+
+// 5. planSessionInfoEmit: fresh vs resumed vs already-sent.
+const plan1 = planSessionInfoEmit({ liveSessionUuids: ["a", "b", "c"], priorEmitted: new Set(["b"]), sentThisRun: new Set(["c"]) });
+expect("planner emits fresh + resumed, skips already-sent-this-run", plan1.length === 2);
+expect("planner: unseen session → resumed:false, seq 0", plan1.find((e) => e.sessionUuid === "a")?.resumed === false && plan1.find((e) => e.sessionUuid === "a")?.seq === 0);
+expect("planner: prior-run session → resumed:true, seq 1", plan1.find((e) => e.sessionUuid === "b")?.resumed === true && plan1.find((e) => e.sessionUuid === "b")?.seq === 1);
+expect("planner: session sent this run is skipped", !plan1.some((e) => e.sessionUuid === "c"));
+const plan2 = planSessionInfoEmit({ liveSessionUuids: ["a", "a", "", null], priorEmitted: new Set(), sentThisRun: new Set() });
+expect("planner dedups repeated ids and drops empties", plan2.length === 1 && plan2[0].sessionUuid === "a");
+expect("planner tolerates array (not Set) inputs", planSessionInfoEmit({ liveSessionUuids: ["x"], priorEmitted: ["x"], sentThisRun: [] })[0].resumed === true);
+
+// 6. Emitted store: round-trips through the temp data dir; survives a reload.
+const AGENT = "Agent-Store-Test";
+expect("loadEmitted: empty before any persist", loadEmitted(AGENT).size === 0);
+persistEmitted(AGENT, new Set(["s1", "s2"]));
+const reloaded = loadEmitted(AGENT);
+expect("persist→load round-trips the announced set", reloaded.has("s1") && reloaded.has("s2") && reloaded.size === 2);
+persistEmitted(AGENT, ["s3"]); // accepts an array too
+expect("persist overwrites with the latest set", loadEmitted(AGENT).has("s3") && loadEmitted(AGENT).size === 1);
+expect("store is per-agent (a different agent is empty)", loadEmitted("Other-Agent").size === 0);
+
+// 7. repoSlugFromRemote: ssh + https + trailing .git.
+expect("repo slug: git@host:org/repo.git → org/repo", repoSlugFromRemote("git@github.com:org/repo.git") === "org/repo");
+expect("repo slug: https://host/org/repo.git → org/repo", repoSlugFromRemote("https://github.com/org/repo.git") === "org/repo");
+expect("repo slug: no .git suffix", repoSlugFromRemote("https://github.com/org/repo") === "org/repo");
+expect("repo slug: unparseable → null", repoSlugFromRemote("not-a-url") === null && repoSlugFromRemote("") === null);
+
+// 8. sessionTitle: prefers repo/cwd basename + branch, falls back to label.
+expect("title: repo + branch", sessionTitle({ repo: "org/myrepo", branch: "feat/x" }) === "myrepo · feat/x");
+expect("title: cwd basename when no repo", sessionTitle({ cwd: "/a/b/proj", branch: "main" }) === "proj · main");
+expect("title: label fallback, no branch", sessionTitle({ label: "mock:1" }) === "mock:1");
+
+// 9. gitInfo: best-effort against THIS repo (a real git checkout) yields a branch;
+//    a non-repo path yields nulls without throwing.
+const here = gitInfo(process.cwd());
+expect("gitInfo: resolves a branch in a real repo", typeof here.branch === "string" && here.branch.length > 0);
+expect("gitInfo: non-repo path → nulls, no throw", (() => { const g = gitInfo("/"); return g.repo === null && g.branch === null; })());
+
+rmSync(DATA_DIR, { recursive: true, force: true });
+const failed = checks.filter((c) => !c.ok);
+console.log("\n" + (failed.length === 0 ? `ALL ${checks.length} CHECKS PASSED ✅` : `${failed.length} FAILED ❌`));
+process.exit(failed.length === 0 ? 0 : 1);

--- a/sdk/plugin-tinyplace/session-info-test.mjs
+++ b/sdk/plugin-tinyplace/session-info-test.mjs
@@ -90,7 +90,7 @@ expect("same (wrapper, seq) → same id (idempotent retry)", again.event.id === 
 
 // 4. Optional payload fields are OMITTED (not null) when empty — matches the SDK `?:`.
 const minimal = JSON.parse(buildSessionInfoEnvelope({ agentAddress: "Addr", wrapperSessionId: CONV, resumed: false, seq: 0 }));
-expect("minimal: no handle/title/repo/branch/model/harness_version keys", !("handle" in minimal.event.payload) && !("title" in minimal.event.payload) && !("repo" in minimal.event.payload) && !("model" in minimal.event.payload));
+expect("minimal: no handle/title/repo/branch/model/harness_version keys", !("handle" in minimal.event.payload) && !("title" in minimal.event.payload) && !("repo" in minimal.event.payload) && !("branch" in minimal.event.payload) && !("model" in minimal.event.payload) && !("harness_version" in minimal.event.payload));
 expect("minimal: no event.model when omitted", !("model" in minimal.event));
 expect("minimal: capabilities defaults to DEFAULT_CAPABILITIES", minimal.event.payload.capabilities.length === DEFAULT_CAPABILITIES.length);
 expect("minimal: required agent_address/resumed/started_at always present", minimal.event.payload.agent_address === "Addr" && minimal.event.payload.resumed === false && typeof minimal.event.payload.started_at === "string");
@@ -128,9 +128,10 @@ expect("title: label fallback, no branch", sessionTitle({ label: "mock:1" }) ===
 
 // 9. gitInfo: best-effort against THIS repo (a real git checkout) yields a branch;
 //    a non-repo path yields nulls without throwing.
-const here = gitInfo(process.cwd());
+const here = await gitInfo(process.cwd());
 expect("gitInfo: resolves a branch in a real repo", typeof here.branch === "string" && here.branch.length > 0);
-expect("gitInfo: non-repo path → nulls, no throw", (() => { const g = gitInfo("/"); return g.repo === null && g.branch === null; })());
+const nonRepo = await gitInfo("/");
+expect("gitInfo: non-repo path → nulls, no throw", nonRepo.repo === null && nonRepo.branch === null);
 
 rmSync(DATA_DIR, { recursive: true, force: true });
 const failed = checks.filter((c) => !c.ok);

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -105,6 +105,7 @@ export type {
   SessionEnvelope,
   SessionEnvelopeV1,
   SessionEnvelopeV2,
+  SessionInfoPayload,
   StatusPayload,
   ToolCallPayload,
   ToolResultPayload,

--- a/sdk/typescript/src/types/harness.ts
+++ b/sdk/typescript/src/types/harness.ts
@@ -65,6 +65,7 @@ export type HarnessEventRole = "owner" | "agent";
 
 // axis 2 — kind (content discriminator; the field the orchestrator switches on).
 export type HarnessEventKind =
+  | "session_info"
   | "user_prompt"
   | "agent_message"
   | "agent_thinking"
@@ -96,6 +97,24 @@ export type HarnessSessionState =
   | "idle"
   | "stopped"
   | "errored";
+
+// `session_info` — the session intro/announce, emitted once a wrapped session is
+// initialized (and a contact relationship with the owner exists). Thin by design:
+// provider/cwd/session-ids ride on the envelope frame (scope/harness), so this
+// payload carries only what the frame lacks — identity confirmation, UI metadata,
+// advertised capabilities, and resume/idempotency signals.
+export interface SessionInfoPayload {
+  agent_address: string; // base58 wallet identity (confirms envelope.from)
+  handle?: string; // @handle, if registered
+  title?: string; // human-friendly session title for the UI header
+  repo?: string; // git remote/slug, if in a repo
+  branch?: string; // git branch
+  model?: string; // active model (may also ride on event.model)
+  harness_version?: string; // plugin/CLI version — compat gating
+  capabilities: Array<HarnessEventKind>; // event kinds this session will emit (feature-gate UI)
+  resumed: boolean; // false = fresh spawn, true = reconnect/resume (idempotency)
+  started_at: string; // ISO-8601 session start
+}
 
 export interface UserPromptPayload {
   text: string;
@@ -156,6 +175,7 @@ export interface UnknownPayload {
 // discriminated union: kind <-> payload, with the coarse role fixed per kind
 // (owner iff kind === "user_prompt", else agent).
 export type HarnessEvent =
+  | { kind: "session_info"; role: "agent"; payload: SessionInfoPayload }
   | { kind: "user_prompt"; role: "owner"; payload: UserPromptPayload }
   | { kind: "agent_message"; role: "agent"; payload: AgentMessagePayload }
   | { kind: "agent_thinking"; role: "agent"; payload: AgentThinkingPayload }

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -2,7 +2,7 @@
 // The version is derived from the package manifest (single source of truth);
 // it is reported in the X-Tinyplace-SDK request header so the backend can
 // recognize first-party clients.
-export const SDK_VERSION = "2.0.0";
+export const SDK_VERSION = "2.0.2";
 
 // HEADER_SDK_CLIENT is the request header first-party SDKs send to identify
 // themselves; SDK_CLIENT is its value for this TypeScript SDK.

--- a/sdk/typescript/tests/harness-envelope.test.ts
+++ b/sdk/typescript/tests/harness-envelope.test.ts
@@ -4,6 +4,7 @@ import {
 } from "../src/cli/harness-envelope.js";
 import type { EnvelopeContext } from "../src/cli/harness-envelope.js";
 import type { HarnessSemanticEvent } from "../src/cli/harness-events.js";
+import type { SessionInfoPayload } from "../src/index.js";
 
 const ctx: EnvelopeContext = {
   provider: "claude",
@@ -80,6 +81,41 @@ describe("buildEventEnvelopeV2", () => {
     expect(a).toBe(b);
     expect(a).not.toBe(c);
     expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("builds a session_info event through the generic v2 builder", () => {
+    const payload: SessionInfoPayload = {
+      agent_address: "ELQUJvq27tYx",
+      handle: "@alice",
+      title: "myrepo · feat/x",
+      repo: "org/myrepo",
+      branch: "feat/x",
+      model: "claude-opus-4-8",
+      harness_version: "1.4.2",
+      capabilities: ["agent_message", "tool_call", "tool_result"],
+      resumed: false,
+      started_at: "2026-07-07T10:34:12.000Z",
+    };
+    const sessionInfo: HarnessSemanticEvent = {
+      line: 0,
+      timestamp: new Date("2026-07-07T10:34:12.000Z"),
+      recordType: "hook:SessionStart",
+      event: { kind: "session_info", role: "agent", payload },
+    };
+    const env = buildEventEnvelopeV2(ctx, sessionInfo, 0);
+    expect(env.event).toMatchObject({
+      seq: 0,
+      kind: "session_info",
+      role: "agent",
+      payload: { agent_address: "ELQUJvq27tYx", resumed: false },
+    });
+    expect(env.source.record_type).toBe("hook:SessionStart");
+    // Idempotent id: a resend of the same session_info (same seq) reuses the id.
+    expect(buildEventEnvelopeV2(ctx, sessionInfo, 0).event.id).toBe(env.event.id);
+    // A resumed re-emit (distinct seq) gets a distinct id so the receiver can
+    // upsert rather than dedup it away.
+    const resumed = buildEventEnvelopeV2(ctx, sessionInfo, 1).event.id;
+    expect(resumed).not.toBe(env.event.id);
   });
 
   it("includes turn_id and model only when provided", () => {


### PR DESCRIPTION
## What

Adds the **`session_info`** session-intro event — the first thing a wrapped coding-agent session announces to its owner (the OpenHuman "Master") over a tiny.place Signal DM, so the owner can register + render the session *before* it does anything. This is **Track A (emit side)** of the session_info delivery plan; it builds additively on the v2 harness stream already merged via #230.

Two focused commits:

### A1 — TS SDK `session_info` schema (`sdk/typescript`)
- add `"session_info"` to `HarnessEventKind` (first — it's the session opener)
- add `SessionInfoPayload` (`agent_address` + optional `handle`/`title`/`repo`/`branch`/`model`/`harness_version`, `capabilities`, `resumed`, `started_at`) — thin by design, since provider/cwd/session-ids ride on the envelope frame
- add the `{ kind:"session_info"; role:"agent" }` arm to the `HarnessEvent` union
- export `SessionInfoPayload` from the SDK root

The generic `buildEventEnvelopeV2` frames any `HarnessEvent`, so it builds `session_info` with **no change** (covered by a new test). The consumer/status switches **default-ignore** the new kind (no chat bubble), so older receivers stay backward-compatible.

### A2 — contact-gated plugin emit (`sdk/plugin-tinyplace`)
- new SDK-free, offline-tested `mcp/session-info.mjs`: the `SessionEnvelopeV2` builder for a `session_info` event (byte-compatible with the SDK v2 emitter, **same stable event id**), the emit planner (`resumed:false` fresh / `resumed:true` reconnect / skip-already-sent), a per-agent emitted store that survives daemon restart, plus owner-address gating and git repo/branch/title helpers
- `hooks/agent-daemon.mjs`: wire `serviceSessionInfo()` into the poll loop + startup kick. Contacts are per-identity, so it sends **one** `contact_add` per identity, waits for accept, then **flushes** one `session_info` per pending session. Adds a **prekey-presence check with exponential backoff** before emitting (contact-accepted ≠ messageable — the first DM runs X3DH). Marks a session sent only on a successful send, so transient/403 failures retry next tick.

The feature is **OFF (pure no-op, wire byte-unchanged)** unless `TINYPLACE_OWNER_ADDRESS` names the owner.

## Compatibility
Additive only; the wire stays byte-compatible with the existing v2 emitter. The Rust SDK is intentionally untouched (per the delivery plan, the OpenHuman mirror carries the receiver-side change).

## Tests
- SDK: extended `tests/harness-envelope.test.ts` (builds `session_info`, idempotent-per-seq id, distinct id on resumed re-emit). `pnpm --filter @tinyhumansai/tinyplace lint && build && test` — **451 pass**.
- Plugin: new `session-info-test.mjs` (46 checks: envelope shape + stable id, planner, emitted store, git/title helpers) wired into the plugin's offline suite. Full plugin suite (incl. `mcp-smoke`) — **green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sharing live session details with the session owner.
  * Introduced a new session event type that can include repository, branch, title, capabilities, and resume status.
  * Improved session tracking so live sessions can be announced reliably across restarts.

* **Bug Fixes**
  * Added safeguards to avoid duplicate announcements and to wait until contact and messaging details are ready before sending.
  * Updated tests to cover session-info formatting, identity behavior, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->