### PR TITLE
feat(sdk): machine session bus — one wallet per machine, v2 always on

### DIFF
--- a/sdk/typescript/src/cli/harness-control.ts
+++ b/sdk/typescript/src/cli/harness-control.ts
@@ -1,0 +1,77 @@
+// Owner → machine control frames for the harness session bus.
+//
+// A machine runs ONE tiny.place wallet shared by every wrapped harness session
+// on it (see machine-bus.ts). Plaintext DMs keep their historical meaning —
+// they are injected into the machine's primary session — while a control frame
+// lets the owner address a SPECIFIC session by id. The session id is the one
+// the machine advertises on its envelope scope: the harness's own session id
+// (`scope.harness_session_id`, e.g. the codex rollout id) or the wrapper
+// session id (`scope.wrapper_session_id`) — a frame may name either.
+
+export const HARNESS_CONTROL_VERSION = "tinyplace.harness.control.v1";
+
+export interface HarnessControlFrame {
+  control_version: typeof HARNESS_CONTROL_VERSION;
+  /** `input` types the text into the addressed session's agent as a prompt. */
+  kind: "input";
+  /** Target session (wrapper or harness session id). Absent → primary session. */
+  session_id?: string;
+  text: string;
+}
+
+export interface EncodeHarnessControlOptions {
+  sessionId?: string;
+}
+
+/** Serialize an `input` control frame for the encrypted DM body. */
+export function encodeHarnessControlFrame(
+  text: string,
+  options: EncodeHarnessControlOptions = {},
+): string {
+  const frame: HarnessControlFrame = {
+    control_version: HARNESS_CONTROL_VERSION,
+    kind: "input",
+    ...(options.sessionId ? { session_id: options.sessionId } : {}),
+    text,
+  };
+  return JSON.stringify(frame);
+}
+
+/**
+ * Decode a DM body into a {@link HarnessControlFrame}, or undefined when the
+ * body is not one of ours (plaintext, a session envelope, another protocol, or
+ * a malformed frame). Never throws — inbound Signal DMs are untrusted.
+ */
+export function parseHarnessControlFrame(
+  body: string,
+): HarnessControlFrame | undefined {
+  if (!body.trimStart().startsWith("{")) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    return undefined;
+  }
+  const record = parsed as Record<string, unknown>;
+  if (record.control_version !== HARNESS_CONTROL_VERSION) {
+    return undefined;
+  }
+  if (record.kind !== "input" || typeof record.text !== "string") {
+    return undefined;
+  }
+  const sessionId =
+    typeof record.session_id === "string" && record.session_id.length > 0
+      ? record.session_id
+      : undefined;
+  return {
+    control_version: HARNESS_CONTROL_VERSION,
+    kind: "input",
+    ...(sessionId ? { session_id: sessionId } : {}),
+    text: record.text,
+  };
+}

--- a/sdk/typescript/src/cli/harness-wrapper.ts
+++ b/sdk/typescript/src/cli/harness-wrapper.ts
@@ -51,6 +51,8 @@ import {
   type SessionStatusState,
 } from "./harness-status.js";
 import { makeContext } from "./context.js";
