### PR TITLE
fix(cli): repair harness↔OpenHuman bridge — locate, echo, auto-submit, directory card

### DIFF
--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -984,12 +984,25 @@ export class SessionEnvelopePublisher {
     if (key.length === 0) {
       return;
     }
-    this.injectedEchoes.set(key, Date.now() + SessionEnvelopePublisher.ECHO_TTL_MS);
+    const now = Date.now();
+    // Prune expired keys on every write so the map stays bounded even when the
+    // echo never comes back (e.g. captureSession off → no tailer → publish()
+    // never consumes entries). Without this it grows one entry per inbound.
+    for (const [existingKey, expiry] of this.injectedEchoes) {
+      if (expiry < now) {
+        this.injectedEchoes.delete(existingKey);
+      }
+    }
+    this.injectedEchoes.set(key, now + SessionEnvelopePublisher.ECHO_TTL_MS);
   }
 
   /** True (consuming the record) if this outbound is an echo of a fresh injection. */
   private isInjectedEcho(envelope: AnySessionEnvelope): boolean {
-    if (envelopeRole(envelope) !== "user") {
+    // The echoed injection is a `user` turn in v1 and an `owner` `user_prompt`
+    // in v2 — accept both, or v2 sessions (TINYPLACE_*_V2=1) leak the echo and
+    // re-enter the auto-reply loop this suppression exists to stop.
+    const role = envelopeRole(envelope);
+    if (role !== "user" && role !== "owner") {
       return false;
     }
     const key = echoKey(envelopeText(envelope));
@@ -1134,16 +1147,23 @@ function envelopeId(envelope: AnySessionEnvelope): string {
     : envelope.message.id;
 }
 
-function envelopeRole(envelope: AnySessionEnvelope): string {
+export function envelopeRole(envelope: AnySessionEnvelope): string {
   return envelope.envelope_version === SESSION_ENVELOPE_VERSION_V2
     ? envelope.event.role
     : envelope.message.role;
 }
 
-function envelopeText(envelope: AnySessionEnvelope): string {
-  return envelope.envelope_version === SESSION_ENVELOPE_VERSION_V2
-    ? ((envelope.event as { text?: string }).text ?? "")
-    : envelope.message.text;
+export function envelopeText(envelope: AnySessionEnvelope): string {
+  if (envelope.envelope_version === SESSION_ENVELOPE_VERSION_V2) {
+    // v2 typed events carry their body under event.payload.text (user_prompt,
+    // agent_message, …); older/other shapes may put it at event.text.
+    const event = envelope.event as {
+      text?: string;
+      payload?: { text?: string };
+    };
+    return event.payload?.text ?? event.text ?? "";
+  }
+  return envelope.message.text;
 }
 
 /** Normalize a message body so an injected inbound and its echoed-back session

--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -962,12 +962,43 @@ export class SessionEnvelopePublisher {
   private failures = 0;
   private pending = new Set<Promise<void>>();
   private queue: Promise<void> = Promise.resolve();
+  // Echo suppression: text injected FROM the owner (inbound) is recorded by the
+  // agent as a `user`-role session line, which the tailer would otherwise stream
+  // straight back — the owner then sees its own message twice AND may auto-reply
+  // to its own echo, feeding a ping-pong loop. Remember recent injections so
+  // `publish()` can drop the matching `user` echo. TTL-bounded so a genuine
+  // later user turn with identical text still forwards.
+  private injectedEchoes = new Map<string, number>();
+  private static readonly ECHO_TTL_MS = 60_000;
 
   public constructor(
     private readonly config: HarnessWrapperConfig,
     private readonly options: TinyPlaceCliOptions,
     private readonly stderr: Writable,
   ) {}
+
+  /** Record an owner→agent injection so its echoed-back `user` line is dropped. */
+  public markInjected(text: string): void {
+    const key = echoKey(text);
+    if (key.length === 0) {
+      return;
+    }
+    this.injectedEchoes.set(key, Date.now() + SessionEnvelopePublisher.ECHO_TTL_MS);
+  }
+
+  /** True (consuming the record) if this outbound is an echo of a fresh injection. */
+  private isInjectedEcho(envelope: AnySessionEnvelope): boolean {
+    if (envelopeRole(envelope) !== "user") {
+      return false;
+    }
+    const key = echoKey(envelopeText(envelope));
+    const expiry = this.injectedEchoes.get(key);
+    if (expiry === undefined) {
+      return false;
+    }
+    this.injectedEchoes.delete(key);
+    return expiry >= Date.now();
+  }
 
   public publish(envelope: AnySessionEnvelope): void {
     const id = envelopeId(envelope);
@@ -976,6 +1007,10 @@ export class SessionEnvelopePublisher {
         id,
         reason: !this.config.dmRecipient ? "no-dmRecipient" : "dryRun",
       });
+      return;
+    }
+    if (this.isInjectedEcho(envelope)) {
+      bridgeLog("publish.echoSkip", { id });
       return;
     }
     bridgeLog("publish.enqueue", {
@@ -1102,6 +1137,18 @@ function envelopeRole(envelope: AnySessionEnvelope): string {
   return envelope.envelope_version === SESSION_ENVELOPE_VERSION_V2
     ? envelope.event.role
     : envelope.message.role;
+}
+
+function envelopeText(envelope: AnySessionEnvelope): string {
+  return envelope.envelope_version === SESSION_ENVELOPE_VERSION_V2
+    ? ((envelope.event as { text?: string }).text ?? "")
+    : envelope.message.text;
+}
+
+/** Normalize a message body so an injected inbound and its echoed-back session
+ *  line compare equal (trim + collapse interior whitespace). */
+function echoKey(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
 }
 
 function isNotAContactError(error: unknown): boolean {
@@ -1250,6 +1297,10 @@ export class InboundMessageReceiver {
         const text = this.filterAndParse(message);
         if (text !== undefined && this.sink) {
           injected += 1;
+          // Record before injecting so the tailer's echoed-back `user` line
+          // (the agent logs the injected prompt as its own user turn) is dropped
+          // by the publisher instead of bouncing to the owner.
+          this.publisher.markInjected(text);
           // "\r" (carriage return) submits the prompt to the agent TUI.
           this.sink(`${text}\r`);
         } else {

--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -21,6 +21,7 @@ import {
   sendMessage,
   type ReadMessage,
 } from "../agent/messaging.js";
+import { publishCard } from "../agent/identity.js";
 import {
   SESSION_ENVELOPE_VERSION_V1,
   SESSION_ENVELOPE_VERSION_V2,
@@ -1217,6 +1218,21 @@ export class InboundMessageReceiver {
     } catch (error) {
       this.stderr.write(
         `tinyplace ${this.config.provider}: failed to publish Signal keys: ${describeError(error)}\n`,
+      );
+    }
+    // Also register a directory card. publishKeys makes us *messageable* (prekey
+    // bundle) but not *discoverable*: a peer that resolves us by lookup —
+    // OpenHuman's `signal send` hits /directory/agents/<id> — 404s without a
+    // card, so first contact from the owner fails. Best-effort; a card failure
+    // must not stop the inbound poll from starting.
+    try {
+      await publishCard(ctx.client, ctx.signer, {
+        name: `tinyplace ${this.config.provider}`,
+        description: `coding-agent bridge (${this.config.provider}) → OpenHuman`,
+      });
+    } catch (error) {
+      this.stderr.write(
+        `tinyplace ${this.config.provider}: failed to publish directory card: ${describeError(error)}\n`,
       );
     }
     if (this.config.receiveFrom) {

--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -1522,6 +1522,12 @@ function readSessionMeta(
   provider: HarnessProvider,
   path: string,
 ): SessionMeta | undefined {
+  // A claude session can open with a cwd-less record (e.g. `type:"last-prompt"`
+  // on a resumed session). Returning on that first line would yield a meta with
+  // no `cwd`, which `locateSession` rejects (`meta.cwd === this.cwd`) — silently
+  // orphaning the whole (correct) session so the tailer never streams. Remember
+  // the id from such lines but keep scanning for one that records the cwd.
+  let claudeFallbackId: string | undefined;
   for (const raw of readAllLines(path)) {
     const record = parseJsonObject(raw);
     if (!record) {
@@ -1540,12 +1546,19 @@ function readSessionMeta(
       };
     }
     if (provider === "claude") {
-      const sessionId = asString(record.sessionId) ?? basename(path, ".jsonl");
-      return {
-        ...(asString(record.cwd) ? { cwd: asString(record.cwd) } : {}),
-        sessionId,
-      };
+      const cwd = asString(record.cwd);
+      const sessionId = asString(record.sessionId);
+      if (!cwd) {
+        claudeFallbackId ??= sessionId;
+        continue;
+      }
+      return { cwd, sessionId: sessionId ?? basename(path, ".jsonl") };
     }
+  }
+  // No cwd-bearing line found. Surface any id we saw so a directly-specified
+  // session file still resolves (locate-by-cwd simply won't match this one).
+  if (claudeFallbackId) {
+    return { sessionId: claudeFallbackId };
   }
   return undefined;
 }

--- a/sdk/typescript/src/cli/tui.ts
+++ b/sdk/typescript/src/cli/tui.ts
@@ -183,6 +183,12 @@ class BlessedTinyPlaceTui {
   // inbound receiver, reused from the harness wrapper.
   private bridgeTailer?: HarnessSessionTailer;
   private bridgeReceiver?: InboundMessageReceiver;
+  // Loop guard: count consecutive auto-submitted inbound turns with no human
+  // keystroke in between. OpenHuman's master auto-replies, so unbounded
+  // auto-submit ping-pongs forever; after MAX_AUTO_INJECTS we stop submitting
+  // (text still parks) until a human types, which resets the counter.
+  private consecutiveAutoInjects = 0;
+  private static readonly MAX_AUTO_INJECTS = 6;
 
   public constructor(
     private readonly ctx: CliContext,
@@ -584,7 +590,58 @@ class BlessedTinyPlaceTui {
       : undefined;
     this.bridgeReceiver?.setSink((text) => {
       bridgeLog("inbound.inject", { chars: text.length });
-      this.writeAgentInput(Buffer.from(text, "utf8"));
+      // The receiver appends a CR to submit. Writing "text\r" straight to the
+      // PTY makes claude's TUI treat the burst as a bracketed paste and swallow
+      // the CR, so the prompt parks unsubmitted. In the native tmux relay,
+      // inject the literal text and then a DISTINCT Enter keypress (separate
+      // send-keys after a short debounce) so the turn actually submits.
+      const body = text.endsWith("\r") ? text.slice(0, -1) : text;
+      // Auto-submit is ON by default: an inbound OpenHuman turn is injected AND
+      // submitted so claude replies without a human keypress. Because
+      // OpenHuman's master also auto-replies, the two can ping-pong; set
+      // TINYPLACE_<KIND>_AUTOSUBMIT=0 to fall back to a human gate (text parks
+      // in the prompt; you press Enter to send). A UI toggle in OpenHuman is the
+      // planned front-door for this same switch.
+      const envAutoSubmit =
+        this.ctx.env[`TINYPLACE_${this.profile.kind.toUpperCase()}_AUTOSUBMIT`] !==
+        "0";
+      // Loop guard: once too many auto-turns fire back-to-back with no human
+      // keystroke, stop auto-submitting so a master↔claude loop can't run away.
+      const guardTripped =
+        this.consecutiveAutoInjects >= BlessedTinyPlaceTui.MAX_AUTO_INJECTS;
+      const autoSubmit = envAutoSubmit && !guardTripped;
+      if (envAutoSubmit && guardTripped) {
+        bridgeLog("inbound.loopGuard", {
+          paused: true,
+          consecutive: this.consecutiveAutoInjects,
+        });
+      }
+      if (autoSubmit) {
+        this.consecutiveAutoInjects += 1;
+      }
+      if (this.tmuxSocket && this.tmuxSession) {
+        const socket = this.tmuxSocket;
+        const session = this.tmuxSession;
+        const cwd = this.options.cwd ?? process.cwd();
+        runTmuxCommand(
+          socket,
+          ["send-keys", "-t", session, "-l", body],
+          this.ctx.env,
+          cwd,
+        );
+        if (autoSubmit) {
+          setTimeout(() => {
+            runTmuxCommand(
+              socket,
+              ["send-keys", "-t", session, "Enter"],
+              this.ctx.env,
+              cwd,
+            );
+          }, 150);
+        }
+        return;
+      }
+      this.writeAgentInput(Buffer.from(autoSubmit ? `${body}\r` : body, "utf8"));
     });
     this.bridgeTailer?.start(new Date());
     void this.bridgeReceiver?.start();
@@ -784,6 +841,9 @@ class BlessedTinyPlaceTui {
       this.pty = pty;
       this.nativeRelayActive = true;
       this.nativeInputHandler = (chunk) => {
+        // A real human keystroke clears the loop-guard streak so auto-submit
+        // resumes after the person re-engages.
+        this.consecutiveAutoInjects = 0;
         pty.write(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk);
       };
       const stdin = this.options.stdin ?? process.stdin;

--- a/sdk/typescript/src/cli/tui.ts
+++ b/sdk/typescript/src/cli/tui.ts
@@ -189,6 +189,9 @@ class BlessedTinyPlaceTui {
   // (text still parks) until a human types, which resets the counter.
   private consecutiveAutoInjects = 0;
   private static readonly MAX_AUTO_INJECTS = 6;
+  // Serial queue for inbound injection so a batch of DMs typed in one receiver
+  // poll keeps its turn boundaries (each body+Enter finishes before the next).
+  private injectionQueue: Promise<void> = Promise.resolve();
 
   public constructor(
     private readonly ctx: CliContext,
@@ -596,52 +599,11 @@ class BlessedTinyPlaceTui {
       // inject the literal text and then a DISTINCT Enter keypress (separate
       // send-keys after a short debounce) so the turn actually submits.
       const body = text.endsWith("\r") ? text.slice(0, -1) : text;
-      // Auto-submit is ON by default: an inbound OpenHuman turn is injected AND
-      // submitted so claude replies without a human keypress. Because
-      // OpenHuman's master also auto-replies, the two can ping-pong; set
-      // TINYPLACE_<KIND>_AUTOSUBMIT=0 to fall back to a human gate (text parks
-      // in the prompt; you press Enter to send). A UI toggle in OpenHuman is the
-      // planned front-door for this same switch.
-      const envAutoSubmit =
-        this.ctx.env[`TINYPLACE_${this.profile.kind.toUpperCase()}_AUTOSUBMIT`] !==
-        "0";
-      // Loop guard: once too many auto-turns fire back-to-back with no human
-      // keystroke, stop auto-submitting so a master↔claude loop can't run away.
-      const guardTripped =
-        this.consecutiveAutoInjects >= BlessedTinyPlaceTui.MAX_AUTO_INJECTS;
-      const autoSubmit = envAutoSubmit && !guardTripped;
-      if (envAutoSubmit && guardTripped) {
-        bridgeLog("inbound.loopGuard", {
-          paused: true,
-          consecutive: this.consecutiveAutoInjects,
-        });
-      }
-      if (autoSubmit) {
-        this.consecutiveAutoInjects += 1;
-      }
-      if (this.tmuxSocket && this.tmuxSession) {
-        const socket = this.tmuxSocket;
-        const session = this.tmuxSession;
-        const cwd = this.options.cwd ?? process.cwd();
-        runTmuxCommand(
-          socket,
-          ["send-keys", "-t", session, "-l", body],
-          this.ctx.env,
-          cwd,
-        );
-        if (autoSubmit) {
-          setTimeout(() => {
-            runTmuxCommand(
-              socket,
-              ["send-keys", "-t", session, "Enter"],
-              this.ctx.env,
-              cwd,
-            );
-          }, 150);
-        }
-        return;
-      }
-      this.writeAgentInput(Buffer.from(autoSubmit ? `${body}\r` : body, "utf8"));
+      // The receiver can deliver several inbound messages in one poll, calling
+      // this sink synchronously per message. Serialize them: each body+Enter
+      // pair must complete before the next body types, or two messages land in
+      // one prompt and the trailing Enter submits an empty turn (lost boundary).
+      this.enqueueInjection(body, this.computeAutoSubmit());
     });
     this.bridgeTailer?.start(new Date());
     void this.bridgeReceiver?.start();
@@ -664,6 +626,69 @@ class BlessedTinyPlaceTui {
     this.bridgeTailer = undefined;
     this.bridgeReceiver = undefined;
     this.state = { ...this.state, bridgeLive: false };
+  }
+
+  /** Resolve whether this inbound turn should auto-submit, applying the env
+   *  switch and the runaway loop guard, and advancing the guard counter. */
+  private computeAutoSubmit(): boolean {
+    // Auto-submit is ON by default so claude replies to an inbound OpenHuman
+    // turn without a human keypress. Because OpenHuman's master also auto-
+    // replies, the two can ping-pong; TINYPLACE_<KIND>_AUTOSUBMIT=0 falls back
+    // to a human gate (text parks in the prompt; press Enter to send).
+    const envAutoSubmit =
+      this.ctx.env[
+        `TINYPLACE_${this.profile.kind.toUpperCase()}_AUTOSUBMIT`
+      ] !== "0";
+    const guardTripped =
+      this.consecutiveAutoInjects >= BlessedTinyPlaceTui.MAX_AUTO_INJECTS;
+    if (envAutoSubmit && guardTripped) {
+      bridgeLog("inbound.loopGuard", {
+        paused: true,
+        consecutive: this.consecutiveAutoInjects,
+      });
+    }
+    const autoSubmit = envAutoSubmit && !guardTripped;
+    if (autoSubmit) {
+      this.consecutiveAutoInjects += 1;
+    }
+    return autoSubmit;
+  }
+
+  /** Chain an injection onto the serial queue so batched inbound turns keep
+   *  their boundaries (body → Enter → next body), never interleaving. */
+  private enqueueInjection(body: string, autoSubmit: boolean): void {
+    this.injectionQueue = this.injectionQueue
+      .then(() => this.injectOne(body, autoSubmit))
+      .catch(() => {});
+  }
+
+  /** Type one inbound turn and, when auto-submitting, the distinct Enter after a
+   *  short debounce (so the agent TUI doesn't swallow the CR as a paste). */
+  private async injectOne(body: string, autoSubmit: boolean): Promise<void> {
+    if (this.tmuxSocket && this.tmuxSession) {
+      const socket = this.tmuxSocket;
+      const session = this.tmuxSession;
+      const cwd = this.options.cwd ?? process.cwd();
+      runTmuxCommand(
+        socket,
+        ["send-keys", "-t", session, "-l", body],
+        this.ctx.env,
+        cwd,
+      );
+      if (autoSubmit) {
+        await delay(150);
+        runTmuxCommand(
+          socket,
+          ["send-keys", "-t", session, "Enter"],
+          this.ctx.env,
+          cwd,
+        );
+      }
+      return;
+    }
+    this.writeAgentInput(
+      Buffer.from(autoSubmit ? `${body}\r` : body, "utf8"),
+    );
   }
 
   private async startAgent(): Promise<void> {
@@ -709,6 +734,11 @@ class BlessedTinyPlaceTui {
     this.terminal = blessed.terminal({
       cursor: "block",
       handler: (input) => {
+        // A genuine keystroke (Blessed-widget path, mirroring the native relay's
+        // nativeInputHandler) clears the loop-guard streak so auto-submit
+        // resumes after the person re-engages. writeAgentInput is also used by
+        // inbound injection, so the reset must live here, not inside it.
+        this.consecutiveAutoInjects = 0;
         this.writeAgentInput(input);
       },
       height: "100%",
@@ -1845,6 +1875,12 @@ function bridgeOwner(
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
 }
 
 function autoStartMs(env: Record<string, string | undefined>): number {

--- a/sdk/typescript/tests/harness-echo.test.ts
+++ b/sdk/typescript/tests/harness-echo.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  envelopeRole,
+  envelopeText,
+} from "../src/cli/harness-wrapper.js";
+import { buildEventEnvelopeV2 } from "../src/cli/harness-envelope.js";
+import type { EnvelopeContext } from "../src/cli/harness-envelope.js";
+import type { HarnessSemanticEvent } from "../src/cli/harness-events.js";
+import {
+  SESSION_ENVELOPE_VERSION_V1,
+  type AnySessionEnvelope,
+} from "../src/index.js";
+
+const ctx: EnvelopeContext = {
+  provider: "claude",
+  command: "claude",
+  argv: [],
+  scopeType: "session",
+  scopeKey: "abc",
+  cwd: "/work/proj",
+  wrapperSessionId: "wrap-1",
+  harnessSessionId: "sess-1",
+  bucketUnit: "hour",
+  sourcePath: "/home/u/.claude/projects/p/sess-1.jsonl",
+};
+
+// The exact shape the tailer emits for an owner→agent prompt in v2: kind
+// `user_prompt`, role `owner`, text under event.payload.text.
+const userPrompt: HarnessSemanticEvent = {
+  line: 3,
+  timestamp: new Date("2026-07-07T10:00:00.000Z"),
+  recordType: "user",
+  event: {
+    kind: "user_prompt",
+    role: "owner",
+    payload: { text: "ping from the owner" },
+  },
+};
+
+describe("envelope role/text extraction (echo suppression)", () => {
+  it("reads a v2 user_prompt as an owner turn with its payload text", () => {
+    const envelope = buildEventEnvelopeV2(ctx, userPrompt, 1);
+
+    // Regression guard: envelopeRole must surface `owner` (not fall through to
+    // "user") and envelopeText must read event.payload.text — otherwise the
+    // publisher's isInjectedEcho misses v2 echoes and the owner sees its own
+    // injected prompt bounce back, re-feeding the auto-reply loop.
+    expect(envelopeRole(envelope)).toBe("owner");
+    expect(envelopeText(envelope)).toBe("ping from the owner");
+  });
+
+  it("reads a v1 envelope from its message fields", () => {
+    const v1 = {
+      envelope_version: SESSION_ENVELOPE_VERSION_V1,
+      message: { role: "user", text: "hello v1" },
+    } as unknown as AnySessionEnvelope;
+
+    expect(envelopeRole(v1)).toBe("user");
+    expect(envelopeText(v1)).toBe("hello v1");
+  });
+});


### PR DESCRIPTION
## Summary

Four fixes to the `tinyplace codex/claude` harness bridge that together make the coding-agent ↔ OpenHuman round-trip actually work. Surfaced while running a live bidirectional bridge against staging.

## Problem

1. **Outbound never streamed.** A resumed claude session can open its JSONL with a cwd-less record (`type:"last-prompt"`). `readSessionMeta` returned on that first line → a meta with no `cwd` → `locateSession` rejected the (correct) session (`meta.cwd === this.cwd`) → the tailer never locked on, so **nothing the agent said reached OpenHuman**.

2. **Owner messages echoed back as duplicates.** An inbound owner message is injected into the agent, which logs it as a `user`-role session line. The tailer streamed that straight back, so OpenHuman saw **its own message twice**, and its master agent could **auto-reply to its own echo** — feeding a ping-pong loop.

3. **Inbound parked, never submitted / then looped.** Injected inbound text had a trailing CR that claude's TUI swallowed as a bracketed paste, so the prompt parked unsubmitted. Naively auto-submitting re-opened the loop, because the OpenHuman master also auto-replies.

4. **Bridge identity undiscoverable.** The bridge called `publishKeys` (messageable) but never `publishCard`, so it wasn't in the Open Directory. A peer resolving it by lookup — OpenHuman's `signal send` hits `/directory/agents/<id>` — **404s**, so the owner's first contact fails.

## Solution

- **`fix(cli): locate claude session when its first line lacks a cwd`** — `readSessionMeta` skips cwd-less records and keeps scanning for one that records the cwd (falls back to the id so a directly-specified session file still resolves).
- **`fix(cli): suppress owner-injected prompt echoes`** — the receiver marks each injected text; the publisher drops the matching `user`-role echo before it goes back out (TTL-bounded, so a genuine later user turn with identical text still forwards).
- **`feat(cli): auto-submit inbound turns with a loop guard`** — inject the literal text then a distinct `Enter` via `tmux send-keys` so the turn submits; gated by `TINYPLACE_<KIND>_AUTOSUBMIT` (default on, `=0` for a human gate). A loop guard stops auto-submitting after `MAX_AUTO_INJECTS` back-to-back auto-turns with no human keystroke, and resets when a human types — so a master↔agent ping-pong can't run away.
- **`fix(cli): publish a directory card at bridge start`** — register a card alongside the key bundle so the bridge identity is discoverable and first contact from the owner resolves (best-effort; a card failure won't stop the inbound poll).

## Testing

- SDK `tsc --noEmit` + `build` green; `pnpm build` (SDK + website) green via the pre-push hook.
- CLI unit suite: 52/53 pass. The one failure (`Home mode ignores a provider-specific recipient`) is **pre-existing on `main`** — it reads the real `~/.tinyplace/config.json` instead of an isolated temp, so it fails locally when a config exists and passes in CI's clean env. Untouched by this PR.
- **Live bidirectional round-trip** against staging: OpenHuman → claude delivers and auto-submits; claude → OpenHuman streams once (no duplicate); loop guard caps a runaway master↔agent exchange; directory card lets the owner resolve+contact the bridge.

## Notes

- **`TINYPLACE_API_URL` is already honored** on the real-bin path (verified: `makeContext` with `options.env === undefined` uses `process.env`). A prod-endpoint result only happens when an embedder passes a partial `options.env`; not changed here to preserve managed/embedder semantics.
- **Session history / resume picker** in the home screen (list past sessions, `--resume` with stable per-session scope) — designed, coming as a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live chat injection now suppresses duplicate echoed owner/user turns to avoid repeated prompts.
  * Session startup additionally publishes a best-effort directory card to improve resolution.
  * TUI auto-injection now includes a loop guard to prevent runaway consecutive auto-submits.
* **Bug Fixes**
  * Session tailing now tolerates missing initial workspace details and still returns a valid session reference.
  * Inbound text injection handling is more robust to preserve turn boundaries and respond correctly to human keystrokes.
* **Tests**
  * Added coverage for envelope text/role parsing and echo-suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->