### PR TITLE
feat(cli): Home menu + remember/auto-connect the OpenHuman owner

### DIFF
--- a/sdk/typescript/src/cli/context.ts
+++ b/sdk/typescript/src/cli/context.ts
@@ -78,7 +78,29 @@ export async function makeContext(
     baseUrl,
     generated,
     ...(seed ? { secretKey: seed } : {}),
+    ...(config.openHumanOwner ? { openHumanOwner: config.openHumanOwner } : {}),
   };
+}
+
+/**
+ * Persist the OpenHuman owner the user picked in the TUI so the next launch
+ * auto-connects the bridge to it. Best-effort (mode 0600); merges over the
+ * existing config so the identity key / SIWS proof are preserved. Passing an
+ * empty/undefined owner clears the stored value.
+ */
+export async function saveOpenHumanOwner(
+  env: Record<string, string | undefined>,
+  owner: string | undefined,
+): Promise<void> {
+  const config = await loadCliConfig(env);
+  const trimmed = owner?.trim();
+  const next: TinyPlaceCliConfig = { ...config };
+  if (trimmed) {
+    next.openHumanOwner = trimmed;
+  } else {
+    delete next.openHumanOwner;
+  }
+  await persistConfig(env, next);
 }
 
 /**
@@ -133,6 +155,9 @@ async function loadCliConfig(
         : {}),
       ...(typeof config.siwsToken === "string"
         ? { siwsToken: config.siwsToken }
+        : {}),
+      ...(typeof config.openHumanOwner === "string"
+        ? { openHumanOwner: config.openHumanOwner }
         : {}),
     };
   } catch (error) {

--- a/sdk/typescript/src/cli/index.ts
+++ b/sdk/typescript/src/cli/index.ts
@@ -132,12 +132,30 @@ async function dispatchCli(
     };
   }
   if (
-    !parsed.command ||
     parsed.command === "help" ||
     parsed.command === "--help" ||
     boolFlag(parsed.flags, "help")
   ) {
     return { code: 0, stdout: HELP, stderr: "" };
+  }
+  // Bare `tinyplace` (no subcommand) opens the HOME menu — a navigable picker
+  // for Codex / Claude / Connect OpenHuman — so developers don't have to recall
+  // subcommands. `tinyplace help` still prints the command reference above.
+  if (!parsed.command) {
+    try {
+      const ctx = await makeContext(options);
+      return await runTinyPlaceTui(ctx, options);
+    } catch (error) {
+      return {
+        code: 1,
+        stdout: "",
+        stderr: `${JSON.stringify(
+          { error: error instanceof Error ? error.message : String(error) },
+          null,
+          2,
+        )}\n`,
+      };
+    }
   }
   if (parsed.command === "codex") {
     try {

--- a/sdk/typescript/src/cli/index.ts
+++ b/sdk/typescript/src/cli/index.ts
@@ -141,22 +141,6 @@ async function dispatchCli(
   // Bare `tinyplace` (no subcommand) opens the HOME menu — a navigable picker
   // for Codex / Claude / Connect OpenHuman — so developers don't have to recall
   // subcommands. `tinyplace help` still prints the command reference above.
-  if (!parsed.command) {
-    try {
-      const ctx = await makeContext(options);
-      return await runTinyPlaceTui(ctx, options);
-    } catch (error) {
-      return {
-        code: 1,
-        stdout: "",
-        stderr: `${JSON.stringify(
-          { error: error instanceof Error ? error.message : String(error) },
-          null,
-          2,
-        )}\n`,
-      };
-    }
-  }
   if (parsed.command === "codex") {
     try {
       return await runCodexCommand(argv.slice(1), options);
@@ -194,6 +178,11 @@ async function dispatchCli(
 
   try {
     const ctx = await makeContext(options);
+    // Bare `tinyplace` opens the HOME menu (no agent pre-chosen); `tui <kind>`
+    // opens a fixed-agent TUI. Both go through this dispatch's error contract.
+    if (!parsed.command) {
+      return await runTinyPlaceTui(ctx, options);
+    }
     if (parsed.command === "tui") {
       return await runTinyPlaceTui(
         ctx,

--- a/sdk/typescript/src/cli/tui.ts
+++ b/sdk/typescript/src/cli/tui.ts
@@ -14,6 +14,7 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import type { IPty } from "node-pty";
 
 import { bridgeLog, createBridgeDiagSink } from "./bridge-debug.js";
+import { saveOpenHumanOwner } from "./context.js";
 import {
   HarnessSessionTailer,
   InboundMessageReceiver,
@@ -65,30 +66,61 @@ interface AgentSessionMeta {
   sessionId: string;
 }
 
-const CODEX_ACTION_INDEX = 0;
-const OPENHUMAN_ACTION_INDEX = 1;
-const SETTINGS_ACTION_INDEX = 2;
-const QUIT_ACTION_INDEX = 3;
+/**
+ * A selectable welcome-menu row. The list is computed per-render so one screen
+ * serves two entry shapes:
+ *  - fixed-agent (`tinyplace codex` / `claude` / `tui <kind>`): one launch row.
+ *  - home (`tinyplace` with no agent): a launch row PER agent, so a developer
+ *    navigates to a session instead of memorizing subcommands.
+ */
+type TuiAction =
+  | "launch"
+  | "launch-codex"
+  | "launch-claude"
+  | "connect"
+  | "settings"
+  | "quit";
+
+const FIXED_ACTIONS: ReadonlyArray<TuiAction> = [
+  "launch",
+  "connect",
+  "settings",
+  "quit",
+];
+const HOME_ACTIONS: ReadonlyArray<TuiAction> = [
+  "launch-codex",
+  "launch-claude",
+  "connect",
+  "settings",
+  "quit",
+];
 const requireForTui = createRequire(import.meta.url);
 
 export async function runTinyPlaceTui(
   ctx: CliContext,
   options: TinyPlaceCliOptions,
-  agentKind: TinyVerseAgentKind = "codex",
+  // `undefined` = HOME mode: no agent pre-chosen, so the welcome menu offers a
+  // launch row per agent. A concrete kind = fixed-agent mode (today's flow).
+  agentKind?: TinyVerseAgentKind,
 ): Promise<TinyPlaceCliResult> {
   const stdin = options.stdin ?? process.stdin;
   const stdout = options.stdout ?? process.stdout;
-  const profile = buildAgentProfile(ctx.env, agentKind);
+  const homeMode = agentKind === undefined;
+  // Home mode still needs a concrete profile for the shared render/agent code;
+  // it defaults to codex and is swapped to the picked agent on launch.
+  const profile = buildAgentProfile(ctx.env, agentKind ?? "codex");
 
   if (!isTty(stdin) || !isTty(stdout)) {
     return {
       code: 0,
       stderr: "",
-      stdout: renderStaticSnapshot(ctx, profile),
+      stdout: homeMode
+        ? renderHomeSnapshot(ctx)
+        : renderStaticSnapshot(ctx, profile),
     };
   }
 
-  await runInteractiveBlessedTui(ctx, options, profile);
+  await runInteractiveBlessedTui(ctx, options, profile, homeMode);
   return { code: 0, stderr: "", stdout: "" };
 }
 