+import { parseHarnessControlFrame } from "./harness-control.js";
+import { createMachineBus, type MachineBus } from "./machine-bus.js";
 import { makePathLookup } from "./daemon/providers.js";
 import {
   OpenCodeEventSource,
@@ -83,9 +85,8 @@ export interface HarnessWrapperConfig {
   captureSession: boolean;
   dmRecipient?: string;
   dryRun: boolean;
-  // Opt-in: also emit the v2 typed-event stream (tool_call/tool_result/status/
-  // thinking) alongside v1. Default off so current v1 consumers are untouched
-  // until the OpenHuman receiver understands v2.
+  // The v2 typed-event stream (tool_call/tool_result/status/thinking) is
+  // always emitted alongside v1; the field remains so tests can silence it.
   emitV2: boolean;
   outDir: string;
   provider: HarnessProvider;
@@ -234,10 +235,29 @@ export async function runHarnessCommand(
     stderr: options.stderr ?? process.stderr,
   };
   const writer = new TerminalEnvelopeWriter(config, cwd, stdio.stderr);
-  const publisher = new SessionEnvelopePublisher(config, options, stdio.stderr);
+  // The machine session bus shares this machine's ONE wallet across every
+  // concurrent wrapper session: a cross-process lock serializes Signal I/O and
+  // a spool routes inbound DMs to their addressed session. Only engaged when
+  // the wrapper actually touches the wallet (an owner is configured).
+  const bus =
+    !config.dryRun && Boolean(config.dmRecipient ?? config.receiveFrom)
+      ? createMachineBus({
+          env,
+          wrapperSessionId: config.wrapperSessionId,
+          provider,
+          cwd,
+        })
+      : undefined;
+  const publisher = new SessionEnvelopePublisher(
+    config,
+    options,
+    stdio.stderr,
+    bus,
+  );
   const receiver = config.receiveEnabled
-    ? new InboundMessageReceiver(config, publisher, stdio.stderr)
+    ? new InboundMessageReceiver(config, publisher, stdio.stderr, bus)
     : undefined;
+  bus?.registerSession();
 
   const usePty = config.usePty && options.spawn === undefined;
   // opencode has no per-session transcript files — it is observed over its
@@ -315,6 +335,9 @@ export async function runHarnessCommand(
 
   let exitCode = 1;
   let dmFailures = 0;
+  const busHeartbeat = bus
+    ? setInterval(() => bus.heartbeatSession(), 10_000)
+    : undefined;
   try {
     exitCode = usePty
       ? await runPtyAgent(launch, config, cwd, env, writer, stdio, onInputSink)
@@ -329,6 +352,10 @@ export async function runHarnessCommand(
           onInputSink,
         );
   } finally {
+    if (busHeartbeat) {
+      clearInterval(busHeartbeat);
+    }
+    bus?.endSession();
     // Teardown order: stop the session observer (flushes the publisher) → stop
     // inbound → kill the opencode server. In a `finally` so a spawn failure
     // still tears the server down instead of leaking a `serve` process.
@@ -539,11 +566,9 @@ export function parseHarnessWrapperArgs(
     captureSession: true,
     ...(owner ? { dmRecipient: owner } : {}),
     dryRun: false,
-    emitV2:
-      firstEnv(env, [
-        `TINYPLACE_${provider.toUpperCase()}_V2`,
-        "TINYPLACE_HARNESS_V2",
-      ]) === "1",
+    // v2 is the protocol: the typed-event stream is always emitted (alongside
+    // v1 for older consumers). The former TINYPLACE_*_V2 opt-in is retired.
+    emitV2: true,
     outDir,
     provider,
     statusHeartbeatMs: numberEnvOr(
@@ -1239,7 +1264,13 @@ export class SessionEnvelopePublisher {
     private readonly config: HarnessWrapperConfig,
     private readonly options: TinyPlaceCliOptions,
     private readonly stderr: Writable,
+    private readonly bus?: MachineBus,
   ) {}
+
+  /** Serialize a wallet-touching call across this machine's processes. */
+  private withWalletLock<T>(fn: () => Promise<T>): Promise<T> {
+    return this.bus ? this.bus.withLock(fn) : fn();
+  }
 
   /** Record an owner→agent injection so its echoed-back `user` line is dropped. */
   public markInjected(text: string): void {
@@ -1290,6 +1321,11 @@ export class SessionEnvelopePublisher {
       bridgeLog("publish.echoSkip", { id });
       return;
     }
+    // Record the harness's own session id on the machine registry as soon as
+    // an envelope reveals it — owners address control frames by this id.
+    this.bus?.heartbeatSession({
+      harnessSessionId: envelope.scope.harness_session_id,
+    });
     bridgeLog("publish.enqueue", {
       id,
       role: envelopeRole(envelope),
@@ -1330,12 +1366,10 @@ export class SessionEnvelopePublisher {
       throw new Error("DM forwarding requires a tiny.place signer");
     }
     const recipient = await this.ensureContact(ctx);
+    const signer = ctx.signer;
     try {
-      await sendMessage(
-        ctx.client,
-        ctx.signer,
-        recipient,
-        JSON.stringify(envelope),
+      await this.withWalletLock(() =>
+        sendMessage(ctx.client, signer, recipient, JSON.stringify(envelope)),
       );
     } catch (error) {
       if (!isNotAContactError(error)) {
@@ -1343,11 +1377,13 @@ export class SessionEnvelopePublisher {
       }
       this.contactPromise = undefined;
       const refreshedRecipient = await this.ensureContact(ctx);
-      await sendMessage(
-        ctx.client,
-        ctx.signer,
-        refreshedRecipient,
-        JSON.stringify(envelope),
+      await this.withWalletLock(() =>
+        sendMessage(
+          ctx.client,
+          signer,
+          refreshedRecipient,
+          JSON.stringify(envelope),
+        ),
       );
     }
   }
@@ -1496,7 +1532,13 @@ export class InboundMessageReceiver {
     private readonly config: HarnessWrapperConfig,
     private readonly publisher: SessionEnvelopePublisher,
     private readonly stderr: Writable,
+    private readonly bus?: MachineBus,
   ) {}
+
+  /** Serialize a wallet-touching call across this machine's processes. */
+  private withWalletLock<T>(fn: () => Promise<T>): Promise<T> {
+    return this.bus ? this.bus.withLock(fn) : fn();
+  }
 
   /** Register the agent-input writer once the child is spawned. Injection is a
    *  no-op until this is set, so the poll loop can start before the child. */
@@ -1517,8 +1559,11 @@ export class InboundMessageReceiver {
     }
     // Publish our Signal key bundle so the owner can open a session to us — the
     // wrapper never did this before, which is why it was un-messageable.
+    // Under the machine bus this is wallet-locked: prekey publication mutates
+    // the shared Signal store, and N sessions start concurrently.
+    const signer = ctx.signer;
     try {
-      await publishKeys(ctx.client, ctx.signer);
+      await this.withWalletLock(() => publishKeys(ctx.client, signer));
     } catch (error) {
       this.stderr.write(
         `tinyplace ${this.config.provider}: failed to publish Signal keys: ${describeError(error)}\n`,
@@ -1610,30 +1655,51 @@ export class InboundMessageReceiver {
       if (!ctx.signer) {
         return;
       }
-      const messages = await readMessages(ctx.client, ctx.signer, {
-        limit: 50,
-      });
+      const signer = ctx.signer;
+      this.bus?.heartbeatSession();
+      const messages = await this.withWalletLock(() =>
+        readMessages(ctx.client, signer, { limit: 50 }),
+      );
       let injected = 0;
       let dropped = 0;
       for (const message of messages) {
         const text = this.filterAndParse(message);
-        // `this.sink` is guaranteed defined here — poll() returns early when it
-        // is not. injectOne re-guards it before each write regardless.
-        if (text !== undefined) {
-          injected += 1;
-          // Record before injecting so the tailer's echoed-back `user` line
-          // (the agent logs the injected prompt as its own user turn) is dropped
-          // by the publisher instead of bouncing to the owner.
-          this.publisher.markInjected(text);
-          // Type the body now, then submit with a DISTINCT carriage return after
-          // a short debounce (see injectOne). Enqueued so batched inbound turns
-          // stay serialized (body → Enter → next body) and never interleave.
-          this.enqueueInjection(text);
-        } else {
+        if (text === undefined) {
           dropped += 1;
+          continue;
+        }
+        if (this.bus) {
+          // Machine bus: the inbox is shared by every session on this wallet,
+          // so a message we happened to read may be addressed to ANOTHER
+          // session — spool it; our own spool is drained below.
+          this.bus.routeInbound(message.from, text);
+          continue;
+        }
+        // No bus (single session, no shared wallet): inject directly. A
+        // control frame still resolves to its text so an owner can use one
+        // frame shape everywhere.
+        const frame = parseHarnessControlFrame(text);
+        const body = frame ? frame.text : text;
+        injected += 1;
+        // Record before injecting so the tailer's echoed-back `user` line
+        // (the agent logs the injected prompt as its own user turn) is dropped
+        // by the publisher instead of bouncing to the owner.
+        this.publisher.markInjected(body);
+        // Type the body now, then submit with a DISTINCT carriage return after
+        // a short debounce (see injectOne). Enqueued so batched inbound turns
+        // stay serialized (body → Enter → next body) and never interleave.
+        this.enqueueInjection(body);
+      }
+      if (this.bus) {
+        // Drain what other pollers (or this one) spooled for this session —
+        // plus the default spool when this session is the machine's primary.
+        for (const item of this.bus.consumeInbound()) {
+          injected += 1;
+          this.publisher.markInjected(item.text);
+          this.enqueueInjection(item.text);
         }
       }
-      if (messages.length > 0) {
+      if (messages.length > 0 || injected > 0) {
         bridgeLog("receiver.poll", {
           read: messages.length,
           injected,

--- a/sdk/typescript/src/cli/machine-bus.ts
+++ b/sdk/typescript/src/cli/machine-bus.ts
@@ -1,0 +1,410 @@
+// Machine-level session bus: one tiny.place wallet shared by every wrapped
+// harness session on a machine.
+//
+// The wallet's Signal state cannot be used concurrently from two processes —
+// the FileSessionStore is a read-modify-write of one JSON file and a double
+// ratchet, and the relay inbox read is destructive — so N interactive wrapper
+// terminals sharing one `TINYPLACE_CONFIG` need machine-local coordination.
+// This module provides it with nothing but the filesystem (no daemon, no
+// socket), anchored beside the wallet config:
+//
+//   <config-dir>/harness-bus/
+//     wallet.lock                cross-process mutex around every Signal op
+//     sessions/<wsid>.json       registry: one entry per wrapper session,
+//                                live/inactive derived from PID liveness
+//     inbox/<wsid>/*.json        spool: inbound DMs routed to their session
+//     inbox/_default/*.json      untargeted inbound (plaintext DMs)
+//
+// Every wrapper process registers its session, wraps sends/reads in
+// `withLock`, and routes each inbound DM it happens to read: a control frame
+// naming another session lands in that session's spool; plaintext lands in the
+// default spool, which only the PRIMARY session (earliest-started live one)
+// consumes — preserving the single-terminal behavior exactly.
+
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+
+import { configPathFor } from "./context.js";
+import { parseHarnessControlFrame } from "./harness-control.js";
+
+/** One registered wrapper session on this machine's wallet. */
+export interface BusSessionInfo {
+  wrapperSessionId: string;
+  /** The harness's own session id (codex rollout id, …) once discovered. */
+  harnessSessionId?: string;
+  provider: string;
+  pid: number;
+  cwd: string;
+  startedAt: string;
+  lastSeenAt: string;
+  /** Marked on clean shutdown; a dead PID also reads as not live. */
+  ended?: boolean;
+  /** Computed on read: not ended and the recorded PID is a running process. */
+  live: boolean;
+}
+
+/** One inbound DM spooled for a session to inject. */
+export interface SpooledInbound {
+  from: string;
+  text: string;
+  ts: string;
+  /** The session id the sender addressed, when it came from a control frame. */
+  sessionId?: string;
+}
+
+export interface MachineBus {
+  readonly dir: string;
+  /** Serialize a wallet-touching operation (send / inbox read / key publish)
+   *  across every process on this machine. Reentrant use is NOT supported. */
+  withLock<T>(fn: () => Promise<T>): Promise<T>;
+  /** Upsert this process's session registry entry. */
+  registerSession(): void;
+  /** Refresh liveness; optionally record the discovered harness session id. */
+  heartbeatSession(patch?: { harnessSessionId?: string }): void;
+  /** Mark this session ended (kept on disk so it lists as inactive). */
+  endSession(): void;
+  /** All registry entries, newest-started first, with liveness computed. */
+  listSessions(): Array<BusSessionInfo>;
+  /** Route one inbound DM into the spool (by control-frame session id, else
+   *  the default spool). */
+  routeInbound(from: string, text: string): void;
+  /** Drain this session's spool — plus the default spool when this session is
+   *  the machine's primary — oldest first. */
+  consumeInbound(): Array<SpooledInbound>;
+}
+
+export interface MachineBusOptions {
+  env?: Record<string, string | undefined>;
+  wrapperSessionId: string;
+  provider: string;
+  cwd: string;
+  /** Override the bus directory (tests). Defaults beside the wallet config. */
+  busDir?: string;
+  /** Lock acquisition budget in ms before an operation fails (default 15s). */
+  lockTimeoutMs?: number;
+}
+
+const LOCK_RETRY_MS = 30;
+/** Registry entries older than this (and not live) are pruned on read. */
+const REGISTRY_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+export function createMachineBus(options: MachineBusOptions): MachineBus {
+  const env = options.env ?? process.env;
+  const dir =
+    options.busDir ?? join(dirname(configPathFor(env)), "harness-bus");
+  const lockTimeoutMs = options.lockTimeoutMs ?? 15_000;
+  const lockPath = join(dir, "wallet.lock");
+  const sessionsDir = join(dir, "sessions");
+  const inboxDir = join(dir, "inbox");
+  const ownSpoolDir = join(inboxDir, sanitize(options.wrapperSessionId));
+  const defaultSpoolDir = join(inboxDir, "_default");
+  const sessionPath = join(
+    sessionsDir,
+    `${sanitize(options.wrapperSessionId)}.json`,
+  );
+  let lastRecordedHarnessSessionId: string | undefined;
+  let lastEntryWriteMs = 0;
+  /** Plain heartbeats are throttled — publish() fires one per envelope. */
+  const HEARTBEAT_MIN_INTERVAL_MS = 5_000;
+
+  function ensureDirs(): void {
+    mkdirSync(sessionsDir, { recursive: true });
+    mkdirSync(ownSpoolDir, { recursive: true });
+    mkdirSync(defaultSpoolDir, { recursive: true });
+  }
+
+  function readOwnEntry(): Partial<BusSessionInfo> {
+    try {
+      return JSON.parse(readFileSync(sessionPath, "utf8")) as BusSessionInfo;
+    } catch {
+      return {};
+    }
+  }
+
+  function writeOwnEntry(patch: Partial<BusSessionInfo>): void {
+    ensureDirs();
+    const existing = readOwnEntry();
+    const now = new Date().toISOString();
+    const entry = {
+      wrapperSessionId: options.wrapperSessionId,
+      provider: options.provider,
+      pid: process.pid,
+      cwd: options.cwd,
+      startedAt: existing.startedAt ?? now,
+      ...(existing.harnessSessionId
+        ? { harnessSessionId: existing.harnessSessionId }
+        : {}),
+      ...(existing.ended ? { ended: existing.ended } : {}),
+      ...patch,
+      lastSeenAt: now,
+    };
+    atomicWrite(sessionPath, `${JSON.stringify(entry, undefined, 2)}\n`);
+    lastEntryWriteMs = Date.now();
+  }
+
+  function listSessions(): Array<BusSessionInfo> {
+    let files: Array<string>;
+    try {
+      files = readdirSync(sessionsDir).filter((name) =>
+        name.endsWith(".json"),
+      );
+    } catch {
+      return [];
+    }
+    const now = Date.now();
+    const sessions: Array<BusSessionInfo> = [];
+    for (const name of files) {
+      const path = join(sessionsDir, name);
+      let entry: BusSessionInfo;
+      try {
+        entry = JSON.parse(readFileSync(path, "utf8")) as BusSessionInfo;
+      } catch {
+        continue;
+      }
+      const live = !entry.ended && pidAlive(entry.pid);
+      const lastSeen = Date.parse(entry.lastSeenAt);
+      if (
+        !live &&
+        Number.isFinite(lastSeen) &&
+        now - lastSeen > REGISTRY_RETENTION_MS
+      ) {
+        // Stale inactive entry — prune it (and its spool) best-effort.
+        try {
+          unlinkSync(path);
+        } catch {
+          // already gone
+        }
+        continue;
+      }
+      sessions.push({ ...entry, live });
+    }
+    sessions.sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+    return sessions;
+  }
+
+  /** The machine's primary session: the earliest-started live one. */
+  function primarySessionId(): string | undefined {
+    const live = listSessions().filter((session) => session.live);
+    if (live.length === 0) {
+      return undefined;
+    }
+    live.sort((a, b) => a.startedAt.localeCompare(b.startedAt));
+    return live[0]?.wrapperSessionId;
+  }
+
+  function spoolDirFor(sessionId: string | undefined): string {
+    if (!sessionId) {
+      return defaultSpoolDir;
+    }
+    // Match by wrapper session id OR the harness's own session id.
+    const target = listSessions().find(
+      (session) =>
+        session.wrapperSessionId === sessionId ||
+        session.harnessSessionId === sessionId,
+    );
+    return target
+      ? join(inboxDir, sanitize(target.wrapperSessionId))
+      : defaultSpoolDir;
+  }
+
+  function drainSpool(spoolDir: string): Array<SpooledInbound> {
+    let files: Array<string>;
+    try {
+      files = readdirSync(spoolDir)
+        .filter((name) => name.endsWith(".json"))
+        .sort();
+    } catch {
+      return [];
+    }
+    const drained: Array<SpooledInbound> = [];
+    for (const name of files) {
+      const path = join(spoolDir, name);
+      let entry: SpooledInbound;
+      try {
+        entry = JSON.parse(readFileSync(path, "utf8")) as SpooledInbound;
+      } catch {
+        try {
+          unlinkSync(path);
+        } catch {
+          // already consumed by a racing process
+        }
+        continue;
+      }
+      try {
+        unlinkSync(path);
+      } catch {
+        continue; // another process consumed it first — skip, don't duplicate
+      }
+      drained.push(entry);
+    }
+    return drained;
+  }
+
+  return {
+    dir,
+
+    async withLock<T>(fn: () => Promise<T>): Promise<T> {
+      mkdirSync(dir, { recursive: true });
+      const deadline = Date.now() + lockTimeoutMs;
+      for (;;) {
+        if (tryLock(lockPath)) {
+          break;
+        }
+        if (isStaleLock(lockPath)) {
+          stealStaleLock(lockPath);
+          continue;
+        }
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `timed out waiting for the machine wallet lock at ${lockPath}`,
+          );
+        }
+        await delay(LOCK_RETRY_MS);
+      }
+      try {
+        return await fn();
+      } finally {
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // released by a stale-steal — nothing to do
+        }
+      }
+    },
+
+    registerSession(): void {
+      writeOwnEntry({});
+    },
+
+    heartbeatSession(patch): void {
+      if (
+        patch?.harnessSessionId &&
+        patch.harnessSessionId !== lastRecordedHarnessSessionId
+      ) {
+        lastRecordedHarnessSessionId = patch.harnessSessionId;
+        writeOwnEntry({ harnessSessionId: patch.harnessSessionId });
+        return;
+      }
+      if (Date.now() - lastEntryWriteMs < HEARTBEAT_MIN_INTERVAL_MS) {
+        return;
+      }
+      writeOwnEntry({});
+    },
+
+    endSession(): void {
+      writeOwnEntry({ ended: true });
+    },
+
+    listSessions,
+
+    routeInbound(from, text): void {
+      ensureDirs();
+      const frame = parseHarnessControlFrame(text);
+      const entry: SpooledInbound = {
+        from,
+        text: frame ? frame.text : text,
+        ts: new Date().toISOString(),
+        ...(frame?.session_id ? { sessionId: frame.session_id } : {}),
+      };
+      const spoolDir = spoolDirFor(frame?.session_id);
+      mkdirSync(spoolDir, { recursive: true });
+      const name = `${Date.now().toString().padStart(15, "0")}-${randomUUID().slice(0, 8)}.json`;
+      atomicWrite(join(spoolDir, name), JSON.stringify(entry));
+    },
+
+    consumeInbound(): Array<SpooledInbound> {
+      ensureDirs();
+      const own = drainSpool(ownSpoolDir);
+      const isPrimary = primarySessionId() === options.wrapperSessionId;
+      const shared = isPrimary ? drainSpool(defaultSpoolDir) : [];
+      return [...own, ...shared].sort((a, b) => a.ts.localeCompare(b.ts));
+    },
+  };
+}
+
+function atomicWrite(path: string, body: string): void {
+  const temporary = `${path}.tmp-${process.pid}-${randomUUID().slice(0, 8)}`;
+  writeFileSync(temporary, body, "utf8");
+  renameSync(temporary, path);
+}
+
+function tryLock(path: string): boolean {
+  let fd: number;
+  try {
+    fd = openSync(path, "wx"); // create-exclusive: at most one winner
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    throw error;
+  }
+  try {
+    writeSync(fd, JSON.stringify({ pid: process.pid, at: Date.now() }));
+  } finally {
+    closeSync(fd);
+  }
+  return true;
+}
+
+function isStaleLock(path: string): boolean {
+  let pid: unknown;
+  try {
+    pid = (JSON.parse(readFileSync(path, "utf8")) as { pid?: unknown }).pid;
+  } catch {
+    return true; // unreadable / vanished → reclaimable
+  }
+  if (typeof pid !== "number") {
+    return true;
+  }
+  return !pidAlive(pid);
+}
+
+/** Steal a stale lock atomically: rename-aside wins for exactly one contender. */
+function stealStaleLock(path: string): void {
+  const aside = `${path}.stale-${process.pid}`;
+  try {
+    renameSync(path, aside);
+  } catch {
+    return; // lost the steal race — the next tryLock decides
+  }
+  try {
+    unlinkSync(aside);
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+function pidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM = alive but not ours. Anything else (ESRCH = gone, EINVAL/ERANGE =
+    // impossible pid) reads as dead so a corrupt lock never wedges the wallet.
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function sanitize(sessionId: string): string {
+  return sessionId.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
+}

--- a/sdk/typescript/src/cli/tui.ts
+++ b/sdk/typescript/src/cli/tui.ts
@@ -27,6 +27,7 @@ import {
   SessionEnvelopePublisher,
   parseHarnessWrapperArgs,
 } from "./harness-wrapper.js";
+import { createMachineBus, type MachineBus } from "./machine-bus.js";
 import {
   OpenCodeEventSource,
   startOpenCodeServer,
@@ -220,6 +221,8 @@ class BlessedTinyPlaceTui {
   private bridgeSource?: OpenCodeEventSource;
   private opencodeServer?: OpenCodeServerHandle;
   private bridgeReceiver?: InboundMessageReceiver;
+  private bridgeBus?: MachineBus;
+  private bridgeBusHeartbeat?: ReturnType<typeof setInterval>;
   // Home-screen resume pane: the recent sessions across both agents, loaded once
   // at start. Empty in fixed-agent mode.
   private recentSessions: Array<RecentSession> = [];
@@ -777,7 +780,27 @@ class BlessedTinyPlaceTui {
     // TINYPLACE_BRIDGE_LOG is set, `createBridgeDiagSink` tees them into the log
     // file instead so bridge failures are visible while debugging.
     const sink = createBridgeDiagSink();
-    const publisher = new SessionEnvelopePublisher(config, this.options, sink);
+    // Machine session bus: this TUI session shares the machine's ONE wallet
+    // with every other wrapper session — the bus serializes Signal I/O across
+    // processes, spools inbound DMs to their addressed session, and registers
+    // this session (live/inactive) on the machine registry.
+    this.bridgeBus = createMachineBus({
+      env: this.ctx.env,
+      wrapperSessionId: config.wrapperSessionId,
+      provider: config.provider,
+      cwd,
+    });
+    this.bridgeBus.registerSession();
+    this.bridgeBusHeartbeat = setInterval(
+      () => this.bridgeBus?.heartbeatSession(),
+      10_000,
+    );
+    const publisher = new SessionEnvelopePublisher(
+      config,
+      this.options,
+      sink,
+      this.bridgeBus,
+    );
     if (this.profile.serverMode && this.opencodeServer) {
       // opencode: observe the live session over the server's SSE bus.
       this.bridgeSource = new OpenCodeEventSource(config, cwd, sink, publisher);
@@ -788,7 +811,7 @@ class BlessedTinyPlaceTui {
         : undefined;
     }
     this.bridgeReceiver = config.receiveEnabled
-      ? new InboundMessageReceiver(config, publisher, sink)
+      ? new InboundMessageReceiver(config, publisher, sink, this.bridgeBus)
       : undefined;
     this.bridgeReceiver?.setSink((text) => {
       bridgeLog("inbound.inject", { chars: text.length });
@@ -823,6 +846,12 @@ class BlessedTinyPlaceTui {
     void this.bridgeTailer?.stop();
     void this.bridgeSource?.stop();
     void this.bridgeReceiver?.stop();
+    if (this.bridgeBusHeartbeat) {
+      clearInterval(this.bridgeBusHeartbeat);
+      this.bridgeBusHeartbeat = undefined;
+    }
+    this.bridgeBus?.endSession();
+    this.bridgeBus = undefined;
     this.bridgeTailer = undefined;
     this.bridgeSource = undefined;
     this.bridgeReceiver = undefined;

--- a/sdk/typescript/src/node/file-session-store.ts
+++ b/sdk/typescript/src/node/file-session-store.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fromBase64, toBase64 } from "../signal/index.js";
@@ -132,6 +132,10 @@ function deserializeSession(value: SerializedSession): SessionState {
  */
 export class FileSessionStore implements SessionStore, GroupSessionStore {
   private cache?: PersistShape;
+  /** Disk stat backing `cache`; when the file changed under us (another
+   *  process on the same wallet advanced the ratchet), the cache is stale and
+   *  `load()` re-reads. Undefined means the cache corresponds to no file. */
+  private cachedStat?: { mtimeMs: number; size: number };
 
   constructor(
     private readonly filePath: string,
@@ -268,27 +272,53 @@ export class FileSessionStore implements SessionStore, GroupSessionStore {
   }
 
   private async load(): Promise<PersistShape> {
-    if (!this.cache) {
-      try {
-        const parsed = JSON.parse(
-          await readFile(this.filePath, "utf8"),
-        ) as Partial<PersistShape>;
-        // Version-tolerant: merge over defaults so a file written by an older
-        // build (no group fields / no version) loads without wiping live state.
-        this.cache = { ...emptyState(), ...parsed, version: 1 };
-      } catch (error) {
-        if ((error as { code?: string }).code === "ENOENT") {
-          this.cache = emptyState();
-        } else {
-          throw error;
-        }
+    // Cross-process coherence: several processes can share one wallet store
+    // (the machine session bus serializes their operations, but each holds its
+    // own FileSessionStore instance). A cached copy is only valid while the
+    // file on disk still matches the stat we read/wrote it at — otherwise a
+    // sibling process advanced the ratchet and we must re-read, or our next
+    // flush would silently roll its chains back (undecryptable messages).
+    const stat = await this.statFile();
+    if (
+      this.cache &&
+      ((stat === undefined && this.cachedStat === undefined) ||
+        (stat !== undefined &&
+          this.cachedStat !== undefined &&
+          stat.mtimeMs === this.cachedStat.mtimeMs &&
+          stat.size === this.cachedStat.size))
+    ) {
+      return this.cache;
+    }
+    try {
+      const parsed = JSON.parse(
+        await readFile(this.filePath, "utf8"),
+      ) as Partial<PersistShape>;
+      // Version-tolerant: merge over defaults so a file written by an older
+      // build (no group fields / no version) loads without wiping live state.
+      this.cache = { ...emptyState(), ...parsed, version: 1 };
+    } catch (error) {
+      if ((error as { code?: string }).code === "ENOENT") {
+        this.cache = emptyState();
+      } else {
+        throw error;
       }
     }
+    this.cachedStat = stat;
     return this.cache;
   }
 
   private async flush(): Promise<void> {
     await mkdir(dirname(this.filePath), { recursive: true });
     await writeFile(this.filePath, JSON.stringify(this.cache), { mode: 0o600 });
+    this.cachedStat = await this.statFile();
+  }
+
+  private async statFile(): Promise<{ mtimeMs: number; size: number } | undefined> {
+    try {
+      const info = await stat(this.filePath);
+      return { mtimeMs: info.mtimeMs, size: info.size };
+    } catch {
+      return undefined;
+    }
   }
 }

--- a/sdk/typescript/src/node/index.ts
+++ b/sdk/typescript/src/node/index.ts
@@ -45,6 +45,20 @@ export {
   isV2,
   parseSessionEnvelope,
 } from "../cli/harness-consumer.js";
+export {
+  HARNESS_CONTROL_VERSION,
+  encodeHarnessControlFrame,
+  parseHarnessControlFrame,
+  type EncodeHarnessControlOptions,
+  type HarnessControlFrame,
+} from "../cli/harness-control.js";
+export {
+  createMachineBus,
+  type BusSessionInfo,
+  type MachineBus,
+  type MachineBusOptions,
+  type SpooledInbound,
+} from "../cli/machine-bus.js";
 
 // Coding-agent daemon: the task protocol, provider detection/execution, and the
 // serialized mailbox that `tinyplace daemon` composes. Exposed so an embedder can

--- a/sdk/typescript/tests/codex-cli.test.ts
+++ b/sdk/typescript/tests/codex-cli.test.ts
@@ -413,13 +413,22 @@ describe("tinyplace codex", () => {
     expect(result.code).toBe(0);
     expect(relay.contactRequests).toEqual([recipient.signer.agentId]);
     const messages = await readMessages(recipient.client, recipient.signer);
-    expect(messages).toHaveLength(2);
     const envelopes = messages.map((message) => JSON.parse(message.text) as Record<string, unknown>);
-    expect(envelopes.map((envelope) => (envelope.message as { role: string }).role)).toEqual([
+    // v2 is always emitted alongside v1 now: the v1 message stream is
+    // unchanged (one user + one agent), and typed v2 events ride with it.
+    const v1 = envelopes.filter(
+      (envelope) => envelope.envelope_version === "tinyplace.harness.session.v1",
+    );
+    const v2 = envelopes.filter(
+      (envelope) => envelope.envelope_version === "tinyplace.harness.session.v2",
+    );
+    expect(v1).toHaveLength(2);
+    expect(v2.length).toBeGreaterThan(0);
+    expect(v1.map((envelope) => (envelope.message as { role: string }).role)).toEqual([
       "user",
       "agent",
     ]);
-    expect(envelopes[0]).toMatchObject({
+    expect(v1[0]).toMatchObject({
       envelope_version: "tinyplace.harness.session.v1",
       harness: { provider: "codex" },
     });
@@ -792,8 +801,14 @@ describe("tinyplace codex", () => {
     expect(envelope).toContain('"role":"agent"');
     expect(envelope).toContain("please inspect this");
     expect(envelope).toContain("I inspected it.");
-    expect(envelope).not.toContain("not a semantic user prompt");
-    expect(envelope).not.toContain("hidden");
+    // The v1 message stream still excludes non-semantic lines; the always-on
+    // v2 typed-event stream carries them as tool_result / agent_thinking.
+    const v1Lines = envelope
+      .split("\n")
+      .filter((line) => line.includes("tinyplace.harness.session.v1"));
+    expect(v1Lines.join("\n")).not.toContain("not a semantic user prompt");
+    expect(v1Lines.join("\n")).not.toContain("hidden");
+    expect(envelope).toContain("tinyplace.harness.session.v2");
   });
 });
 

--- a/sdk/typescript/tests/file-session-store-coherence.test.ts
+++ b/sdk/typescript/tests/file-session-store-coherence.test.ts
@@ -1,0 +1,70 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { FileSessionStore } from "../src/node/file-session-store.js";
+import { generateX25519KeyPair } from "../src/signal/index.js";
+import type { SessionState } from "../src/signal/index.js";
+
+function sessionState(marker: number): SessionState {
+  return {
+    dhSendKeyPair: generateX25519KeyPair(),
+    dhRecvPublicKey: null,
+    rootKey: new Uint8Array(32).fill(1),
+    sendChainKey: new Uint8Array(32).fill(2),
+    recvChainKey: null,
+    sendMessageNumber: marker,
+    recvMessageNumber: 0,
+    previousChainLength: 0,
+    skippedKeys: new Map(),
+  };
+}
+
+describe("FileSessionStore cross-process coherence", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "tp-store-coherence-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { force: true, recursive: true });
+  });
+
+  it("re-reads a session another store instance advanced on disk", async () => {
+    const path = join(dir, "signal.json");
+    const identity = generateX25519KeyPair();
+    const a = new FileSessionStore(path, identity);
+    const b = new FileSessionStore(path, identity);
+
+    await a.storeSession("peer", sessionState(1));
+    // b loads (and caches) the state written by a.
+    expect((await b.getSession("peer"))?.sendMessageNumber).toBe(1);
+
+    // a advances the ratchet; ensure a distinct mtime for coarse filesystems.
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 5));
+    await a.storeSession("peer", sessionState(7));
+
+    // Without stat-based invalidation b would return its stale cache (1) and a
+    // later write from b would roll a's chain back.
+    expect((await b.getSession("peer"))?.sendMessageNumber).toBe(7);
+  });
+
+  it("a stale instance's write does not resurrect its old cache", async () => {
+    const path = join(dir, "signal.json");
+    const identity = generateX25519KeyPair();
+    const a = new FileSessionStore(path, identity);
+    const b = new FileSessionStore(path, identity);
+
+    await a.storeSession("peer", sessionState(1));
+    expect((await b.getSession("peer"))?.sendMessageNumber).toBe(1);
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 5));
+    await a.storeSession("peer", sessionState(7));
+
+    // b writes a DIFFERENT session; it must first reload, so peer stays at 7.
+    await b.storeSession("other", sessionState(2));
+    expect((await a.getSession("peer"))?.sendMessageNumber).toBe(7);
+    expect((await a.getSession("other"))?.sendMessageNumber).toBe(2);
+  });
+});

--- a/sdk/typescript/tests/machine-bus.test.ts
+++ b/sdk/typescript/tests/machine-bus.test.ts
@@ -1,0 +1,196 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  encodeHarnessControlFrame,
+  parseHarnessControlFrame,
+} from "../src/cli/harness-control.js";
+import { createMachineBus, type MachineBus } from "../src/cli/machine-bus.js";
+
+describe("harness control frames", () => {
+  it("round-trips a session-addressed input frame", () => {
+    const wire = encodeHarnessControlFrame("run the tests", {
+      sessionId: "0199a-codex-rollout",
+    });
+    const frame = parseHarnessControlFrame(wire);
+    expect(frame).toEqual({
+      control_version: "tinyplace.harness.control.v1",
+      kind: "input",
+      session_id: "0199a-codex-rollout",
+      text: "run the tests",
+    });
+  });
+
+  it("omits session_id when unaddressed (primary-session semantics)", () => {
+    const frame = parseHarnessControlFrame(
+      encodeHarnessControlFrame("hello"),
+    );
+    expect(frame?.session_id).toBeUndefined();
+    expect(frame?.text).toBe("hello");
+  });
+
+  it("rejects plaintext, foreign JSON, and malformed frames", () => {
+    expect(parseHarnessControlFrame("just a prompt")).toBeUndefined();
+    expect(
+      parseHarnessControlFrame(JSON.stringify({ envelope_version: "x" })),
+    ).toBeUndefined();
+    expect(
+      parseHarnessControlFrame(
+        JSON.stringify({
+          control_version: "tinyplace.harness.control.v1",
+          kind: "input",
+        }),
+      ),
+    ).toBeUndefined();
+    expect(parseHarnessControlFrame("{not json")).toBeUndefined();
+  });
+});
+
+describe("machine session bus", () => {
+  let busDir: string;
+
+  beforeEach(() => {
+    busDir = mkdtempSync(join(tmpdir(), "tp-machine-bus-"));
+  });
+
+  afterEach(() => {
+    rmSync(busDir, { force: true, recursive: true });
+  });
+
+  function makeBus(wrapperSessionId: string, startedAtOffset = 0): MachineBus {
+    const bus = createMachineBus({
+      busDir,
+      cwd: "/work",
+      env: {},
+      provider: "codex",
+      wrapperSessionId,
+    });
+    bus.registerSession();
+    // Session ordering is by startedAt; tests register in call order and the
+    // ISO timestamps of two immediate registrations can collide, so nudge via
+    // a heartbeat when an explicit ordering matters.
+    if (startedAtOffset > 0) {
+      bus.heartbeatSession();
+    }
+    return bus;
+  }
+
+  it("registers sessions and lists them with liveness", () => {
+    const bus = makeBus("session-a");
+    const sessions = bus.listSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      wrapperSessionId: "session-a",
+      provider: "codex",
+      pid: process.pid,
+      live: true,
+    });
+  });
+
+  it("records the harness session id from a heartbeat patch", () => {
+    const bus = makeBus("session-a");
+    bus.heartbeatSession({ harnessSessionId: "rollout-123" });
+    expect(bus.listSessions()[0]?.harnessSessionId).toBe("rollout-123");
+  });
+
+  it("marks an ended session inactive but keeps it listed", () => {
+    const bus = makeBus("session-a");
+    bus.endSession();
+    const sessions = bus.listSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.live).toBe(false);
+    expect(sessions[0]?.ended).toBe(true);
+  });
+
+  it("routes a session-addressed control frame to that session's spool", () => {
+    const first = makeBus("session-a");
+    const second = makeBus("session-b");
+    second.heartbeatSession({ harnessSessionId: "rollout-b" });
+
+    first.routeInbound(
+      "owner",
+      encodeHarnessControlFrame("for b, by wrapper id", {
+        sessionId: "session-b",
+      }),
+    );
+    first.routeInbound(
+      "owner",
+      encodeHarnessControlFrame("for b, by harness id", {
+        sessionId: "rollout-b",
+      }),
+    );
+
+    expect(first.consumeInbound().map((item) => item.text)).toEqual([]);
+    expect(second.consumeInbound().map((item) => item.text)).toEqual([
+      "for b, by wrapper id",
+      "for b, by harness id",
+    ]);
+    // Drained — a second consume returns nothing (no double injection).
+    expect(second.consumeInbound()).toEqual([]);
+  });
+
+  it("delivers plaintext to the primary (earliest-started live) session only", () => {
+    const first = makeBus("session-a");
+    // Ensure a strictly later startedAt for the second session.
+    const before = Date.now();
+    while (Date.now() - before < 5) {
+      // busy-wait a few ms so ISO startedAt differs
+    }
+    const second = makeBus("session-b");
+
+    second.routeInbound("owner", "plain prompt");
+    expect(second.consumeInbound()).toEqual([]); // not primary
+    const drained = first.consumeInbound();
+    expect(drained.map((item) => item.text)).toEqual(["plain prompt"]);
+    expect(drained[0]?.sessionId).toBeUndefined();
+  });
+
+  it("falls back to the default spool when a frame names an unknown session", () => {
+    const bus = makeBus("session-a");
+    bus.routeInbound(
+      "owner",
+      encodeHarnessControlFrame("ghost", { sessionId: "no-such-session" }),
+    );
+    const drained = bus.consumeInbound();
+    expect(drained.map((item) => item.text)).toEqual(["ghost"]);
+    expect(drained[0]?.sessionId).toBe("no-such-session");
+  });
+
+  it("serializes concurrent withLock sections", async () => {
+    const bus = makeBus("session-a");
+    const order: Array<string> = [];
+    await Promise.all([
+      bus.withLock(async () => {
+        order.push("a-start");
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 30));
+        order.push("a-end");
+      }),
+      bus.withLock(async () => {
+        order.push("b-start");
+        order.push("b-end");
+      }),
+    ]);
+    // Whichever section starts first must finish before the other starts.
+    const firstEnd = order.indexOf(`${order[0]?.charAt(0)}-end`);
+    expect(firstEnd).toBe(1);
+    expect(order).toHaveLength(4);
+  });
+
+  it("reclaims a stale lock left by a dead process", async () => {
+    const bus = makeBus("session-a");
+    // Simulate a dead holder: a lock file naming the PID of an already-exited
+    // child process (freshly reaped, so it cannot be a live process).
+    const deadPid = spawnSync("true").pid ?? 2 ** 30;
+    mkdirSync(busDir, { recursive: true });
+    writeFileSync(
+      join(busDir, "wallet.lock"),
+      JSON.stringify({ pid: deadPid, at: Date.now() }),
+      "utf8",
+    );
+    const result = await bus.withLock(async () => "ran");
+    expect(result).toBe("ran");
+  });
+});


### PR DESCRIPTION
## Summary

Implements the one-wallet-per-machine session architecture for harness wrappers (driven by medulla's operator TUI — see tinyhumansai/medulla-v1#40):

- **Machine session bus** (`sdk/typescript/src/cli/machine-bus.ts`): every `tinyplace codex`/`claude` terminal on a machine shares the machine's ONE wallet (`TINYPLACE_CONFIG`) safely. A cross-process wallet lock serializes all Signal operations (sends, destructive inbox reads, prekey publication — the FileSessionStore ratchet cannot be touched concurrently), a filesystem spool routes inbound DMs to their addressed session, and a PID-probed registry under `<config-dir>/harness-bus/sessions` tracks each wrapper session live/inactive, recording the harness's own session id (codex rollout id) as soon as an envelope reveals it.
- **Control frames** (`tinyplace.harness.control.v1`): an owner can address input at a specific session by wrapper or harness session id. Plaintext DMs keep their historical meaning — they go to the machine's *primary* session (earliest-started live one), which is exactly the single-terminal behavior.
- **v2 enforced**: the typed-event envelope stream is now always emitted alongside v1; the `TINYPLACE_*_V2` opt-in env flag is retired.

The bus only engages when a wrapper actually touches the wallet (an owner is configured); single-session machines behave exactly as before, just spool-routed.

## Validation

- `pnpm build`, `pnpm lint` (tsc), full `pnpm test` — 559 passed. 11 new tests cover control-frame codec, registry liveness, session-addressed + primary-session spool routing, lock serialization, and stale-lock reclaim. Two existing wrapper tests updated for the always-on dual v1+v2 stream.
- Consumed live by medulla-v1's TUI (session-addressed concurrent dispatch): tinyhumansai/medulla-v1#40.

https://claude.ai/code/session_013xjQ7FUumJaRzS9Hv6B5yu