### PR TITLE
Fix review follow-ups from key and CLI PRs

### DIFF
--- a/sdk/python/src/tinyplace/api/keys.py
+++ b/sdk/python/src/tinyplace/api/keys.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from ..http import HttpClient, encode
 from ..types import Json, JsonDict
 
@@ -45,9 +47,7 @@ def _key_route_id(agent_id: str) -> str:
 def _looks_like_base64_public_key(value: str) -> bool:
     if len(value) < 40 or not any(marker in value for marker in "+/="):
         return False
-    return all(char.isalnum() or char in "+/=" for char in value) and (
-        value.rstrip("=").count("=") == 0
-    )
+    return bool(re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", value))
 
 
 def _base64_to_base64url(value: str) -> str:

--- a/sdk/python/tests/test_api_namespaces.py
+++ b/sdk/python/tests/test_api_namespaces.py
@@ -69,6 +69,28 @@ async def test_keys_routes_base64_public_keys_as_url_safe_segments() -> None:
     assert session.requests[1]["headers"]["X-Agent-ID"] == agent_id
 
 
+async def test_keys_keeps_non_canonical_base64_like_ids_on_legacy_route() -> None:
+    signer = LocalSigner.from_seed(bytes([26]) * 32)
+    session = FakeSession([FakeResponse(200, {"ok": True}) for _ in range(2)])
+    client = TinyPlaceClient(
+        base_url="https://api.example.test",
+        signer=signer,
+        session=session,  # type: ignore[arg-type]
+    )
+
+    await client.keys.get_bundle("h71YEo+jgSQJ8bG0msq/ES3I4A0K9oKRA5Eqq3yY4Q8===")
+    await client.keys.get_bundle("h71YEo+jgSQJ8bG0msq/ES3I4A0K9oKRA5Eqq3yY4Qé=")
+
+    paths = [
+        request["url"].replace("https://api.example.test", "")
+        for request in session.requests
+    ]
+    assert paths == [
+        "/keys/h71YEo%2BjgSQJ8bG0msq%2FES3I4A0K9oKRA5Eqq3yY4Q8%3D%3D%3D/bundle",
+        "/keys/h71YEo%2BjgSQJ8bG0msq%2FES3I4A0K9oKRA5Eqq3yY4Q%C3%A9%3D/bundle",
+    ]
+
+
 async def test_directory_routes() -> None:
     session = FakeSession([FakeResponse(200, {"ok": True}) for _ in range(9)])
     signer = LocalSigner.from_seed(bytes([23]) * 32)

--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -288,7 +288,9 @@ async function runPtyAgent(
   let pty: IPty;
   try {
     fixNodePtyHelperPermissions();
-    const { spawn: spawnPty } = await import("node-pty");
+    const { spawn: spawnPty } = requireForHarness(
+      "node-pty",
+    ) as typeof import("node-pty");
     pty = spawnPty(launch.command, launch.args, {
       cols: terminalColumns(stdio.stdout),
       cwd,


### PR DESCRIPTION
## Summary
- align the Python base64 public-key route heuristic with the TypeScript SDK, including ASCII-only matching and at most two padding characters
- add regression coverage for over-padded and Unicode-containing base64-like IDs staying on the legacy route
- replace the function-scoped dynamic `import("node-pty")` in the CLI harness with the existing `createRequire` loader, preserving lazy loading while following SDK import rules

## Verification
- `uv run --with pytest --with pytest-asyncio --with-editable . pytest -o addopts='' tests/test_api_namespaces.py`
- `sdk/typescript/node_modules/.bin/vitest run sdk/typescript/tests/cli.test.ts`
- `sdk/typescript/node_modules/.bin/tsc --noEmit --project sdk/typescript/tsconfig.json --pretty false`

Refs #213
Refs #216
Refs #217
Follow-up to #244 and #245.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of public-key identifiers, preserving non-canonical or invalid base64-like IDs on the legacy key endpoint.
  * Ensured unusual identifiers, including padded and non-ASCII values, are correctly URL-encoded.
  * Improved terminal session startup reliability, with automatic fallback to pipe-based execution when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->