### PR TITLE
fix: align unified plugin with SDK v2

### DIFF
--- a/sdk/plugin-tinyplace/package.json
+++ b/sdk/plugin-tinyplace/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "@tinyhumansai/tinyplace": "^1.0.1",
+    "@tinyhumansai/tinyplace": "^2.0.4",
     "zod": "^3.25.0"
   }
 }


### PR DESCRIPTION
## Summary

- require the v2 Tinyplace SDK from the unified harness plugin
- prevent npm from nesting SDK v1 alongside the v2 CLI
- restore base58 mailbox and Signal-session interoperability for external v2 clients

## Validation

- `npm install` resolves `@tinyhumansai/tinyplace` to `2.0.4`
- `npm test` passes all unified plugin tests
- live staging diagnosis: SDK v1 keyed the peer session by base64 while OpenHuman SDK v2 sent to the base58 crypto id, producing `No session for <base58 peer>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Tinyplace plugin dependency to version 2.0.4 for improved compatibility and access to the latest package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->