### PR TITLE
fix(rust/websocket): sign the upgrade with X-TinyPlace-Signature headers

### DIFF
--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -75,9 +75,12 @@ conn.close();
 
 Every frame is delivered to `on_message` as a `serde_json::Value`; frames that
 carry a string `type` field are also routed to a matching `on(type, ..)`
-callback. Agent-scoped streams sign the connection with directory-write auth
-when a signing key is configured. The optional `tokio` feature set for streaming
-is bundled by default (no extra Cargo features needed).
+callback. When a signing key is configured, authenticated streams sign the
+upgrade request itself: the handshake carries `X-TinyPlace-Signature` (a `siws:`
+proof or a freshness-bound `v1:` token) alongside `X-TinyPlace-Public-Key`, which
+the backend verifies before returning `101` — an unsigned handshake is rejected
+with `401`. The optional `tokio` feature set for streaming is bundled by default
+(no extra Cargo features needed).
 
 ## Install
 

--- a/sdk/rust/src/auth.rs
+++ b/sdk/rust/src/auth.rs
@@ -7,7 +7,7 @@
 
 use rand::RngCore as _;
 
-use crate::crypto::{sha256_hex, to_base64, to_base64_url};
+use crate::crypto::{canonical_payload, sha256_hex, to_base64, to_base64_url};
 use crate::error::Result;
 use crate::signer::Signer;
 use crate::util::encode;
@@ -167,9 +167,43 @@ pub async fn sign_directory_write_query(
     ))
 }
 
+/// The signature header the backend authenticates a WebSocket upgrade with.
+pub const WS_SIGNATURE_HEADER: &str = "X-TinyPlace-Signature";
+/// The public-key header presented alongside [`WS_SIGNATURE_HEADER`].
+pub const WS_PUBLIC_KEY_HEADER: &str = "X-TinyPlace-Public-Key";
+/// The optional crypto-id header naming the identity the signer acts as.
+pub const WS_CRYPTO_ID_HEADER: &str = "X-TinyPlace-Crypto-Id";
+
+/// Sign a WebSocket upgrade, returning the `X-TinyPlace-*` headers the backend
+/// verifies on the handshake request itself.
+///
+/// A WebSocket upgrade is a plain HTTP `GET`, so it carries the same credential
+/// the REST routes use, and the server's auth middleware runs on it *before* the
+/// 101 response — an unsigned or badly signed handshake is rejected with 401 and
+/// never upgrades. The value of [`WS_SIGNATURE_HEADER`] is either a reusable
+/// `siws:` ownership proof or a freshness-bound
+/// `v1:<b64url(timestamp)>:<b64url(nonce)>:<base64(signature)>` token over the
+/// canonical payload `{"action":"","fields":{}}` — a stream `GET` declares no
+/// action and no fields, so the payload is the empty canonical envelope.
+pub async fn sign_websocket_upgrade(
+    signer: &dyn Signer,
+    public_key_base64: &str,
+) -> Result<Headers> {
+    let payload = canonical_payload("", serde_json::json!({}));
+    let signature = sign_fresh_canonical_payload(signer, &payload).await?;
+    Ok(vec![
+        (
+            WS_PUBLIC_KEY_HEADER.to_string(),
+            public_key_base64.to_string(),
+        ),
+        (WS_CRYPTO_ID_HEADER.to_string(), signer.agent_id()),
+        (WS_SIGNATURE_HEADER.to_string(), signature),
+    ])
+}
+
 /// Build the query string the agent `Authorization` header is carried in for
