### PR TITLE
fix: Home-menu sessions line + adopt the CLI wallet in the plugin

### DIFF
--- a/sdk/plugin-tinyplace/bin/tinyplace.mjs
+++ b/sdk/plugin-tinyplace/bin/tinyplace.mjs
@@ -29,7 +29,7 @@ import { LocalSigner } from "@tinyhumansai/tinyplace";
 
 import { activeAdapter, harnessDataDir, ADAPTERS, _resetAdapterCache } from "../mcp/harness.mjs";
 import { canForegroundInject } from "../mcp/foreground-inject.mjs";
-import { loadWallets, saveWallets } from "../mcp/wallets.mjs";
+import { loadWallets, saveWallets, sharedDir } from "../mcp/wallets.mjs";
 
 // bin/tinyplace.mjs -> plugin root is one dir up from bin/.
 const PLUGIN_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -109,6 +109,31 @@ async function importWallet(name, secretInput) {
   });
   saveWallets(wallets);
   return { address: signer.agentId, publicKey: signer.publicKeyBase64 };
+}
+
+// Fold the tinyplace **CLI's** auto-minted wallet (`~/.tinyplace/config.json` →
+// `secretKey`, a 32-byte seed in hex) into the shared plugin store on first run.
+// The CLI mints its identity into `config.json`; the plugin reads `wallets.json`
+// — two different files in the same dir — so without this a session started via
+// the CLI sees "no wallets" and prompts for a brand-new identity instead of
+// reusing the one you already created. Best-effort + only when the store is
+// empty, so it never overwrites or duplicates a wallet the user already has.
+async function seedFromCliConfig() {
+  if (loadWallets().length) return;
+  let secretKey;
+  try {
+    secretKey = JSON.parse(
+      readFileSync(join(sharedDir(), "config.json"), "utf8"),
+    )?.secretKey;
+  } catch {
+    return; // no CLI config / unreadable
+  }
+  if (typeof secretKey !== "string" || !secretKey) return;
+  try {
+    await importWallet("cli", secretKey);
+  } catch {
+    /* bad key or a race created the store — leave it to the menu */
+  }
 }
 
 // ── tiny ANSI helpers ────────────────────────────────────────────────────────
