### PR TITLE
fix(cli): raw-wrapper DM injection submits, and codex assistant messages emit once

### DIFF
--- a/sdk/typescript/src/cli/daemon/providers.ts
+++ b/sdk/typescript/src/cli/daemon/providers.ts
@@ -4,7 +4,7 @@
  * The daemon runs a delegated task by spawning the requested coding-agent CLI
  * **once**, non-interactively, with the instruction as the prompt, then folds
  * the CLI's streaming output through the shared semantic-event mappers
- * (`harnessEventsFromLine`) — the same parser the interactive wrapper uses — to
+ * (`createHarnessLineMapper`) — the same parser the interactive wrapper uses — to
  * derive status updates and the final agent message. This is the headless
  * complement to `harness-wrapper.ts`: that module wraps a human-driven PTY
  * session and tails its transcript files; this one drives a one-shot run and
@@ -20,7 +20,7 @@ import { accessSync, constants } from "node:fs";
 import { delimiter, join } from "node:path";
 
 import {
-  harnessEventsFromLine,
+  createHarnessLineMapper,
   type HarnessSemanticEvent,
 } from "../harness-events.js";
 import type { HarnessProvider } from "../../types/harness.js";
@@ -257,6 +257,9 @@ function runProviderAttempt(options: RunTaskOptions): Promise<RunTaskResult> {
   const child = spawn(bin, args, { cwd: options.cwd, env: options.env });
 
   return new Promise<RunTaskResult>((resolvePromise, reject) => {
+    // Per-run stateful mapper: dedupes codex's double-recorded assistant
+    // message so `messages` collects each reply exactly once.
+    const mapEventsFromLine = createHarnessLineMapper(options.provider);
     const messages: Array<string> = [];
     let claudeResult: string | undefined;
     let events = 0;
@@ -311,7 +314,7 @@ function runProviderAttempt(options: RunTaskOptions): Promise<RunTaskResult> {
           claudeResult = result;
         }
       }
-      for (const event of harnessEventsFromLine(options.provider, raw, line)) {
+      for (const event of mapEventsFromLine(raw, line)) {
         events += 1;
         options.onEvent?.(event);
         if (event.event.kind === "agent_message") {

--- a/sdk/typescript/src/cli/harness-events.ts
+++ b/sdk/typescript/src/cli/harness-events.ts
@@ -61,6 +61,44 @@ export function harnessEventsFromLine(
   return mapper ? mapper(raw, line) : [];
 }
 
+// Codex records every assistant message twice, on adjacent lines with the same
+// timestamp: an `event_msg:agent_message` and a `response_item:message`. Both
+// shapes stay mapped above (neither is guaranteed present across codex
+// versions/modes — the v1 mapper and `codex exec --json` streams have seen
+// each alone), so the per-stream mapper drops the repeat instead: an
+// agent_message whose text equals the previous one within this window is the
+// same message re-recorded, not a new turn.
+const CODEX_DUPLICATE_WINDOW_MS = 2000;
+
+/** Stateful per-stream mapper. Wraps `harnessEventsFromLine` and, for codex,
+ *  dedupes the double-recorded assistant message so downstream consumers (the
+ *  wrapper tailer and the daemon provider runner) see each message exactly
+ *  once. Create one per tailed session / child stream — the dedupe state must
+ *  not leak across streams. */
+export function createHarnessLineMapper(
+  provider: HarnessProvider,
+): HarnessLineMapper {
+  if (provider !== "codex") {
+    return (raw, line) => harnessEventsFromLine(provider, raw, line);
+  }
+  let lastText: string | undefined;
+  let lastAtMs = Number.NEGATIVE_INFINITY;
+  return (raw, line) =>
+    harnessEventsFromLine(provider, raw, line).filter((semantic) => {
+      if (semantic.event.kind !== "agent_message") {
+        return true;
+      }
+      const text = semantic.event.payload.text;
+      const atMs = semantic.timestamp.getTime();
+      const duplicate =
+        text === lastText &&
+        Math.abs(atMs - lastAtMs) <= CODEX_DUPLICATE_WINDOW_MS;
+      lastText = text;
+      lastAtMs = atMs;
+      return !duplicate;
+    });
+}
+
 // ── Claude ───────────────────────────────────────────────────────────────────
 
 export function claudeEventsFromLine(

--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -35,8 +35,11 @@ import {
   type StatusPayload,
 } from "../types/harness.js";
 import { bridgeLog } from "./bridge-debug.js";
-import { harnessEventsFromLine } from "./harness-events.js";
-import type { HarnessSemanticEvent } from "./harness-events.js";
+import { createHarnessLineMapper } from "./harness-events.js";
+import type {
+  HarnessLineMapper,
+  HarnessSemanticEvent,
+} from "./harness-events.js";
 import {
   buildEventEnvelopeV2,
   type EnvelopeContext,
@@ -669,13 +672,18 @@ export class HarnessSessionTailer {
   private status: SessionStatusState = initialStatus();
   private v2Seq = 0;
   private lastHeartbeatMs = 0;
+  // Stateful per-stream mapper: dedupes codex's double-recorded assistant
+  // message (event_msg + response_item for the same turn).
+  private readonly mapEventsFromLine: HarnessLineMapper;
 
   public constructor(
     private readonly config: HarnessWrapperConfig,
     private readonly cwd: string,
     private readonly dryRunOutput: Writable,
     private readonly publisher: SessionEnvelopePublisher,
-  ) {}
+  ) {
+    this.mapEventsFromLine = createHarnessLineMapper(config.provider);
+  }
 
   public start(startedAt: Date): void {
     this.startedAt = startedAt;
@@ -764,11 +772,7 @@ export class HarnessSessionTailer {
           this.write(message);
         }
         if (this.config.emitV2) {
-          for (const event of harnessEventsFromLine(
-            this.config.provider,
-            raw,
-            line,
-          )) {
+          for (const event of this.mapEventsFromLine(raw, line)) {
             this.writeV2(event);
           }
         }

--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -1261,10 +1261,18 @@ const RESET_SENTINEL = "\x01tp-rehandshake\x01";
  * and the SDK primitives `publishKeys` (be messageable) + `readMessages` (decrypt).
  */
 export class InboundMessageReceiver {
+  // Debounce between typing the body and sending the distinct Enter, mirroring
+  // the interactive TUI (tui.ts injectOne) so the agent TUI doesn't swallow the
+  // carriage return as part of a bracketed paste.
+  private static readonly INJECT_ENTER_DELAY_MS = 150;
+
   private sink: ((text: string) => void) | undefined;
   private timer: ReturnType<typeof setInterval> | undefined;
   private draining = false;
   private ownerAddress: string | undefined;
+  // Serialize injected turns so a batched poll never interleaves them: each
+  // body → Enter pair completes before the next body types.
+  private injectionQueue: Promise<void> = Promise.resolve();
 
   public constructor(
     private readonly config: HarnessWrapperConfig,
@@ -1345,6 +1353,8 @@ export class InboundMessageReceiver {
     } catch {
       // best-effort final drain
     }
+    // Let any queued body → Enter injections finish before we tear down.
+    await this.injectionQueue;
   }
 
   /** Accept the owner contact so inbound DMs are not 403'd by the relay. */
@@ -1389,14 +1399,18 @@ export class InboundMessageReceiver {
       let dropped = 0;
       for (const message of messages) {
         const text = this.filterAndParse(message);
-        if (text !== undefined && this.sink) {
+        // `this.sink` is guaranteed defined here — poll() returns early when it
+        // is not. injectOne re-guards it before each write regardless.
+        if (text !== undefined) {
           injected += 1;
           // Record before injecting so the tailer's echoed-back `user` line
           // (the agent logs the injected prompt as its own user turn) is dropped
           // by the publisher instead of bouncing to the owner.
           this.publisher.markInjected(text);
-          // "\r" (carriage return) submits the prompt to the agent TUI.
-          this.sink(`${text}\r`);
+          // Type the body now, then submit with a DISTINCT carriage return after
+          // a short debounce (see injectOne). Enqueued so batched inbound turns
+          // stay serialized (body → Enter → next body) and never interleave.
+          this.enqueueInjection(text);
         } else {
           dropped += 1;
         }
@@ -1415,6 +1429,29 @@ export class InboundMessageReceiver {
       });
     } finally {
       this.draining = false;
+    }
+  }
+
+  /** Chain an injection onto the serial queue so batched inbound turns keep
+   *  their boundaries (body → Enter → next body), never interleaving. */
+  private enqueueInjection(text: string): void {
+    this.injectionQueue = this.injectionQueue
+      .then(() => this.injectOne(text))
+      .catch(() => {});
+  }
+
+  /** Type one inbound turn, then send the carriage return as a SEPARATE write
+   *  after a short debounce. Writing "text\r" in one chunk makes the agent TUI
+   *  (codex/claude) treat the burst as a bracketed paste and swallow the CR, so
+   *  the prompt parks unsubmitted; a distinct CR after the paste settles submits
+   *  it. Mirrors the interactive TUI's injectOne. */
+  private async injectOne(text: string): Promise<void> {
+    if (this.sink) {
+      this.sink(text);
+    }
+    await delay(InboundMessageReceiver.INJECT_ENTER_DELAY_MS);
+    if (this.sink) {
+      this.sink("\r");
     }
   }
 
@@ -1462,6 +1499,12 @@ export class InboundMessageReceiver {
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
 }
 
 class TerminalEnvelopeWriter {

--- a/sdk/typescript/src/node/index.ts
+++ b/sdk/typescript/src/node/index.ts
@@ -25,6 +25,7 @@ export { FileSessionStore } from "./file-session-store.js";
 export {
   claudeEventsFromLine,
   codexEventsFromLine,
+  createHarnessLineMapper,
   harnessEventsFromLine,
   normalizeToolKind,
   opencodeEventsFromLine,

--- a/sdk/typescript/tests/codex-cli.test.ts
+++ b/sdk/typescript/tests/codex-cli.test.ts
@@ -561,7 +561,12 @@ describe("tinyplace codex", () => {
       relay: HarnessRelay;
       ownerAgentId: string;
       send: (wrapperAddress: string) => Promise<void>;
-    }): Promise<{ code: number; stdin: string; wrapperAddress: string }> {
+    }): Promise<{
+      code: number;
+      stdin: string;
+      stdinChunks: Array<string>;
+      wrapperAddress: string;
+    }> {
       const tempDir = await mkdtemp(join(tmpdir(), "tinyplace-inbound-"));
       const wrapperSigner = await LocalSigner.fromSeed(new Uint8Array(32).fill(33));
       const stdinChunks: Array<string> = [];
@@ -609,7 +614,12 @@ describe("tinyplace codex", () => {
           },
         },
       );
-      return { code: result.code, stdin: stdinChunks.join(""), wrapperAddress: wrapperSigner.agentId };
+      return {
+        code: result.code,
+        stdin: stdinChunks.join(""),
+        stdinChunks,
+        wrapperAddress: wrapperSigner.agentId,
+      };
     }
 
     it("publishes its Signal keys so the owner can DM it (was un-messageable before)", async () => {
@@ -627,11 +637,11 @@ describe("tinyplace codex", () => {
       expect(relay.keysPublished).toContain(wrapperAddress);
     });
 
-    it("injects an owner DM into the codex process as `<text>\\r`", async () => {
+    it("injects an owner DM as the body then a DISTINCT carriage return", async () => {
       const relay = makeRelay({ autoAcceptContacts: true });
       const owner = await makeClient(44, relay);
       await publishKeys(owner.client, owner.signer);
-      const { code, stdin } = await runWrapperReceiving({
+      const { code, stdin, stdinChunks } = await runWrapperReceiving({
         relay,
         ownerAgentId: owner.signer.agentId,
         send: async (wrapperAddress) => {
@@ -639,6 +649,14 @@ describe("tinyplace codex", () => {
         },
       });
       expect(code).toBe(0);
+      // The body and the submitting CR must be SEPARATE writes: writing
+      // "text\r" in one chunk makes the agent TUI swallow the CR as a paste and
+      // park the prompt unsubmitted.
+      expect(stdinChunks).toContain("hello from openhuman");
+      expect(stdinChunks).toContain("\r");
+      // The body is not written with a trailing CR fused onto it.
+      expect(stdinChunks).not.toContain("hello from openhuman\r");
+      // The CR still lands after the body so the joined stream submits.
       expect(stdin).toContain("hello from openhuman\r");
     });
 

--- a/sdk/typescript/tests/harness-events.test.ts
+++ b/sdk/typescript/tests/harness-events.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   claudeEventsFromLine,
   codexEventsFromLine,
+  createHarnessLineMapper,
   harnessEventsFromLine,
   normalizeToolKind,
   toolDisplay,
@@ -341,6 +342,78 @@ describe("codexEventsFromLine", () => {
       5,
     );
     expect(events[0].event.payload).toMatchObject({ ok: false, is_error: true });
+  });
+});
+
+describe("createHarnessLineMapper (codex duplicate assistant records)", () => {
+  // Codex v0.144 rollout JSONL records every assistant message twice, on
+  // adjacent lines with the same timestamp — these mirror the real shapes.
+  const eventMsgLine = (text: string, timestamp: string): string =>
+    claudeLine({
+      type: "event_msg",
+      timestamp,
+      payload: { type: "agent_message", message: text, phase: "final_answer" },
+    });
+  const responseItemLine = (text: string, timestamp: string): string =>
+    claudeLine({
+      type: "response_item",
+      timestamp,
+      payload: {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text }],
+      },
+    });
+
+  it("emits a single agent_message for the event_msg + response_item pair", () => {
+    const map = createHarnessLineMapper("codex");
+    const at = "2026-07-12T10:00:00.000Z";
+    const events = [
+      ...map(eventMsgLine("all done", at), 1),
+      ...map(responseItemLine("all done", at), 2),
+    ];
+    expect(kinds(events)).toStrictEqual(["agent_message"]);
+    expect(events[0].event.payload).toMatchObject({ text: "all done" });
+  });
+
+  it("keeps distinct messages and a genuine later repeat", () => {
+    const map = createHarnessLineMapper("codex");
+    const events = [
+      ...map(eventMsgLine("first", "2026-07-12T10:00:00.000Z"), 1),
+      ...map(responseItemLine("first", "2026-07-12T10:00:00.000Z"), 2),
+      ...map(eventMsgLine("second", "2026-07-12T10:00:01.000Z"), 3),
+      ...map(responseItemLine("second", "2026-07-12T10:00:01.000Z"), 4),
+      // Same text again much later — a real new turn, not the double record.
+      ...map(eventMsgLine("first", "2026-07-12T10:05:00.000Z"), 5),
+    ];
+    const texts = events.map(
+      (event) => (event.event.payload as { text: string }).text,
+    );
+    expect(kinds(events)).toStrictEqual([
+      "agent_message",
+      "agent_message",
+      "agent_message",
+    ]);
+    expect(texts).toStrictEqual(["first", "second", "first"]);
+  });
+
+  it("still emits when only one record shape is present", () => {
+    // Neither shape is guaranteed across codex versions/modes, so a stream
+    // carrying only response_item (or only event_msg) must not lose messages.
+    const map = createHarnessLineMapper("codex");
+    const events = map(
+      responseItemLine("lone reply", "2026-07-12T10:00:00.000Z"),
+      1,
+    );
+    expect(kinds(events)).toStrictEqual(["agent_message"]);
+  });
+
+  it("does not dedupe across separate mapper instances (per-stream state)", () => {
+    const at = "2026-07-12T10:00:00.000Z";
+    const first = createHarnessLineMapper("codex")(eventMsgLine("hi", at), 1);
+    const second = createHarnessLineMapper("codex")(eventMsgLine("hi", at), 1);
+    expect(kinds(first)).toStrictEqual(["agent_message"]);
+    expect(kinds(second)).toStrictEqual(["agent_message"]);
   });
 });
 


### PR DESCRIPTION
Two wrapper bugs found while wiring an external orchestrator (medulla) as the OpenHuman-protocol owner of an unmodified `tinyplace codex --raw` session, both verified live against a real codex v0.144 session on staging.

## 1. Raw-mode DM injection never submits (codex)

The headless `InboundMessageReceiver` injected an inbound DM as a single chunk `text\r`. Codex's TUI treats the burst as a bracketed paste and swallows the trailing CR — the prompt sits in the composer unsubmitted forever. The interactive TUI already solved this in `injectOne`; the `--raw` path never got the fix.

Now the body and the CR are two separate writes ~150ms apart, serialized on a per-receiver queue so batched polls can't interleave a second body between the first body and its Enter. `markInjected` echo-suppression semantics are unchanged; the TUI's overridden sink is untouched.

## 2. Codex assistant messages emitted twice

Codex v0.144's rollout JSONL records every assistant message on two adjacent lines (`event_msg`/`agent_message` + `response_item`/assistant message). `codexEventsFromLine` mapped both, so every consumer of the v2 event stream — the wrapper publisher and the daemon provider runner — saw each reply doubled.

Since "both shapes always present" can't be guaranteed across codex versions/modes (the daemon consumes `codex exec --json` stdout, a different stream), neither shape is dropped. Instead a new `createHarnessLineMapper(provider)` wraps the pure mapper with per-stream state and filters an `agent_message` whose text repeats the previous one within a 2s window. Wired into `HarnessSessionTailer` and `daemon/providers.ts`.

## Validation

- `pnpm lint` (tsc --noEmit) clean
- `pnpm test`: 524 passed / 98 skipped (5 new tests: distinct-write injection; the two real v0.144 record shapes deduping to one message; single-shape streams and genuine repeats still emitting; no state leakage across mapper instances)
- `pnpm build` clean
- Live: medulla owner → staging → `tinyplace codex --raw` → codex created the requested file and the reply folded back exactly once

https://claude.ai/code/session_01XALwJxgkeQYi9GkerXiib6