-/// WebSocket upgrades (`?authorization=<urlencoded>`), since headers can't be
-/// set on a browser/standard WS handshake.
+/// WebSocket upgrades (`?authorization=<urlencoded>`), for backends (and
+/// browser clients) that read the credential from the URL instead of a header.
 pub async fn sign_request_query(signer: &dyn Signer, request_uri: &str) -> Result<String> {
     let headers = sign_request(signer, "").await?;
     let authorization = headers

--- a/sdk/rust/src/websocket.rs
+++ b/sdk/rust/src/websocket.rs
@@ -4,29 +4,39 @@
 //! their `stream()` methods. Call [`TinyPlaceWebSocket::connect`] to open the
 //! socket and obtain a [`WebSocketConnection`], then `recv()` messages in a loop.
 //!
-//! Auth travels in the URL (a WebSocket upgrade can't carry the usual custom
-//! headers): directory-write credentials as signed query params, or the agent
-//! `Authorization` header as a single `authorization=` query param.
+//! Auth travels on the upgrade request as `X-TinyPlace-*` headers — the same
+//! credential the REST routes carry, verified by the backend's auth middleware
+//! before the socket is upgraded (see [`sign_websocket_upgrade`]). The legacy
+//! URL-borne credentials (directory-write query params, or the agent
+//! `Authorization` as an `authorization=` param) are still appended, so the same
+//! handle authenticates against backends that only read the query string.
 
 use std::sync::Arc;
 
 use futures_util::{SinkExt as _, StreamExt as _};
 use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
+use tokio_tungstenite::tungstenite::http::{HeaderName, HeaderValue};
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
-use crate::auth::{sign_directory_write_query, sign_request_query};
+use crate::auth::{
+    sign_directory_write_query, sign_request_query, sign_websocket_upgrade, Headers,
+};
 use crate::error::{Error, Result};
+use crate::http::{SDK_CLIENT, SDK_CLIENT_HEADER};
 use crate::signer::Signer;
 
-/// How a WebSocket upgrade is authenticated.
+/// How a WebSocket upgrade is authenticated. Both authenticated modes send the
+/// `X-TinyPlace-*` upgrade headers; they differ only in the legacy URL-borne
+/// credential they append for query-string backends.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WsAuth {
     /// No auth (public stream, or no signer configured).
     None,
-    /// Agent `Authorization` carried as an `authorization=` query param.
+    /// Agent `Authorization` also carried as an `authorization=` query param.
     Agent,
-    /// Directory-write credentials carried as signed `X-TinyPlace-*` query params.
+    /// Directory-write credentials also carried as signed `X-TinyPlace-*` query params.
     Directory,
 }
 
@@ -81,10 +91,34 @@ impl TinyPlaceWebSocket {
         Ok(format!("{}{}", self.origin, uri))
     }
 
