### PR TITLE
fix(sdk): fail fast when agent messaging has no encryption

### DIFF
--- a/sdk/typescript/src/agent/messaging.ts
+++ b/sdk/typescript/src/agent/messaging.ts
@@ -89,17 +89,26 @@ export interface SendMessageResult {
 }
 
 /**
- * Sends a message to `recipient` (a @handle, cryptoId, or base64 key). The body
- * is Signal-encrypted by the client before it leaves the process.
- *
- * This is the E2E facade: it REQUIRES the client to have encryption configured
- * (`encryption: { store }` + a signer). A client without encryption would send
- * the body as plaintext, which the relay rejects — a plaintext JSON body trips
- * its `looksLikeJSON` guard with `HTTP 400: body must be encrypted ciphertext`,
- * surfacing far from the misconfiguration (a client built without a signer/store,
- * e.g. an under-provisioned daemon). Fail fast here with a clear cause instead of
- * leaking plaintext and getting a cryptic relay rejection. Callers that genuinely
- * want plain relay transport use `client.messages.send` directly.
+ * The E2E facade REQUIRES a client with encryption configured (`encryption: { store }`
+ * + a signer). A client without it would relay the body as plaintext, which the backend
+ * rejects — a plaintext JSON body trips its `looksLikeJSON` guard with `HTTP 400: body
+ * must be encrypted ciphertext`, surfacing far from the misconfiguration (a client built
+ * without a signer/store, e.g. an under-provisioned daemon). Fail fast with a clear cause
+ * instead of leaking plaintext. Callers that want plain transport use `client.messages.send`.
+ */
+function assertEncryptionEnabled(client: TinyPlaceClient): void {
+  if (client.encryptionEnabled) return;
+  throw new Error(
+    "agent messaging requires encryption: construct the client with " +
+      "`encryption: { store }` and a signer. Sending a plaintext body over the " +
+      'E2E channel is rejected by the relay ("body must be encrypted ciphertext").',
+  );
+}
+
+/**
+ * Sends a message to `recipient` (a @handle, cryptoId, or base64 key). The body is
+ * Signal-encrypted by the client before it leaves the process; encryption must be
+ * configured (see {@link assertEncryptionEnabled}).
  */
 export async function sendMessage(
   client: TinyPlaceClient,
@@ -107,13 +116,7 @@ export async function sendMessage(
   recipient: string,
   text: string,
 ): Promise<SendMessageResult> {
-  if (!client.encryptionEnabled) {
-    throw new Error(
-      "agent messaging requires encryption: construct the client with " +
-        "`encryption: { store }` and a signer. Sending a plaintext body over the " +
-        'E2E channel is rejected by the relay ("body must be encrypted ciphertext").',
-    );
-  }
+  assertEncryptionEnabled(client);
   const to = await resolveRecipientKey(client, recipient);
   const envelope: MessageEnvelope = {
     id: messageId(),

--- a/sdk/typescript/src/agent/messaging.ts
+++ b/sdk/typescript/src/agent/messaging.ts
@@ -90,8 +90,16 @@ export interface SendMessageResult {
 
 /**
  * Sends a message to `recipient` (a @handle, cryptoId, or base64 key). The body
- * is Signal-encrypted by the client before it leaves the process when encryption
- * is configured (the recommended setup); otherwise it is sent as plaintext.
+ * is Signal-encrypted by the client before it leaves the process.
+ *
+ * This is the E2E facade: it REQUIRES the client to have encryption configured
+ * (`encryption: { store }` + a signer). A client without encryption would send
+ * the body as plaintext, which the relay rejects — a plaintext JSON body trips
+ * its `looksLikeJSON` guard with `HTTP 400: body must be encrypted ciphertext`,
+ * surfacing far from the misconfiguration (a client built without a signer/store,
+ * e.g. an under-provisioned daemon). Fail fast here with a clear cause instead of
+ * leaking plaintext and getting a cryptic relay rejection. Callers that genuinely
+ * want plain relay transport use `client.messages.send` directly.
  */
 export async function sendMessage(
   client: TinyPlaceClient,
@@ -99,6 +107,13 @@ export async function sendMessage(
   recipient: string,
   text: string,
 ): Promise<SendMessageResult> {
+  if (!client.encryptionEnabled) {
+    throw new Error(
+      "agent messaging requires encryption: construct the client with " +
+        "`encryption: { store }` and a signer. Sending a plaintext body over the " +
+        'E2E channel is rejected by the relay ("body must be encrypted ciphertext").',
+    );
+  }
   const to = await resolveRecipientKey(client, recipient);
   const envelope: MessageEnvelope = {
     id: messageId(),

--- a/sdk/typescript/tests/agent-messaging.test.ts
+++ b/sdk/typescript/tests/agent-messaging.test.ts
@@ -162,4 +162,16 @@ describe("sendMessage / readMessages round-trip", () => {
     // Consumed on read.
     expect(await readMessages(bob.client, bob.signer)).toHaveLength(0);
   });
+
+  it("refuses to send when the client has no encryption configured", async () => {
+    // A client built without `encryption: { store }` would relay the body as
+    // plaintext, which the backend rejects with `400: body must be encrypted
+    // ciphertext`. The facade must fail fast at the misconfiguration instead.
+    const signer = await LocalSigner.generate();
+    const plain = new TinyPlaceClient({ baseUrl: "https://relay.test", signer });
+    expect(plain.encryptionEnabled).toBe(false);
+    await expect(
+      sendMessage(plain, signer, signer.agentId, "hi"),
+    ).rejects.toThrow(/requires encryption/);
+  });
 });


### PR DESCRIPTION
## Problem

The Agent E2E facade (`agent.sendMessage` / `sendMessage()`) silently sent the body as **plaintext** when the underlying `TinyPlaceClient` was built **without** `encryption: { store }` (i.e. no encryption context — e.g. a daemon whose client was constructed without a signer/session store).

The relay rejects a plaintext JSON body via its `looksLikeJSON` guard with:

```
HTTP 400: /messages — body must be encrypted ciphertext
```

That error surfaces **far from the real cause**: the send code looks correct, the encrypt stack (`EncryptionContext.encryptEnvelope` → `session.encrypt`) never actually ran, and the operator sees a confusing relay 400 rather than "this client has no encryption configured." Every encrypt path in the SDK either produces real ciphertext or throws — so a plaintext body reaching the relay always means encryption was never wired, which is exactly the case worth catching loudly.

## Fix

Guard the E2E facade on the existing `client.encryptionEnabled` getter and throw a clear, actionable error before building/sending the envelope:

> agent messaging requires encryption: construct the client with `encryption: { store }` and a signer. Sending a plaintext body over the E2E channel is rejected by the relay ("body must be encrypted ciphertext").

The low-level transparent `client.messages.send` path is **untouched**, so callers that genuinely want plain relay transport (and its documented transparent-plaintext behavior) are unaffected.

## Validation

- `pnpm --filter @tinyhumansai/tinyplace build` (tsc) ✅
- `pnpm --filter @tinyhumansai/tinyplace test` — 578 passed / 99 skipped ✅ (adds a case asserting the facade throws when the client has no encryption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented end-to-end messages from being sent when encryption is disabled.
  * Improved the error messaging so failed deliveries clearly indicate that encryption is required.

* **Tests**
  * Added coverage verifying that attempting to send an unencrypted message fails and matches the expected “requires encryption” error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->