@@ -110,9 +142,10 @@ function runInteractiveBlessedTui(
   ctx: CliContext,
   options: TinyPlaceCliOptions,
   profile: AgentProfile,
+  homeMode: boolean,
 ): Promise<void> {
   return new Promise((resolve) => {
-    const app = new BlessedTinyPlaceTui(ctx, options, profile, resolve);
+    const app = new BlessedTinyPlaceTui(ctx, options, profile, resolve, homeMode);
     app.start();
   });
 }
@@ -137,7 +170,7 @@ class BlessedTinyPlaceTui {
     activeSessionId: "none",
     autoStartAvailable: true,
     openHumanConnected: false,
-    selectedIndex: CODEX_ACTION_INDEX,
+    selectedIndex: 0,
     view: "welcome",
   };
   private terminal?: Widgets.TerminalElement;
@@ -151,10 +184,27 @@ class BlessedTinyPlaceTui {
   public constructor(
     private readonly ctx: CliContext,
     private readonly options: TinyPlaceCliOptions,
-    private readonly profile: AgentProfile,
+    // Mutable: home mode swaps this to the picked agent before launch.
+    private profile: AgentProfile,
     private readonly resolve: () => void,
+    private readonly homeMode: boolean = false,
   ) {
     this.createBlessedLayout();
+  }
+
+  /** Welcome-menu rows for the current entry shape (home = per-agent pickers). */
+  private actions(): ReadonlyArray<TuiAction> {
+    return this.homeMode ? HOME_ACTIONS : FIXED_ACTIONS;
+  }
+
+  /** The action the cursor is on right now. */
+  private selectedAction(): TuiAction {
+    return this.actions()[this.state.selectedIndex] ?? "quit";
+  }
+
+  /** Home mode: bind the chosen agent before entering the launch flow. */
+  private setProfile(kind: TinyVerseAgentKind): void {
+    this.profile = buildAgentProfile(this.ctx.env, kind);
   }
 
   private createBlessedLayout(): void {
@@ -206,6 +256,18 @@ class BlessedTinyPlaceTui {
 
   public start(): void {
     this.registerKeys();
+    // Auto-adopt a remembered OpenHuman owner (persisted config or env) so the
+    // footer shows "connected" and the bridge wires to it the moment the agent
+    // launches — no manual "Connect with OpenHuman" needed on repeat launches.
+    const owner = this.resolveOwner();
+    if (owner) {
+      this.state = {
+        ...this.state,
+        openHumanConnected: true,
+        openHumanOwner: owner,
+        openHumanSessionId: owner,
+      };
+    }
     this.render();
     this.scheduleAutoStart();
   }
@@ -280,7 +342,7 @@ class BlessedTinyPlaceTui {
       selectedIndex: clamp(
         this.state.selectedIndex + delta,
         0,
-        QUIT_ACTION_INDEX,
+        this.actions().length - 1,
       ),
     };
     this.render();
@@ -301,19 +363,28 @@ class BlessedTinyPlaceTui {
       this.render();
       return;
     }
-    if (this.state.selectedIndex === CODEX_ACTION_INDEX) {
-      void this.startAgent();
-      return;
+    switch (this.selectedAction()) {
+      case "launch":
+        void this.startAgent();
+        return;
+      case "launch-codex":
+        this.setProfile("codex");
+        void this.startAgent();
+        return;
+      case "launch-claude":
+        this.setProfile("claude");
+        void this.startAgent();
+        return;
+      case "connect":
+        this.connectOpenHuman();
+        return;
+      case "settings":
+        this.openSettings();
+        return;
+      case "quit":
+        this.close();
+        return;
     }
-    if (this.state.selectedIndex === OPENHUMAN_ACTION_INDEX) {
-      this.connectOpenHuman();
-      return;
-    }
-    if (this.state.selectedIndex === SETTINGS_ACTION_INDEX) {
-      this.openSettings();
-      return;
-    }
-    this.close();
   }
 
   private openSettings(): void {
@@ -326,9 +397,18 @@ class BlessedTinyPlaceTui {
     this.render();
   }
 
-  /** The owner we bridge to: entered in the TUI (overrides) else from env. */
+  /**
+   * The owner we bridge to. Priority: entered this session (overrides) → env
+   * (explicit per-run override) → persisted config (remembered from a previous
+   * "Connect with OpenHuman"). The persisted value makes the next launch
+   * auto-connect without re-asking.
+   */
   private resolveOwner(): string | undefined {
-    return this.state.openHumanOwner ?? bridgeOwner(this.ctx.env);
+    return (
+      this.state.openHumanOwner ??
+      bridgeOwner(this.ctx.env) ??
+      this.ctx.openHumanOwner
+    );
   }
 
   /** Prompt for the OpenHuman owner (@handle or address), store it, and — if the
@@ -401,6 +481,8 @@ class BlessedTinyPlaceTui {
           openHumanOwner: owner,
           openHumanSessionId: owner,
         };
+        // Remember it so the next launch auto-connects without re-asking.
+        void saveOpenHumanOwner(this.ctx.env, owner);
         // If a session is live, restart the bridge so the new owner takes effect.
         if (this.state.view === "agent") {
           this.stopBridge();
@@ -846,7 +928,13 @@ class BlessedTinyPlaceTui {
       this.body.setContent(renderSettingsContent(this.ctx, this.profile));
     } else {
       this.body.setContent(
-        renderWelcomeContent(this.ctx, this.profile, this.state),
+        renderWelcomeContent(
+          this.ctx,
+          this.profile,
+          this.state,
+          this.actions(),
+          this.homeMode,
+        ),
       );
     }
     this.renderFooter();
@@ -906,10 +994,12 @@ class BlessedTinyPlaceTui {
     if (this.autoStartUsed) {
       return;
     }
-    if (
-      this.state.view !== "welcome" ||
-      this.state.selectedIndex !== CODEX_ACTION_INDEX
-    ) {
+    // Home mode has no pre-chosen agent, so never auto-launch — the developer
+    // picks Codex or Claude explicitly.
+    if (this.homeMode) {
+      return;
+    }
+    if (this.state.view !== "welcome" || this.selectedAction() !== "launch") {
       return;
     }
     const timeoutMs = autoStartMs(this.ctx.env);
@@ -1011,6 +1101,8 @@ function renderWelcomeContent(
   ctx: CliContext,
   profile: AgentProfile,
   state: Readonly<TuiState>,
+  actions: ReadonlyArray<TuiAction>,
+  homeMode: boolean,
 ): string {
   const timeoutMs = autoStartMs(ctx.env);
   const launchLabel =
@@ -1019,13 +1111,16 @@ function renderWelcomeContent(
       : state.autoStartAvailable && timeoutMs > 0
         ? `[ Launch ${profile.displayName} automatically in ${formatDuration(timeoutMs)} ]`
         : `[ Launch ${profile.displayName} ]`;
-  const lines = [
-    "{bold}welcome to tiny.place{/bold}",
-    `{gray-fg}${profile.displayName} runs inside this shell while tiny.place tracks the active ${profile.displayName} session.{/gray-fg}`,
-    "",
+  const header = homeMode
+    ? "{gray-fg}Pick a session to start, or connect your OpenHuman. Arrows/j,k move · Enter selects · q quits.{/gray-fg}"
+    : `{gray-fg}${profile.displayName} runs inside this shell while tiny.place tracks the active ${profile.displayName} session.{/gray-fg}`;
+  const info = [
     renderKeyValue("tiny.place", ctx.baseUrl, "{cyan-fg}"),
     renderKeyValue("wallet", walletIdFor(ctx), "{yellow-fg}"),
-    renderKeyValue(profile.kind, profile.launch.label, "{green-fg}"),
+    // Fixed-agent mode names the one agent; home mode doesn't bind one yet.
+    ...(homeMode
+      ? []
+      : [renderKeyValue(profile.kind, profile.launch.label, "{green-fg}")]),
     renderKeyValue("sessions", profile.sessionsDir, "{cyan-fg}"),
     state.openHumanConnected
       ? renderKeyValue(
@@ -1034,35 +1129,51 @@ function renderWelcomeContent(
           "{green-fg}",
         )
       : renderKeyValue("OpenHuman", "disconnected", "{gray-fg}"),
+  ];
+  const rows = actions.map((action, index) => {
+    const [label, colorTag] = actionRow(action, launchLabel, state);
+    return renderActionRow(state.selectedIndex === index, label, colorTag);
+  });
+  const lines = [
+    "{bold}welcome to tiny.place{/bold}",
+    header,
     "",
-    renderActionRow(
-      state.selectedIndex === CODEX_ACTION_INDEX,
-      launchLabel,
-      "{green-fg}",
-    ),
-    renderActionRow(
-      state.selectedIndex === OPENHUMAN_ACTION_INDEX,
-      state.openHumanConnected
-        ? "[ Connect with OpenHuman ] connected"
-        : "[ Connect with OpenHuman ]",
-      state.openHumanConnected ? "{green-fg}" : "{cyan-fg}",
-    ),
-    renderActionRow(
-      state.selectedIndex === SETTINGS_ACTION_INDEX,
-      "[ Settings ]",
-      "{cyan-fg}",
-    ),
-    renderActionRow(
-      state.selectedIndex === QUIT_ACTION_INDEX,
-      "[ Quit ]",
-      "{gray-fg}",
-    ),
+    ...info,
+    "",
+    ...rows,
     "",
     state.notice
       ? `{yellow-fg}${state.notice}{/yellow-fg}`
       : "{gray-fg}Enter launches the selected action. Move selection to cancel auto-launch. q quits.{/gray-fg}",
   ];
   return `${lines.join("\n")}\n`;
+}
+
+/** Label + color for one welcome-menu action row. */
+function actionRow(
+  action: TuiAction,
+  launchLabel: string,
+  state: Readonly<TuiState>,
+): [string, string] {
+  switch (action) {
+    case "launch":
+      return [launchLabel, "{green-fg}"];
+    case "launch-codex":
+      return ["[ Start Codex session ]", "{green-fg}"];
+    case "launch-claude":
+      return ["[ Start Claude session ]", "{green-fg}"];
+    case "connect":
+      return [
+        state.openHumanConnected
+          ? "[ Connect with OpenHuman ] connected"
+          : "[ Connect with OpenHuman ]",
+        state.openHumanConnected ? "{green-fg}" : "{cyan-fg}",
+      ];
+    case "settings":
+      return ["[ Settings ]", "{cyan-fg}"];
+    case "quit":
+      return ["[ Quit ]", "{gray-fg}"];
+  }
 }
 
 function renderActionRow(
@@ -1521,6 +1632,7 @@ function splitShellWords(input: string): Array<string> {
 
 function renderStaticSnapshot(ctx: CliContext, profile: AgentProfile): string {
   const timeoutMs = autoStartMs(ctx.env);
+  const owner = bridgeOwner(ctx.env) ?? ctx.openHumanOwner;
   const lines = [
     "welcome to tiny.place",
     `${profile.displayName} runs inside this shell while tiny.place tracks the active ${profile.displayName} session.`,
@@ -1529,7 +1641,9 @@ function renderStaticSnapshot(ctx: CliContext, profile: AgentProfile): string {
     `wallet: ${walletIdFor(ctx)}`,
     `${profile.kind}: ${profile.launch.label}`,
     `sessions: ${profile.sessionsDir}`,
-    "OpenHuman: disconnected",
+    owner
+      ? `OpenHuman: ${owner} (auto-connect on launch)`
+      : "OpenHuman: disconnected",
     "",
     `> ${
       timeoutMs > 0
@@ -1541,6 +1655,36 @@ function renderStaticSnapshot(ctx: CliContext, profile: AgentProfile): string {
     "  [ Quit ]",
     "",
     "Enter launches the selected action. Move selection to cancel auto-launch. q quits.",
+    `${ctx.baseUrl ? "Connected to tiny.place" : "Disconnected"} - Chat id: none`,
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Non-TTY snapshot for bare `tinyplace` (home mode) — the agent picker. Mirrors
+ * the interactive home menu so scripts / `| cat` see the same options.
+ */
+function renderHomeSnapshot(ctx: CliContext): string {
+  const owner = bridgeOwner(ctx.env) ?? ctx.openHumanOwner;
+  const lines = [
+    "welcome to tiny.place",
+    "Pick a session to start, or connect your OpenHuman.",
+    "",
+    `tiny.place: ${ctx.baseUrl}`,
+    `wallet: ${walletIdFor(ctx)}`,
+    owner
+      ? `OpenHuman: ${owner} (auto-connect on launch)`
+      : "OpenHuman: disconnected",
+    "",
+    "> [ Start Codex session ]",
+    "  [ Start Claude session ]",
+    owner
+      ? "  [ Connect with OpenHuman ] connected"
+      : "  [ Connect with OpenHuman ]",
+    "  [ Settings ]",
+    "  [ Quit ]",
+    "",
+    "Arrows/j,k move · Enter selects · q quits.",
     `${ctx.baseUrl ? "Connected to tiny.place" : "Disconnected"} - Chat id: none`,
   ];
   return `${lines.join("\n")}\n`;

--- a/sdk/typescript/src/cli/tui.ts
+++ b/sdk/typescript/src/cli/tui.ts
@@ -818,11 +818,26 @@ class BlessedTinyPlaceTui {
     }
   }
 
+  /**
+   * Whether to run the agent through the **native tmux relay** rather than the
+   * embedded Blessed `terminal` widget. Native relay is the default for BOTH
+   * agents: it tears Blessed down and hands the real terminal to the agent (with
+   * the tiny.place chrome as a tmux status line), so the terminal's own text
+   * selection / copy / scrollback keep working. The Blessed widget owns the
+   * screen (alternate buffer + term.js mouse handling) and disables all of that
+   * — the "whole pane is inaccessible" symptom. Opt back into it per agent with
+   * `TINYPLACE_<KIND>_TERMINAL_MODE=blessed`, or globally with
+   * `TINYPLACE_TERMINAL_MODE=blessed`. If tmux/node-pty is missing, the relay
+   * fails soft and falls back to the Blessed widget anyway.
+   */
   private usesNativeRelay(): boolean {
-    const mode =
-      this.ctx.env.TINYVERSE_CLAUDE_TERMINAL_MODE ??
-      this.ctx.env.TINYPLACE_CLAUDE_TERMINAL_MODE;
-    return this.profile.kind === "claude" && mode !== "blessed";
+    const kindMode =
+      this.profile.kind === "claude"
+        ? (this.ctx.env.TINYVERSE_CLAUDE_TERMINAL_MODE ??
+          this.ctx.env.TINYPLACE_CLAUDE_TERMINAL_MODE)
+        : this.ctx.env.TINYPLACE_CODEX_TERMINAL_MODE;
+    const mode = kindMode ?? this.ctx.env.TINYPLACE_TERMINAL_MODE;
+    return mode !== "blessed";
   }
 
   private updateNativeTerminalTitle(): void {

--- a/sdk/typescript/src/cli/tui.ts
+++ b/sdk/typescript/src/cli/tui.ts
@@ -37,6 +37,9 @@ interface TuiState {
   autoStartRemainingMs?: number;
   notice?: string;
   openHumanConnected: boolean;
+  // True once the real bridge (tailer/receiver) is running — as opposed to an
+  // owner that is merely remembered/adopted but not yet bridged (pre-launch).
+  bridgeLive?: boolean;
   // Owner entered in the TUI (overrides env); the address/@handle we bridge to.
   openHumanOwner?: string;
   openHumanSessionId?: string;
@@ -317,7 +320,9 @@ class BlessedTinyPlaceTui {
       this.moveSelection(1);
     });
     this.screen.key(["c", "n"], () => {
-      if (this.state.view === "agent") {
+      // Home mode has no single default agent — force the picker (arrows/Enter)
+      // so `c`/`n`/`x` can't silently launch Codex when the user wanted Claude.
+      if (this.homeMode || this.state.view === "agent") {
         return;
       }
       void this.startAgent();
@@ -335,7 +340,7 @@ class BlessedTinyPlaceTui {
       this.connectOpenHuman();
     });
     this.screen.key(["x"], () => {
-      if (this.state.view !== "welcome") {
+      if (this.homeMode || this.state.view !== "welcome") {
         return;
       }
       void this.startAgent();
@@ -483,14 +488,14 @@ class BlessedTinyPlaceTui {
       }
       settled = true;
       modal.destroy();
+      const inAgent = this.state.view === "agent";
       const owner = value?.trim();
       if (owner) {
         this.state = {
           ...this.state,
-          notice:
-            this.state.view === "agent"
-              ? `OpenHuman owner set to ${owner}; reconnecting bridge.`
-              : `OpenHuman owner set to ${owner}. Launch ${this.profile.displayName} to connect.`,
+          notice: inAgent
+            ? `OpenHuman owner set to ${owner}; reconnecting bridge.`
+            : `OpenHuman owner set to ${owner}. Launch ${this.profile.displayName} to connect.`,
           openHumanConnected: true,
           openHumanOwner: owner,
           openHumanSessionId: owner,
@@ -500,9 +505,26 @@ class BlessedTinyPlaceTui {
         // unhandled rejection — swallow and keep the in-memory owner for this run.
         void saveOpenHumanOwner(this.ctx.env, owner).catch(() => {});
         // If a session is live, restart the bridge so the new owner takes effect.
-        if (this.state.view === "agent") {
+        if (inAgent) {
           this.stopBridge();
           this.startBridge();
+        }
+      } else if (value !== undefined) {
+        // Empty SUBMIT (not cancel): forget the remembered owner so it stops
+        // auto-connecting. `undefined` here means Esc/cancel — leave it alone.
+        void saveOpenHumanOwner(this.ctx.env, undefined).catch(() => {});
+        // Also drop the in-context persisted value so resolveOwner() doesn't
+        // resurrect it later this session (env overrides are intentionally kept).
+        this.ctx.openHumanOwner = undefined;
+        this.state = {
+          ...this.state,
+          notice: "OpenHuman owner cleared.",
+          openHumanConnected: false,
+          openHumanOwner: undefined,
+          openHumanSessionId: undefined,
+        };
+        if (inAgent) {
+          this.stopBridge();
         }
       } else {
         this.state = { ...this.state, notice: "OpenHuman owner unchanged." };
@@ -570,6 +592,8 @@ class BlessedTinyPlaceTui {
       ...this.state,
       openHumanConnected: true,
       openHumanSessionId: owner,
+      // The bridge is actually up now — distinct from a merely *remembered* owner.
+      bridgeLive: true,
     };
     if (!this.nativeRelayActive) {
       this.renderFooter();
@@ -582,6 +606,7 @@ class BlessedTinyPlaceTui {
     void this.bridgeReceiver?.stop();
     this.bridgeTailer = undefined;
     this.bridgeReceiver = undefined;
+    this.state = { ...this.state, bridgeLive: false };
   }
 
   private async startAgent(): Promise<void> {
@@ -963,9 +988,12 @@ class BlessedTinyPlaceTui {
     const status = connected
       ? "{green-fg}Connected to tiny.place{/green-fg}"
       : "{red-fg}Disconnected{/red-fg}";
-    const openHuman = this.state.openHumanConnected
-      ? `{green-fg}OpenHuman ${blessed.escape(this.state.openHumanSessionId ?? "")}{/green-fg}`
-      : "{gray-fg}OpenHuman off{/gray-fg}";
+    const ownerLabel = blessed.escape(this.state.openHumanSessionId ?? "");
+    const openHuman = this.state.bridgeLive
+      ? `{green-fg}OpenHuman ${ownerLabel}{/green-fg}`
+      : this.state.openHumanConnected
+        ? `{yellow-fg}OpenHuman ${ownerLabel} (remembered){/yellow-fg}`
+        : "{gray-fg}OpenHuman off{/gray-fg}";
     this.footer.setContent(
       ` ${status} {gray-fg}-{/gray-fg} ${openHuman} {gray-fg}- Chat id:{/gray-fg} {yellow-fg}${blessed.escape(activeSession)}{/yellow-fg}`,
     );
@@ -1138,13 +1166,19 @@ function renderWelcomeContent(
       ? []
       : [renderKeyValue(profile.kind, profile.launch.label, "{green-fg}")]),
     renderKeyValue("sessions", profile.sessionsDir, "{cyan-fg}"),
-    state.openHumanConnected
+    state.bridgeLive
       ? renderKeyValue(
           "OpenHuman",
           `connected to ${state.openHumanSessionId ?? "openhuman:mock"}`,
           "{green-fg}",
         )
-      : renderKeyValue("OpenHuman", "disconnected", "{gray-fg}"),
+      : state.openHumanConnected
+        ? renderKeyValue(
+            "OpenHuman",
+            `remembered ${state.openHumanSessionId ?? ""} (connects on launch)`,
+            "{yellow-fg}",
+          )
+        : renderKeyValue("OpenHuman", "disconnected", "{gray-fg}"),
   ];
   const rows = actions.map((action, index) => {
     const [label, colorTag] = actionRow(action, launchLabel, state);
@@ -1710,8 +1744,6 @@ function walletIdFor(ctx: CliContext): string {
   return ctx.signer?.agentId ?? "mock-wallet-8Hf3Qp2N";
 }
 
-/** The configured OpenHuman owner (whom we bridge to), if any. Mirrors the
- *  wrapper's recipient resolution order. */
 /**
  * The configured OpenHuman owner (whom we bridge to), mirroring the wrapper's
  * provider-scoped recipient resolution. When the agent `kind` is known, only

--- a/sdk/typescript/src/cli/tui.ts
+++ b/sdk/typescript/src/cli/tui.ts
@@ -496,7 +496,9 @@ class BlessedTinyPlaceTui {
           openHumanSessionId: owner,
         };
         // Remember it so the next launch auto-connects without re-asking.
-        void saveOpenHumanOwner(this.ctx.env, owner);
+        // Best-effort: a corrupt/unreadable config must not crash the TUI with an
+        // unhandled rejection — swallow and keep the in-memory owner for this run.
+        void saveOpenHumanOwner(this.ctx.env, owner).catch(() => {});
         // If a session is live, restart the bridge so the new owner takes effect.
         if (this.state.view === "agent") {
           this.stopBridge();

--- a/sdk/typescript/src/cli/tui.ts
+++ b/sdk/typescript/src/cli/tui.ts
@@ -202,9 +202,11 @@ class BlessedTinyPlaceTui {
     return this.actions()[this.state.selectedIndex] ?? "quit";
   }
 
-  /** Home mode: bind the chosen agent before entering the launch flow. */
+  /** Home mode: bind the chosen agent, then resolve the owner for THAT agent
+   *  (provider-specific recipients only take effect once the agent is known). */
   private setProfile(kind: TinyVerseAgentKind): void {
     this.profile = buildAgentProfile(this.ctx.env, kind);
+    this.adoptRememberedOwner();
   }
 
   private createBlessedLayout(): void {
@@ -256,9 +258,23 @@ class BlessedTinyPlaceTui {
 
   public start(): void {
     this.registerKeys();
-    // Auto-adopt a remembered OpenHuman owner (persisted config or env) so the
-    // footer shows "connected" and the bridge wires to it the moment the agent
-    // launches — no manual "Connect with OpenHuman" needed on repeat launches.
+    // Fixed-agent mode: auto-adopt a remembered owner so the footer shows
+    // "connected" and the bridge wires on launch — no manual Connect on repeat
+    // launches. HOME mode defers this until an agent is picked (setProfile),
+    // because the recipient can be provider-specific and the agent isn't chosen
+    // yet — adopting a Codex recipient before the user picks Claude would bridge
+    // to the wrong owner.
+    if (!this.homeMode) {
+      this.adoptRememberedOwner();
+    }
+    this.render();
+    this.scheduleAutoStart();
+  }
+
+  /** Adopt a remembered OpenHuman owner (persisted config or env) into state so
+   *  the footer reflects it and the bridge wires to it on launch. Resolved
+   *  against the *current* profile, so it must run after any home-mode pick. */
+  private adoptRememberedOwner(): void {
     const owner = this.resolveOwner();
     if (owner) {
       this.state = {
@@ -268,8 +284,6 @@ class BlessedTinyPlaceTui {
         openHumanSessionId: owner,
       };
     }
-    this.render();
-    this.scheduleAutoStart();
   }
 
   private registerKeys(): void {
@@ -406,7 +420,7 @@ class BlessedTinyPlaceTui {
   private resolveOwner(): string | undefined {
     return (
       this.state.openHumanOwner ??
-      bridgeOwner(this.ctx.env) ??
+      bridgeOwner(this.ctx.env, this.profile.kind) ??
       this.ctx.openHumanOwner
     );
   }
@@ -1632,7 +1646,7 @@ function splitShellWords(input: string): Array<string> {
 
 function renderStaticSnapshot(ctx: CliContext, profile: AgentProfile): string {
   const timeoutMs = autoStartMs(ctx.env);
-  const owner = bridgeOwner(ctx.env) ?? ctx.openHumanOwner;
+  const owner = bridgeOwner(ctx.env, profile.kind) ?? ctx.openHumanOwner;
   const lines = [
     "welcome to tiny.place",
     `${profile.displayName} runs inside this shell while tiny.place tracks the active ${profile.displayName} session.`,
@@ -1696,17 +1710,26 @@ function walletIdFor(ctx: CliContext): string {
 
 /** The configured OpenHuman owner (whom we bridge to), if any. Mirrors the
  *  wrapper's recipient resolution order. */
+/**
+ * The configured OpenHuman owner (whom we bridge to), mirroring the wrapper's
+ * provider-scoped recipient resolution. When the agent `kind` is known, only
+ * that agent's `TINYPLACE_<KIND>_DM_TO`/`_RECEIVE_FROM` is consulted (never the
+ * other agent's) so, e.g., a Claude session never picks up
+ * `TINYPLACE_CODEX_DM_TO`. When `kind` is undefined (home menu, before an agent
+ * is chosen) only the agent-agnostic vars are used — the per-agent recipient is
+ * resolved once the user picks Codex vs Claude.
+ */
 function bridgeOwner(
   env: Record<string, string | undefined>,
+  kind?: TinyVerseAgentKind,
 ): string | undefined {
+  const upper = kind?.toUpperCase();
   return firstEnv(env, [
-    "TINYPLACE_CODEX_DM_TO",
-    "TINYPLACE_CLAUDE_DM_TO",
+    ...(upper ? [`TINYPLACE_${upper}_DM_TO`] : []),
     "TINYPLACE_HARNESS_DM_TO",
     "TINYPLACE_OPENHUMAN_OWNER",
     "OPENHUMAN_OWNER_AGENT",
-    "TINYPLACE_CODEX_RECEIVE_FROM",
-    "TINYPLACE_CLAUDE_RECEIVE_FROM",
+    ...(upper ? [`TINYPLACE_${upper}_RECEIVE_FROM`] : []),
     "TINYPLACE_HARNESS_RECEIVE_FROM",
   ]);
 }

--- a/sdk/typescript/src/cli/types.ts
+++ b/sdk/typescript/src/cli/types.ts
@@ -60,6 +60,13 @@ export interface TinyPlaceCliConfig {
    * preferred auth credential, rather than re-signing a sign-in message per run.
    */
   siwsToken?: string;
+  /**
+   * The OpenHuman owner (@handle or address) this identity bridges to, saved from
+   * the TUI's "Connect with OpenHuman" step. Persisting it lets the next launch
+   * auto-connect the bridge without re-asking. Env (`TINYPLACE_*_DM_TO` etc.)
+   * still overrides at resolution time.
+   */
+  openHumanOwner?: string;
 }
 
 export interface CliContext {
@@ -78,6 +85,12 @@ export interface CliContext {
    * LocalSigner only exposes detached message signing.
    */
   secretKey?: string;
+  /**
+   * The persisted OpenHuman owner (@handle or address) this identity bridges to,
+   * loaded from the CLI config. The TUI auto-connects to it on launch; env vars
+   * still override. Undefined until the user runs "Connect with OpenHuman" once.
+   */
+  openHumanOwner?: string;
 }
 
 export interface TinyPlaceCliResult {

--- a/sdk/typescript/tests/cli.test.ts
+++ b/sdk/typescript/tests/cli.test.ts
@@ -915,6 +915,20 @@ describe("tinyplace CLI", () => {
     expect(home.stdout).not.toContain("tinyplace raw <command>");
   });
 
+  it("Home mode ignores a provider-specific recipient until an agent is picked", async () => {
+    // A Codex-only recipient must NOT be adopted before the user chooses Codex
+    // vs Claude — otherwise picking Claude would bridge to the Codex owner.
+    const home = await runTinyPlaceCli([], {
+      env: {
+        TINYPLACE_ENDPOINT: "https://example.test",
+        TINYPLACE_CODEX_DM_TO: "@codex-only-owner",
+      },
+    });
+    expect(home.code).toBe(0);
+    expect(home.stdout).toContain("OpenHuman: disconnected");
+    expect(home.stdout).not.toContain("@codex-only-owner");
+  });
+
   it("documents the full feed surface, including likes", () => {
     const feedCommands = HARNESS_CLI_COMMANDS.filter(
       (command) => command.capability === "feeds",

--- a/sdk/typescript/tests/cli.test.ts
+++ b/sdk/typescript/tests/cli.test.ts
@@ -890,16 +890,29 @@ describe("tinyplace CLI", () => {
     expect(graphql!.body).toMatch(/batched GraphQL gateway/);
     expect(graphql!.body).toMatch(/429/);
 
-    const help = await runTinyPlaceCli([], {});
+    const help = await runTinyPlaceCli(["help"], {});
     expect(help.stdout).toContain("graphql");
   });
 
   it("help separates workflows from raw commands", async () => {
-    const help = await runTinyPlaceCli([], {});
+    const help = await runTinyPlaceCli(["help"], {});
     expect(help.code).toBe(0);
     expect(help.stdout).toContain("Workflows");
     expect(help.stdout).toContain("tinyplace raw <command>");
     expect(help.stdout).toContain("status");
+  });
+
+  it("bare `tinyplace` opens the Home picker (both agents), not the help dump", async () => {
+    const home = await runTinyPlaceCli([], {
+      env: { TINYPLACE_ENDPOINT: "https://example.test" },
+    });
+    expect(home.code).toBe(0);
+    expect(home.stdout).toContain("welcome to tiny.place");
+    expect(home.stdout).toContain("[ Start Codex session ]");
+    expect(home.stdout).toContain("[ Start Claude session ]");
+    expect(home.stdout).toContain("[ Connect with OpenHuman ]");
+    // The command reference is NOT dumped for the bare entry anymore.
+    expect(home.stdout).not.toContain("tinyplace raw <command>");
   });
 
   it("documents the full feed surface, including likes", () => {

--- a/sdk/typescript/tests/openhuman-owner.test.ts
+++ b/sdk/typescript/tests/openhuman-owner.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { makeContext, saveOpenHumanOwner } from "../src/cli/context.js";
+
+/**
+ * The TUI "Connect with OpenHuman" step persists the owner so the next launch
+ * auto-connects the bridge without re-asking. These lock the round-trip through
+ * the CLI config file (independent of the interactive Blessed layer).
+ */
+describe("OpenHuman owner persistence", () => {
+  async function tempConfig(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "tinyplace-owner-"));
+    return join(dir, "config.json");
+  }
+
+  it("saves the owner and makeContext reads it back", async () => {
+    const configPath = await tempConfig();
+    const env = { TINYPLACE_CONFIG: configPath };
+
+    await saveOpenHumanOwner(env, "@carol");
+
+    // Persisted to disk under the documented key.
+    const onDisk = JSON.parse(await readFile(configPath, "utf8")) as {
+      openHumanOwner?: string;
+    };
+    expect(onDisk.openHumanOwner).toBe("@carol");
+
+    // And surfaced on the context the TUI auto-connects from.
+    const ctx = await makeContext({ env });
+    expect(ctx.openHumanOwner).toBe("@carol");
+  });
+
+  it("trims whitespace and preserves the identity key on the same file", async () => {
+    const configPath = await tempConfig();
+    await writeFile(
+      configPath,
+      JSON.stringify({ secretKey: "ab".repeat(32) }),
+      "utf8",
+    );
+    const env = { TINYPLACE_CONFIG: configPath };
+
+    await saveOpenHumanOwner(env, "  6wNaBJkatir4B86cw5ykHZWQ3xoNaKygX5vAU9MQbHSh  ");
+
+    const onDisk = JSON.parse(await readFile(configPath, "utf8")) as {
+      openHumanOwner?: string;
+      secretKey?: string;
+    };
+    expect(onDisk.openHumanOwner).toBe(
+      "6wNaBJkatir4B86cw5ykHZWQ3xoNaKygX5vAU9MQbHSh",
+    );
+    // The wallet key the config already held is untouched by the owner write.
+    expect(onDisk.secretKey).toBe("ab".repeat(32));
+  });
+
+  it("clears the stored owner when passed an empty value", async () => {
+    const configPath = await tempConfig();
+    const env = { TINYPLACE_CONFIG: configPath };
+
+    await saveOpenHumanOwner(env, "@dave");
+    await saveOpenHumanOwner(env, "   ");
+
+    const ctx = await makeContext({ env });
+    expect(ctx.openHumanOwner).toBeUndefined();
+  });
+});

--- a/sdk/typescript/tests/openhuman-owner.test.ts
+++ b/sdk/typescript/tests/openhuman-owner.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { runTinyPlaceCli } from "../src/cli.js";
 import { makeContext, saveOpenHumanOwner } from "../src/cli/context.js";
 
 /**
@@ -63,5 +64,31 @@ describe("OpenHuman owner persistence", () => {
 
     const ctx = await makeContext({ env });
     expect(ctx.openHumanOwner).toBeUndefined();
+  });
+
+  it("renders a persisted owner as auto-connect in the non-TTY home snapshot", async () => {
+    const configPath = await tempConfig();
+    const env = {
+      TINYPLACE_CONFIG: configPath,
+      TINYPLACE_ENDPOINT: "https://example.test",
+    };
+    await saveOpenHumanOwner(env, "@carol");
+
+    const home = await runTinyPlaceCli([], { env });
+    expect(home.code).toBe(0);
+    expect(home.stdout).toContain("@carol (auto-connect on launch)");
+  });
+
+  it("rejects on a corrupt config instead of clobbering it (caller must catch)", async () => {
+    const configPath = await tempConfig();
+    // Unparseable JSON: loadCliConfig rethrows (non-ENOENT), so the save must
+    // reject rather than silently overwrite — otherwise it would drop the
+    // secretKey. The TUI call site swallows this with `.catch()`.
+    await writeFile(configPath, "{ not valid json", "utf8");
+    await expect(
+      saveOpenHumanOwner({ TINYPLACE_CONFIG: configPath }, "@eve"),
+    ).rejects.toThrow();
+    // The corrupt file is left untouched (not overwritten with a partial config).
+    expect(await readFile(configPath, "utf8")).toBe("{ not valid json");
   });
 });


### PR DESCRIPTION
## Summary
Two connected onboarding wins for the `tinyplace` CLI:

1. **Home menu** — bare `tinyplace` (which only dumped `--help`) now opens a navigable menu so developers don't have to recall subcommands.
2. **Remember + auto-connect** the OpenHuman owner, so you connect once and every later launch is wired automatically.

## Home menu
```
welcome to tiny.place
Pick a session to start, or connect your OpenHuman.
> [ Start Codex session ]
  [ Start Claude session ]
  [ Connect with OpenHuman ]
  [ Settings ]
  [ Quit ]
Arrows/j,k move · Enter selects · q quits.
```
- The single-agent welcome menu is generalized into a computed action list; **home mode** renders a launch row per agent and binds the profile on pick, reusing the existing launch/agent flow. No auto-launch in home (you choose).
- `tinyplace codex` / `claude` / `tui <kind>` stay as direct shortcuts; `tinyplace help` still prints the command reference.

## Remember + auto-connect
- New `saveOpenHumanOwner` + an `openHumanOwner` field on the CLI config/context. The owner picked in **Connect with OpenHuman** is persisted (mode 0600, merged over the wallet key).
- On start the TUI auto-adopts a remembered owner (persisted config **or** env) — footer shows connected and the bridge wires on agent launch, **no manual Connect on repeat launches**.
- Resolution priority: entered-this-session → env override → persisted config.

## Notes
- Builds on the connect-modal repair in c9725a05 (I only graft the persistence call into its `done()`; no change to the modal mechanics).

## Tests
- Bare `tinyplace` → Home picker (both agents); `tinyplace help` still the reference.
- `saveOpenHumanOwner` round-trips through config + `makeContext` (new `openhuman-owner.test.ts`).
- Owner auto-connect line in the non-TTY snapshot.
- `tsc --noEmit` clean; cli + owner suites green (52 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI now supports a “home mode” when started without a command, including an agent picker and a non-TTY home snapshot.
  * OpenHuman owner selections are persisted and reused for auto-connection on future runs.

* **Bug Fixes**
  * Help now appears only for explicit `help`/`--help`, not for a bare CLI launch.
  * OpenHuman owner inputs are trimmed before saving; empty values clear the saved owner.
  * If a persisted config is corrupt/unparseable, it’s left untouched rather than overwritten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->