@@ -425,6 +450,10 @@ async function main() {
   // Resolve the active adapter + its data dir now that the override is in env.
   ADAPTER = activeAdapter();
   DATA_DIR = harnessDataDir(ADAPTER);
+
+  // First-run: adopt the CLI's auto-minted wallet so `--wallet cli` and the menu
+  // both see the identity created by the tinyplace CLI, not just plugin-created ones.
+  await seedFromCliConfig();
 
   // Non-interactive fast path: `tinyplace-plugin --wallet alice`.
   const walletFlag = flags.indexOf("--wallet");

--- a/sdk/plugin-tinyplace/bin/tinyplace.mjs
+++ b/sdk/plugin-tinyplace/bin/tinyplace.mjs
@@ -122,9 +122,12 @@ async function seedFromCliConfig() {
   if (loadWallets().length) return;
   let secretKey;
   try {
-    secretKey = JSON.parse(
-      readFileSync(join(sharedDir(), "config.json"), "utf8"),
-    )?.secretKey;
+    // Resolve the CLI config the same way the SDK's configPathFor does — honor
+    // TINYPLACE_CONFIG so a non-default profile / embedder / test that moved the
+    // CLI identity is adopted, instead of silently reading the default file.
+    const configPath =
+      process.env.TINYPLACE_CONFIG ?? join(sharedDir(), "config.json");
+    secretKey = JSON.parse(readFileSync(configPath, "utf8"))?.secretKey;
   } catch {
     return; // no CLI config / unreadable
   }

--- a/sdk/typescript/src/cli/tui.ts
+++ b/sdk/typescript/src/cli/tui.ts
@@ -1176,11 +1176,15 @@ function renderWelcomeContent(
   const info = [
     renderKeyValue("tiny.place", ctx.baseUrl, "{cyan-fg}"),
     renderKeyValue("wallet", walletIdFor(ctx), "{yellow-fg}"),
-    // Fixed-agent mode names the one agent; home mode doesn't bind one yet.
+    // Fixed-agent mode names the one agent + its sessions dir; home mode hasn't
+    // bound one yet, so showing a codex-specific `sessions:` path there is
+    // misleading — omit both until the user picks an agent.
     ...(homeMode
       ? []
-      : [renderKeyValue(profile.kind, profile.launch.label, "{green-fg}")]),
-    renderKeyValue("sessions", profile.sessionsDir, "{cyan-fg}"),
+      : [
+          renderKeyValue(profile.kind, profile.launch.label, "{green-fg}"),
+          renderKeyValue("sessions", profile.sessionsDir, "{cyan-fg}"),
+        ]),
     state.bridgeLive
       ? renderKeyValue(
           "OpenHuman",

--- a/sdk/typescript/tests/cli.test.ts
+++ b/sdk/typescript/tests/cli.test.ts
@@ -903,8 +903,13 @@ describe("tinyplace CLI", () => {
   });
 
   it("bare `tinyplace` opens the Home picker (both agents), not the help dump", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "tinyplace-home-"));
     const home = await runTinyPlaceCli([], {
-      env: { TINYPLACE_ENDPOINT: "https://example.test" },
+      env: {
+        TINYPLACE_ENDPOINT: "https://example.test",
+        // Isolate the config so a real persisted owner in ~/.tinyplace can't leak in.
+        TINYPLACE_CONFIG: join(dir, "config.json"),
+      },
     });
     expect(home.code).toBe(0);
     expect(home.stdout).toContain("welcome to tiny.place");
@@ -918,9 +923,12 @@ describe("tinyplace CLI", () => {
   it("Home mode ignores a provider-specific recipient until an agent is picked", async () => {
     // A Codex-only recipient must NOT be adopted before the user chooses Codex
     // vs Claude — otherwise picking Claude would bridge to the Codex owner.
+    const dir = await mkdtemp(join(tmpdir(), "tinyplace-home-"));
     const home = await runTinyPlaceCli([], {
       env: {
         TINYPLACE_ENDPOINT: "https://example.test",
+        // Isolate the config so a real persisted owner in ~/.tinyplace can't leak in.
+        TINYPLACE_CONFIG: join(dir, "config.json"),
         TINYPLACE_CODEX_DM_TO: "@codex-only-owner",
       },
     });


### PR DESCRIPTION
Two onboarding follow-ups reported after #236/#237 landed.

## 1. Home menu showed a codex-specific `sessions:` path (cli)
Bare `tinyplace` Home mode defaults its profile to codex for the shared render, so the welcome screen printed `sessions: ~/.codex/sessions` **before** the user picked an agent — misleading, since nothing is bound yet.
- Omit the `sessions:` line in Home mode (the agent line was already omitted); fixed-agent mode (`tinyplace codex`/`claude`/`tui`) is unchanged.
- Also isolate `TINYPLACE_CONFIG` in the two Home-mode tests so a real persisted owner in `~/.tinyplace/config.json` can't leak into assertions (they passed on clean CI but were env-dependent).

## 2. Plugin didn't reuse the CLI's wallet (plugin)
The CLI auto-mints its identity into `~/.tinyplace/config.json` (`secretKey`); the plugin reads `~/.tinyplace/wallets.json` — **two different files**. So a session launched through the plugin saw "no wallets" and prompted for a brand-new identity instead of the one the CLI already created.
- On first run (shared store empty), fold `config.json`'s `secretKey` into the store as a wallet named `cli` via the existing `importWallet` path.
- Same seed → same identity (verified deterministic). Best-effort + guarded: only when the store is empty, wrapped in try/catch, so it never overwrites or duplicates an existing wallet.

## Tests
- `tsc --noEmit` clean; 58 CLI/owner tests green (incl. the now-isolated Home tests).
- Plugin wallet derivation validated directly (hex `secretKey` → deterministic `{address, publicKey}` via `LocalSigner.fromSeed`). The launcher's full menu path is interactive + standalone (workspace-excluded), so the adoption step wants a live smoke on a real install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-time setup can now automatically seed a wallet from the tinyplace CLI’s auto-minted identity when the plugin wallet store is empty.

* **Bug Fixes**
  * Updated the welcome screen to show the agent kind label and `sessions:` path only in the appropriate TUI mode, avoiding extra clutter in home mode.
  * Improved CLI home-mode behavior for clean/empty-config starts to ensure scenarios run reliably.

* **Tests**
  * Enhanced home-mode CLI test coverage by using isolated temporary config files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->