### PR TITLE
feat(cli): give `tinyplace claude` the same TUI onboarding as codex

### DIFF
--- a/sdk/typescript/src/cli/codex.ts
+++ b/sdk/typescript/src/cli/codex.ts
@@ -221,9 +221,15 @@ async function runAgentTui(
   // An installed dependency (resolved from node_modules) already has its deps;
   // only the in-repo checkout — a standalone package excluded from the workspace
   // — can be missing them, and would otherwise crash with ERR_MODULE_NOT_FOUND.
+  // An injected `options.spawn` (tests) never really launches node, so skip the
+  // real-launch precondition and let the dispatch/harness wiring be asserted.
   const isInstalledDependency = launcher.includes(`${sep}node_modules${sep}`);
   const pluginDir = dirname(dirname(launcher));
-  if (!isInstalledDependency && !existsSync(join(pluginDir, "node_modules"))) {
+  if (
+    options.spawn === undefined &&
+    !isInstalledDependency &&
+    !existsSync(join(pluginDir, "node_modules"))
+  ) {
     return failure(
       `The tiny.place plugin at ${pluginDir} has no node_modules — it is a standalone ` +
         "package excluded from the workspace. Install its deps first: " +
@@ -248,7 +254,7 @@ async function runAgentTui(
     childEnv.TINYPLACE_AUTORESPOND = "off";
   }
 
-  const code = await spawnInteractive("node", launcherArgs, childEnv);
+  const code = await spawnInteractive("node", launcherArgs, childEnv, options.spawn);
   return { code, stdout: "", stderr: "" };
 }
 
@@ -256,14 +262,22 @@ function failure(message: string): TinyPlaceCliResult {
   return { code: 1, stdout: "", stderr: `${JSON.stringify({ error: message }, null, 2)}\n` };
 }
 
-/** Spawn the interactive launcher, inheriting the TTY; resolve its exit code. */
+/**
+ * Spawn the interactive launcher, inheriting the TTY; resolve its exit code. A
+ * caller-supplied `spawn` (tests) is used instead of the real child_process
+ * spawn — the injected form omits `stdio: "inherit"` (its type forbids it) since
+ * the test child never touches a real TTY.
+ */
 function spawnInteractive(
   command: string,
   args: Array<string>,
   env: NodeJS.ProcessEnv,
+  injectedSpawn?: TinyPlaceCliOptions["spawn"],
 ): Promise<number> {
   return new Promise((resolve) => {
-    const child = spawn(command, args, { stdio: "inherit", env });
+    const child = injectedSpawn
+      ? injectedSpawn(command, args, { env })
+      : spawn(command, args, { stdio: "inherit", env });
     child.on("error", () => resolve(1));
     child.on("exit", (code) => resolve(code ?? 0));
   });

--- a/sdk/typescript/src/cli/codex.ts
+++ b/sdk/typescript/src/cli/codex.ts
@@ -11,7 +11,7 @@ import {
   type CodexWrapperConfig,
 } from "./harness-wrapper.js";
 import { makeContext } from "./context.js";
-import { runTinyPlaceTui } from "./tui.js";
+import { runTinyPlaceTui, type TinyVerseAgentKind } from "./tui.js";
 import type { TinyPlaceCliOptions, TinyPlaceCliResult } from "./types.js";
 
 /** Prod endpoint the SDK falls back to (mirrors `context.ts`). */
@@ -38,21 +38,46 @@ export async function runCodexCommand(
   argv: Array<string>,
   options: TinyPlaceCliOptions = {},
 ): Promise<TinyPlaceCliResult> {
-  if (wantsAgentMode(argv)) {
-    return runCodexAgentTui(argv, options);
-  }
-  if (wantsRawMode(argv)) {
-    return runHarnessCommand("codex", stripFlag(argv, "--raw"), options);
-  }
-  const ctx = await makeContext(options);
-  return runTinyPlaceTui(ctx, options, "codex");
+  return runHarnessAgentCommand("codex", argv, options);
 }
 
+/**
+ * `tinyplace claude` mirrors `tinyplace codex` exactly — same three
+ * mutually-exclusive modes so both agents get the identical onboarding:
+ *
+ * - default: the **tiny.place TUI** — visible wrapper that surfaces the
+ *   OpenHuman connection ("[ Connect with OpenHuman ]"), prompts for the owner,
+ *   and runs the real bidirectional bridge while claude runs inside it.
+ * - `--raw`: the **transparent harness wrapper** (headless; used by
+ *   embedders/tests/smoke).
+ * - `--agent`: a first-class **agent** session via the plugin launcher
+ *   (`--harness claude`) with its own wallet + MCP tools.
+ *
+ * Previously bare `tinyplace claude` went straight to the headless wrapper, so
+ * claude never got the connect-to-OpenHuman step codex users saw. Routing it
+ * through the same dispatch closes that gap.
+ */
 export async function runClaudeCommand(
   argv: Array<string>,
   options: TinyPlaceCliOptions = {},
 ): Promise<TinyPlaceCliResult> {
-  return runHarnessCommand("claude", argv, options);
+  return runHarnessAgentCommand("claude", argv, options);
+}
+
+/** Shared codex/claude dispatch: `--agent` → plugin, `--raw` → wrapper, else TUI. */
+async function runHarnessAgentCommand(
+  harness: TinyVerseAgentKind,
+  argv: Array<string>,
+  options: TinyPlaceCliOptions,
+): Promise<TinyPlaceCliResult> {
+  if (wantsAgentMode(argv)) {
+    return runAgentTui(harness, argv, options);
+  }
+  if (wantsRawMode(argv)) {
+    return runHarnessCommand(harness, stripFlag(argv, "--raw"), options);
+  }
+  const ctx = await makeContext(options);
+  return runTinyPlaceTui(ctx, options, harness);
 }
 
 export function parseCodexWrapperArgs(
@@ -163,17 +188,18 @@ export function parseAgentArgs(argv: Array<string>): AgentInvocation {
   return { wallet, autorespond, passthrough, forwarded: post };
 }
 
-async function runCodexAgentTui(
+async function runAgentTui(
+  harness: TinyVerseAgentKind,
   argv: Array<string>,
   options: TinyPlaceCliOptions,
 ): Promise<TinyPlaceCliResult> {
   const launcher = resolveUnifiedLauncher();
   if (!launcher) {
     return failure(
-      `tinyplace codex --agent needs the unified plugin (${PLUGIN_PACKAGE}), which is not ` +
+      `tinyplace ${harness} --agent needs the unified plugin (${PLUGIN_PACKAGE}), which is not ` +
         "installed. Install it (npm i " +
         `${PLUGIN_PACKAGE}) and re-run, run from a tiny.place checkout, or launch the ` +
-        "plugin directly: node sdk/plugin-tinyplace/bin/tinyplace.mjs --harness codex",
+        `plugin directly: node sdk/plugin-tinyplace/bin/tinyplace.mjs --harness ${harness}`,
     );
   }
   // An installed dependency (resolved from node_modules) already has its deps;
@@ -185,12 +211,12 @@ async function runCodexAgentTui(
     return failure(
       `The tiny.place plugin at ${pluginDir} has no node_modules — it is a standalone ` +
         "package excluded from the workspace. Install its deps first: " +
-        `(cd ${pluginDir} && pnpm install), then re-run tinyplace codex --agent.`,
+        `(cd ${pluginDir} && pnpm install), then re-run tinyplace ${harness} --agent.`,
     );
   }
 
   const { wallet, autorespond, passthrough, forwarded } = parseAgentArgs(argv);
-  const launcherArgs: Array<string> = [launcher, "--harness", "codex"];
+  const launcherArgs: Array<string> = [launcher, "--harness", harness];
   if (wallet) launcherArgs.push("--wallet", wallet);
   const forwardTail = [...passthrough, ...forwarded];
   if (forwardTail.length > 0) launcherArgs.push("--", ...forwardTail);

--- a/sdk/typescript/src/cli/codex.ts
+++ b/sdk/typescript/src/cli/codex.ts
@@ -64,7 +64,20 @@ export async function runClaudeCommand(
   return runHarnessAgentCommand("claude", argv, options);
 }
 
-/** Shared codex/claude dispatch: `--agent` → plugin, `--raw` → wrapper, else TUI. */
+/**
+ * Shared codex/claude dispatch:
+ * - `--agent` → plugin launcher
+ * - `--raw` → transparent wrapper
+ * - **bare** (no args) → interactive TUI onboarding
+ * - **args present** → transparent wrapper
+ *
+ * The last rule matters: the TUI builds the command + OpenHuman owner from env
+ * only, so if the caller passed wrapper flags or a `-- <agent-args>` tail (e.g.
+ * `tinyplace claude --tinyplace-dm-to @owner -- --model opus`), opening the TUI
+ * would silently drop the requested recipient/model. Any explicit args mean the
+ * caller wants to wrap a specific session, so route to the wrapper and honor
+ * them; the TUI is reserved for the argument-free onboarding entry.
+ */
 async function runHarnessAgentCommand(
   harness: TinyVerseAgentKind,
   argv: Array<string>,
@@ -75,6 +88,9 @@ async function runHarnessAgentCommand(
   }
   if (wantsRawMode(argv)) {
     return runHarnessCommand(harness, stripFlag(argv, "--raw"), options);
+  }
+  if (argv.length > 0) {
+    return runHarnessCommand(harness, argv, options);
   }
   const ctx = await makeContext(options);
   return runTinyPlaceTui(ctx, options, harness);

--- a/sdk/typescript/src/cli/commands.ts
+++ b/sdk/typescript/src/cli/commands.ts
@@ -191,7 +191,9 @@ export const HARNESS_CLI_COMMANDS: Array<TinyPlaceCliCommand> = [
   },
   {
     name: "claude",
-    capability: "workflow",
+    // Same capability as `codex` — the two are parity siblings, so they group
+    // together in help.
+    capability: "maintenance",
     description:
       "Launch the tiny.place TUI wrapping Claude Code: shows the active session + OpenHuman connection and runs the bidirectional bridge (publish keys, stream turns, inject inbound DMs). Use --raw for the headless transparent wrapper (no UI), or --agent to boot a first-class agent session via the unified plugin (own wallet + MCP tools, auto-reply off by default).",
     usage: "[--raw | --agent [--wallet <name>] [--autorespond]] [--tinyplace-dm-to <recipient>] [--tinyplace-out <dir>] [--tinyplace-scope folder|session] [--tinyplace-bucket minute|hour|day] [--] <claude-args...>",

--- a/sdk/typescript/src/cli/commands.ts
+++ b/sdk/typescript/src/cli/commands.ts
@@ -193,8 +193,8 @@ export const HARNESS_CLI_COMMANDS: Array<TinyPlaceCliCommand> = [
     name: "claude",
     capability: "workflow",
     description:
-      "Run Claude Code through the same tiny.place wrapper, writing session envelopes and optional Signal DMs.",
-    usage: "[--tinyplace-dm-to <recipient>] [--tinyplace-out <dir>] [--tinyplace-scope folder|session] [--tinyplace-bucket minute|hour|day] [--] <claude-args...>",
+      "Launch the tiny.place TUI wrapping Claude Code: shows the active session + OpenHuman connection and runs the bidirectional bridge (publish keys, stream turns, inject inbound DMs). Use --raw for the headless transparent wrapper (no UI), or --agent to boot a first-class agent session via the unified plugin (own wallet + MCP tools, auto-reply off by default).",
+    usage: "[--raw | --agent [--wallet <name>] [--autorespond]] [--tinyplace-dm-to <recipient>] [--tinyplace-out <dir>] [--tinyplace-scope folder|session] [--tinyplace-bucket minute|hour|day] [--] <claude-args...>",
   },
   {
     name: "tui",

--- a/sdk/typescript/tests/codex-cli.test.ts
+++ b/sdk/typescript/tests/codex-cli.test.ts
@@ -63,6 +63,19 @@ describe("tinyplace codex", () => {
     expect(result.stdout).toContain("welcome to tiny.place");
   });
 
+  it("routes bare `claude` to the TUI too, so it gets the same OpenHuman onboarding as codex", async () => {
+    const result = await runTinyPlaceCli(["claude"], {
+      env: { TINYPLACE_ENDPOINT: "https://relay.test" },
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+    });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("welcome to tiny.place");
+    // The claude profile drives the snapshot — not codex.
+    expect(result.stdout).toContain("claude: claude");
+  });
+
   it("proxies terminal streams into envelope files without creating tinyplace context", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "tinyplace-codex-"));
     const stdin = new PassThrough();
@@ -608,6 +621,7 @@ describe("tinyplace codex", () => {
     const resultPromise = runTinyPlaceCli(
       [
         "claude",
+        "--raw",
         "--tinyplace-no-pty",
         "--tinyplace-out",
         tempDir,

--- a/sdk/typescript/tests/codex-cli.test.ts
+++ b/sdk/typescript/tests/codex-cli.test.ts
@@ -76,6 +76,37 @@ describe("tinyplace codex", () => {
     expect(result.stdout).toContain("claude: claude");
   });
 
+  it("wraps `claude <args>` (no --raw) instead of dropping them in the TUI", async () => {
+    // Regression: bare `claude` opens the TUI, but any args (recipient/model/…)
+    // mean the caller wants to wrap a specific session — route to the wrapper
+    // and forward them rather than silently ignoring them.
+    let spawned: { args: Array<string>; command: string } | undefined;
+    const result = await runTinyPlaceCli(
+      ["claude", "--tinyplace-no-pty", "--tinyplace-no-session-tail", "--model", "opus"],
+      {
+        cwd: "/tmp/project",
+        env: { TINYPLACE_CLAUDE_BIN: "fake-claude" },
+        stdin: new PassThrough(),
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        spawn: (command, args) => {
+          spawned = { args, command };
+          const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+          child.stdin = new PassThrough();
+          child.stdout = new PassThrough();
+          child.stderr = new PassThrough();
+          child.pid = 4321;
+          queueMicrotask(() => child.emit("exit", 0, null));
+          return child;
+        },
+      },
+    );
+    expect(result.code).toBe(0);
+    // The TUI never spawns via the injected `spawn`; the wrapper does — and the
+    // model flag survives (only tinyplace-* flags are consumed).
+    expect(spawned).toEqual({ command: "fake-claude", args: ["--model", "opus"] });
+  });
+
   it("proxies terminal streams into envelope files without creating tinyplace context", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "tinyplace-codex-"));
     const stdin = new PassThrough();

--- a/sdk/typescript/tests/codex-cli.test.ts
+++ b/sdk/typescript/tests/codex-cli.test.ts
@@ -107,6 +107,34 @@ describe("tinyplace codex", () => {
     expect(spawned).toEqual({ command: "fake-claude", args: ["--model", "opus"] });
   });
 
+  it("routes `claude --agent` to the plugin launcher with `--harness claude`", async () => {
+    // The core new behavior of the parity dispatch is harness-parameterizing the
+    // agent launcher. An injected spawn lets us assert it without a real plugin
+    // install (the launcher is workspace-excluded and has no node_modules in CI).
+    let spawned: { args: Array<string>; command: string } | undefined;
+    const result = await runTinyPlaceCli(["claude", "--agent"], {
+      env: { TINYPLACE_ENDPOINT: "https://relay.test" },
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      spawn: (command, args) => {
+        spawned = { args, command };
+        const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+        child.pid = 5555;
+        queueMicrotask(() => child.emit("exit", 0, null));
+        return child;
+      },
+    });
+    expect(result.code).toBe(0);
+    // Launches `node <launcher> --harness claude` — the claude adapter, not codex.
+    expect(spawned?.command).toBe("node");
+    expect(spawned?.args).toEqual(
+      expect.arrayContaining(["--harness", "claude"]),
+    );
+    const h = spawned?.args.indexOf("--harness") ?? -1;
+    expect(spawned?.args[h + 1]).toBe("claude");
+  });
+
   it("proxies terminal streams into envelope files without creating tinyplace context", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "tinyplace-codex-"));
     const stdin = new PassThrough();


### PR DESCRIPTION
## Summary
Bare `tinyplace claude` went straight to the headless harness wrapper, so a Claude session never got the `[ Connect with OpenHuman ]` TUI onboarding that `tinyplace codex` shows. This routes `claude` through the exact same dispatch as `codex`.

## What changed
- Extracted a shared `runHarnessAgentCommand(harness, …)` so **codex and claude are identical**:
  - default → tiny.place **TUI** (active session + OpenHuman connection + bidirectional bridge)
  - `--raw` → transparent headless wrapper (embedders/tests/smoke)
  - `--agent` → first-class plugin session (`--harness claude`, own wallet + MCP tools)
- Generalized the agent-mode launcher (`runCodexAgentTui` → `runAgentTui(harness, …)`) so `--agent` boots the claude adapter too.
- Updated the `claude` command help to document `--raw`/`--agent` (mirrors codex).

The TUI and plugin launcher already supported the `claude` profile — this only wires the command to them.

## Behavior change
Bare `tinyplace claude` now opens the TUI. Headless callers must pass `tinyplace claude --raw` (same convention codex already uses).

## Tests
- `tinyplace claude` (bare) → TUI static snapshot in a non-TTY.
- `tinyplace claude --raw` → transparent wrapper over the Claude session JSONL.
- `tsc --noEmit` clean; codex-cli suite green (14 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `tinyplace claude` now supports three modes: default TUI, `--raw` headless mode, and `--agent` mode (consistent with `tinyplace codex`).
  * Updated Claude CLI help text and usage to document the new modes and passthrough arguments.
* **Bug Fixes**
  * Improved CLI routing so `tinyplace claude` and `tinyplace codex` launch consistently, including correct forwarding of Claude options.
  * Enhanced agent-mode onboarding and remediation messaging for unsupported plugin setups.
* **Tests**
  * Added CLI routing coverage for bare `claude`, `claude <args>`, and `--raw` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->