+    /// The headers sent on the upgrade request: the SDK client tag, plus the
+    /// signed `X-TinyPlace-*` credential when this stream is authenticated.
+    /// Exposed for testing and diagnostics.
+    pub async fn upgrade_headers(&self) -> Result<Headers> {
+        let mut headers: Headers = vec![(SDK_CLIENT_HEADER.to_string(), SDK_CLIENT.to_string())];
+        if let (WsAuth::Agent | WsAuth::Directory, Some(signer), Some(public_key)) =
+            (self.auth, &self.signer, &self.public_key)
+        {
+            headers.extend(sign_websocket_upgrade(signer.as_ref(), public_key).await?);
+        }
+        Ok(headers)
+    }
+
     /// Open the WebSocket and return a connection to read/write messages.
     pub async fn connect(&self) -> Result<WebSocketConnection> {
         let url = self.signed_url().await?;
-        let (stream, _response) = connect_async(&url)
+        let mut request = url
+            .as_str()
+            .into_client_request()
+            .map_err(|error| Error::WebSocket(error.to_string()))?;
+        for (name, value) in self.upgrade_headers().await? {
+            let name = HeaderName::try_from(name.as_str())
+                .map_err(|error| Error::WebSocket(error.to_string()))?;
+            let value = HeaderValue::try_from(value.as_str())
+                .map_err(|error| Error::WebSocket(error.to_string()))?;
+            request.headers_mut().insert(name, value);
+        }
+        let (stream, _response) = connect_async(request)
             .await
             .map_err(|error| Error::WebSocket(error.to_string()))?;
         Ok(WebSocketConnection { inner: stream })

--- a/sdk/rust/tests/e2e_docker.rs
+++ b/sdk/rust/tests/e2e_docker.rs
@@ -12,9 +12,10 @@
 //!
 //! Override the target with `TINYPLACE_E2E_URL` (default `http://localhost:8080`).
 
+use std::sync::Arc;
 use std::time::Duration;
 
-use tinyplace::{TinyPlaceClient, TinyPlaceClientOptions, TinyPlaceWebSocket};
+use tinyplace::{LocalSigner, Signer, TinyPlaceClient, TinyPlaceClientOptions, TinyPlaceWebSocket};
 
 fn base_url() -> String {
     std::env::var("TINYPLACE_E2E_URL").unwrap_or_else(|_| "http://localhost:8080".to_string())
@@ -110,4 +111,21 @@ async fn ledger_stream_pushes_frames() {
         "ledger.stream",
     )
     .await;
+}
+
+#[tokio::test]
+#[ignore = "requires the docker-compose stack on :8080"]
+async fn authenticated_inbox_stream_upgrades_with_signed_headers() {
+    // `/inbox/stream` is auth-gated: the backend verifies the signed
+    // `X-TinyPlace-*` headers on the upgrade request and answers 401 (never
+    // upgrading) when they are missing or stale. A fresh key simply has an empty
+    // inbox, so reaching the snapshot frame at all proves the handshake
+    // authenticated.
+    let signer = LocalSigner::generate();
+    let client = TinyPlaceClient::new(TinyPlaceClientOptions {
+        base_url: base_url(),
+        signer: Some(Arc::new(signer) as Arc<dyn Signer>),
+        ..Default::default()
+    });
+    assert_stream_pushes_a_typed_frame(client.inbox.stream(), "inbox.stream").await;
 }

--- a/sdk/rust/tests/e2e_docker.rs
+++ b/sdk/rust/tests/e2e_docker.rs
@@ -10,7 +10,13 @@
 //! cargo test --test e2e_docker -- --ignored --nocapture   # from sdk/rust/
 //! ```
 //!
-//! Override the target with `TINYPLACE_E2E_URL` (default `http://localhost:8080`).
+//! Override the target with `TINYPLACE_E2E_URL` (default `http://localhost:8080`),
+//! e.g. to run the same suite against staging:
+//!
+//! ```sh
+//! TINYPLACE_E2E_URL=https://staging-api.tiny.place \
+//!   cargo test --test e2e_docker -- --ignored --nocapture
+//! ```
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,6 +30,19 @@ fn base_url() -> String {
 fn anon_client() -> TinyPlaceClient {
     TinyPlaceClient::new(TinyPlaceClientOptions {
         base_url: base_url(),
+        ..Default::default()
+    })
+}
+
+/// A client signing as a fresh, unregistered identity. `siws` picks the scheme
+/// the upgrade header carries: a reusable `siws:` proof (the `LocalSigner`
+/// default) or the per-request freshness-bound `v1:` token.
+fn signed_client(siws: bool) -> TinyPlaceClient {
+    let signer = LocalSigner::generate();
+    let signer = if siws { signer } else { signer.without_siws() };
+    TinyPlaceClient::new(TinyPlaceClientOptions {
+        base_url: base_url(),
+        signer: Some(Arc::new(signer) as Arc<dyn Signer>),
         ..Default::default()
     })
 }
@@ -121,11 +140,64 @@ async fn authenticated_inbox_stream_upgrades_with_signed_headers() {
     // upgrading) when they are missing or stale. A fresh key simply has an empty
     // inbox, so reaching the snapshot frame at all proves the handshake
     // authenticated.
-    let signer = LocalSigner::generate();
-    let client = TinyPlaceClient::new(TinyPlaceClientOptions {
-        base_url: base_url(),
-        signer: Some(Arc::new(signer) as Arc<dyn Signer>),
-        ..Default::default()
-    });
-    assert_stream_pushes_a_typed_frame(client.inbox.stream(), "inbox.stream").await;
+    assert_stream_pushes_a_typed_frame(signed_client(true).inbox.stream(), "inbox.stream[siws]")
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "requires the docker-compose stack on :8080"]
+async fn authenticated_stream_accepts_the_fresh_signature_scheme() {
+    // The same upgrade, signed with the per-request `v1:<ts>:<nonce>:<sig>`
+    // token instead of a reusable SIWS proof. Both schemes must authenticate.
+    assert_stream_pushes_a_typed_frame(signed_client(false).inbox.stream(), "inbox.stream[v1]")
+        .await;
+}
+
+#[tokio::test]
+#[ignore = "requires the docker-compose stack on :8080"]
+async fn authenticated_stream_rejects_an_unsigned_upgrade() {
+    // The negative control for the two tests above: without a signer the SDK
+    // sends no credential, and the backend must refuse to upgrade. Without this,
+    // a permanently-public endpoint would make the signed cases pass for the
+    // wrong reason.
+    let error = anon_client()
+        .inbox
+        .stream()
+        .connect()
+        .await
+        .err()
+        .expect("an unsigned upgrade must not connect");
+    println!("unsigned inbox.stream rejected: {error}");
+    assert!(
+        error.to_string().contains("401"),
+        "expected a 401 on the upgrade, got: {error}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires the docker-compose stack on :8080"]
+async fn directory_auth_stream_authenticates_the_upgrade() {
+    // `/a2a/:id/stream` takes the directory-auth path and is owner-gated. A
+    // fresh identity owns no directory card, so the backend may answer 403/404 —
+    // but it must not answer 401, which would mean the credential itself never
+    // authenticated.
+    let client = signed_client(true);
+    let agent_id = client
+        .http()
+        .signer()
+        .expect("signed client has a signer")
+        .agent_id();
+    match client.a2a.stream(&agent_id).connect().await {
+        Ok(conn) => {
+            println!("a2a.stream connected as {agent_id}");
+            let _ = conn.close().await;
+        }
+        Err(error) => {
+            println!("a2a.stream not readable for a fresh identity: {error}");
+            assert!(
+                !error.to_string().contains("401"),
+                "the signed upgrade was not authenticated: {error}"
+            );
+        }
+    }
 }

--- a/sdk/rust/tests/websocket.rs
+++ b/sdk/rust/tests/websocket.rs
@@ -1,11 +1,17 @@
-//! WebSocket streaming tests: signed-URL construction (public API) and a live
+//! WebSocket streaming tests: signed-URL construction, the signed upgrade
+//! headers the backend authenticates the handshake with (public API), and a live
 //! connect/recv/send/close round-trip against a local `tokio-tungstenite` server.
 
+use std::collections::HashMap;
+use std::sync::mpsc;
 use std::sync::Arc;
 
+use base64::Engine as _;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use futures_util::{SinkExt as _, StreamExt as _};
-use tinyplace::{LocalSigner, TinyPlaceClient, TinyPlaceClientOptions};
+use tinyplace::{LocalSigner, Signer as _, TinyPlaceClient, TinyPlaceClientOptions};
 use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
 use tokio_tungstenite::tungstenite::Message;
 
 fn client(base_url: &str, with_signer: bool) -> TinyPlaceClient {
@@ -17,6 +23,25 @@ fn client(base_url: &str, with_signer: bool) -> TinyPlaceClient {
         signer,
         ..Default::default()
     })
+}
+
+/// A client whose signer opts out of SIWS, so authenticated requests carry the
+/// per-request freshness-bound `v1:` token instead of a reusable proof.
+fn client_without_siws(base_url: &str) -> (TinyPlaceClient, LocalSigner) {
+    let signer = LocalSigner::from_seed(&[3u8; 32]).unwrap().without_siws();
+    let client = TinyPlaceClient::new(TinyPlaceClientOptions {
+        base_url: base_url.to_string(),
+        signer: Some(Arc::new(signer.clone()) as Arc<dyn tinyplace::Signer>),
+        ..Default::default()
+    });
+    (client, signer)
+}
+
+fn header_map(headers: Vec<(String, String)>) -> HashMap<String, String> {
+    headers
+        .into_iter()
+        .map(|(name, value)| (name.to_lowercase(), value))
+        .collect()
 }
 
 #[tokio::test]
@@ -69,6 +94,151 @@ async fn ws_stream_query_params_are_included() {
         .unwrap();
     assert!(url.starts_with("wss://api.example.com/channels/c1/stream?"));
     assert!(url.contains("limit=50"), "got: {url}");
+}
+
+#[tokio::test]
+async fn ws_upgrade_headers_carry_the_signed_credential() {
+    let client = client("https://api.example.com", true);
+    let headers = header_map(
+        client
+            .inbox
+            .stream()
+            .upgrade_headers()
+            .await
+            .expect("upgrade headers"),
+    );
+
+    // The backend authenticates the handshake on X-TinyPlace-Signature, keyed to
+    // the public key presented alongside it.
+    let signature = headers
+        .get("x-tinyplace-signature")
+        .expect("signature header");
+    assert!(signature.starts_with("siws:"), "got: {signature}");
+    assert_eq!(
+        headers.get("x-tinyplace-public-key").map(String::as_str),
+        Some(
+            LocalSigner::from_seed(&[1u8; 32])
+                .unwrap()
+                .public_key_base64()
+        )
+        .as_deref()
+    );
+    assert_eq!(
+        headers.get("x-tinyplace-crypto-id").map(String::as_str),
+        Some(LocalSigner::from_seed(&[1u8; 32]).unwrap().agent_id()).as_deref()
+    );
+    assert_eq!(
+        headers.get("x-tinyplace-sdk").map(String::as_str),
+        Some(tinyplace::SDK_CLIENT)
+    );
+}
+
+#[tokio::test]
+async fn ws_upgrade_signature_signs_the_empty_canonical_payload() {
+    let (client, signer) = client_without_siws("https://api.example.com");
+    let headers = header_map(
+        client
+            .a2a
+            .stream("@alice")
+            .upgrade_headers()
+            .await
+            .expect("upgrade headers"),
+    );
+
+    // v1:<b64url(timestamp)>:<b64url(nonce)>:<base64(signature)>, signed over
+    // `<canonical payload>\n<timestamp>\n<nonce>`. A stream GET declares no
+    // action and no fields, so the payload is the empty canonical envelope.
+    let token = headers
+        .get("x-tinyplace-signature")
+        .expect("signature header");
+    let parts: Vec<&str> = token.split(':').collect();
+    assert_eq!(parts.len(), 4, "got: {token}");
+    assert_eq!(parts[0], "v1");
+
+    let url_safe = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let timestamp = String::from_utf8(url_safe.decode(parts[1]).unwrap()).unwrap();
+    let nonce = String::from_utf8(url_safe.decode(parts[2]).unwrap()).unwrap();
+    let signature = base64::engine::general_purpose::STANDARD
+        .decode(parts[3])
+        .unwrap();
+    assert!(
+        timestamp.contains('T') && timestamp.ends_with('Z'),
+        "{timestamp}"
+    );
+    assert!(!nonce.is_empty());
+
+    let payload = format!("{{\"action\":\"\",\"fields\":{{}}}}\n{timestamp}\n{nonce}");
+    let verifying = VerifyingKey::from_bytes(signer.public_key()).unwrap();
+    verifying
+        .verify(
+            payload.as_bytes(),
+            &Signature::from_slice(&signature).unwrap(),
+        )
+        .expect("upgrade signature verifies against the signer's key");
+}
+
+#[tokio::test]
+async fn ws_upgrade_headers_without_a_signer_carry_only_the_sdk_tag() {
+    let client = client("https://api.example.com", false);
+    let headers = header_map(
+        client
+            .activity
+            .stream(None)
+            .upgrade_headers()
+            .await
+            .expect("upgrade headers"),
+    );
+    assert_eq!(headers.len(), 1);
+    assert!(headers.contains_key("x-tinyplace-sdk"));
+}
+
+// The handshake callback's error type is tungstenite's own `ErrorResponse`.
+#[allow(clippy::result_large_err)]
+#[tokio::test]
+async fn ws_handshake_sends_the_signed_headers_to_the_server() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (sender, receiver) = mpsc::channel::<HashMap<String, String>>();
+
+    let server = tokio::spawn(async move {
+        let (tcp, _) = listener.accept().await.unwrap();
+        let mut ws =
+            tokio_tungstenite::accept_hdr_async(tcp, |request: &Request, response: Response| {
+                let seen = request
+                    .headers()
+                    .iter()
+                    .map(|(name, value)| {
+                        (
+                            name.as_str().to_lowercase(),
+                            value.to_str().unwrap_or_default().to_string(),
+                        )
+                    })
+                    .collect();
+                sender.send(seen).unwrap();
+                Ok(response)
+            })
+            .await
+            .unwrap();
+        let _ = ws.close(None).await;
+    });
+
+    let client = client(&format!("http://{addr}"), true);
+    let conn = client.inbox.stream().connect().await.unwrap();
+    conn.close().await.unwrap();
+    server.await.unwrap();
+
+    let seen = receiver.recv().unwrap();
+    assert!(
+        seen.get("x-tinyplace-signature")
+            .is_some_and(|value| value.starts_with("siws:")),
+        "handshake reached the server without a signature header: {seen:?}"
+    );
+    assert!(seen.contains_key("x-tinyplace-public-key"));
+    assert!(seen.contains_key("x-tinyplace-crypto-id"));
+    assert_eq!(
+        seen.get("x-tinyplace-sdk").map(String::as_str),
+        Some(tinyplace::SDK_CLIENT)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

The Rust SDK could not open **any** authenticated WebSocket stream against the backend. Every auth-gated stream — `/a2a/:id/stream`, `/inbox/stream`, `/broadcasts/:id/stream`, `/conversations/:id/stream`, `/escrow/:id/stream` — was answered with `401 Unauthorized` and never upgraded.

The handle authenticated purely through the URL, on the premise recorded in its own module docs that *"a WebSocket upgrade can't carry the usual custom headers"*. That is a browser limitation, not a protocol one, and the backend does not read those params:

- `middleware.Auth` runs as ordinary Gin middleware on the upgrade `GET`, reading `X-TinyPlace-Signature` / `X-TinyPlace-Public-Key`, and aborts **401 before** the handler ever reaches `upgrader.Upgrade` — so a bad handshake never becomes a `101`.
- Its only query fallbacks are `?signature` / `?signerPublicKey`. The SDK was sending `?authorization=` and `?X-TinyPlace-Signature=`, neither of which the router looks at.

REST was unaffected and has been working all along: those calls go through `sign_directory_write`, which already puts the credential in the `X-TinyPlace-Signature` **header**. Only the WebSocket path carried it in the URL, which is why this stayed invisible until an auth-gated stream was used.

## Fix

Send the credential as real headers on the handshake, mirroring the REST pipeline.

`sign_websocket_upgrade` emits the signer's public key, its crypto id, and a signature that is either a reusable `siws:` proof or a freshness-bound `v1:<b64url(ts)>:<b64url(nonce)>:<b64(sig)>` token over the canonical payload `{"action":"","fields":{}}` — a stream `GET` declares no action and no fields. It reuses the existing `sign_fresh_canonical_payload`, so it picks the same scheme the rest of the SDK would for a given signer. The `X-Tinyplace-SDK` client tag rides along, as it does on every HTTP request.

```
GET /inbox/stream
X-TinyPlace-Public-Key: <base64 ed25519 key>
X-TinyPlace-Crypto-Id:  <base58 address>
X-TinyPlace-Signature:  siws:<proof>   |  v1:<ts>:<nonce>:<sig>
X-Tinyplace-SDK:        rust/2.0.4
```

The existing URL-borne credentials are left in place, so a query-string backend still authenticates and nothing regresses for older deployments.

## Verification

Live against `staging-api.tiny.place` (`version 0.1.4`), **9/9**:

| case | result |
|---|---|
| `/inbox/stream`, SIWS proof | `101` → `snapshot` frame |
| `/inbox/stream`, `v1:` token | `101` → `snapshot` frame |
| `/inbox/stream`, **no credential** | `401` (negative control) |
| `/a2a/<cryptoId>/stream` (directory auth) | connected |
| `activity` / `ledger` / `explorer.live` (public) | `snapshot` / connected |

Reverting just the two source files to the pre-fix state and re-running the authenticated case against the same server reproduces `401 Unauthorized` — the header is what makes it connect.

Offline suite: 33 test binaries, 0 failures. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean for both the default and `cli` feature sets. New unit tests pin the header set, verify the `v1:` token's signature byte-for-byte against the signer's key, and assert through a real handshake that the server actually receives the headers.

Run the live suite with:

```sh
cd sdk/rust
TINYPLACE_E2E_URL=https://staging-api.tiny.place \
  cargo test --test e2e_docker -- --ignored --nocapture
```

## Out of scope

`sign_directory_write`'s **non-SIWS** branch still emits the legacy `X-TinyPlace-Date`/`X-TinyPlace-Nonce` + raw-base64 signature, which the backend no longer reads — so a `.without_siws()` signer gets `401` on REST (measured, not inferred). Nothing constructs one by default, and it is pre-existing rather than touched here, so it is left for a follow-up. Note the WebSocket path above now works with both schemes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1praWiMWorz1ZREBRfbwg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated WebSocket upgrade support for the Rust SDK.
  * WebSocket handshakes now include signed authentication headers when configured, supporting both SIWS and freshness-bound signatures.
  * Added access to upgrade headers for custom WebSocket integrations.
  * Unsigned authenticated handshakes are rejected with a 401 response.

* **Documentation**
  * Updated Rust SDK guidance for WebSocket authentication and streaming feature configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->