### PR TITLE
docs(spec): document that marketplace `seller` filters by cryptoId (#231)

### DIFF
--- a/gitbooks/commerce/marketplace.md
+++ b/gitbooks/commerce/marketplace.md
@@ -137,15 +137,32 @@ The marketplace surfaces listings through unified [search](../discovery/search/R
 
 Search parameters:
 
-| Parameter               | Description                                     |
-| ----------------------- | ----------------------------------------------- |
-| `q`                     | Free-text search across names and descriptions  |
-| `category`              | Filter by category                              |
-| `tags`                  | Filter by tags (comma-separated)                |
-| `seller`                | Filter by seller username                       |
-| `minPrice` / `maxPrice` | Price range filter                              |
-| `sortBy`                | `price`, `rating`, `salesCount`, or `createdAt` |
-| `type`                  | `product` or `identity` (default: all)          |
+| Parameter               | Description                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `q`                     | Free-text search across names and descriptions                                |
+| `category`              | Filter by category                                                            |
+| `tags`                  | Filter by tags (comma-separated)                                              |
+| `seller`                | Filter by seller **`cryptoId`** — not the username. See the note below.       |
+| `minPrice` / `maxPrice` | Price range filter                                                            |
+| `sortBy`                | `price`, `rating`, `salesCount`, or `createdAt`                               |
+| `type`                  | `product` or `identity` (default: all)                                        |
+| `limit`                 | Page size. Omitted, the endpoint returns the full result set.                 |
+| `offset`                | Rows to skip; page with `limit` until a page returns fewer than `limit` rows. |
+
+> **`seller` takes a `cryptoId`.** `GET /marketplace/identities?seller=<cryptoId>`
+> returns that seller's listings; passing a username (with or without the leading
+> `@`) matches nothing and returns an empty list rather than an error. There is no
+> `sellerCryptoId` parameter — that spelling is ignored and the response comes back
+> unfiltered, which is easy to mistake for "this seller owns everything". Verified
+> against production; see [#231](https://github.com/tinyhumansai/tiny.place/issues/231),
+> where a client that browsed the marketplace-wide feed instead of scoping to the
+> viewer lost for-sale badges once the feed outgrew its page size.
+>
+> To answer "what has this account listed?", scope **and** page the query:
+>
+> ```
+> GET /marketplace/identities?seller=<cryptoId>&limit=100&offset=0
+> ```
 
 Categories are organized for browsing (`dataset`, `model`, `api-key`, `report`, `template`, `tool`, `other`, plus identity), and the marketplace publishes category counts so buyers can see where the supply is. Curated surfaces include:
 

--- a/website/public/spec/marketplace.md
+++ b/website/public/spec/marketplace.md
@@ -129,15 +129,32 @@ GET /marketplace/featured                    Curated/trending products
 
 Search parameters:
 
-| Parameter               | Description                                    |
-| ----------------------- | ---------------------------------------------- |
-| `q`                     | Free-text search across names and descriptions |
-| `category`              | Filter by category                             |
-| `tags`                  | Filter by tags (comma-separated)               |
-| `seller`                | Filter by seller username                      |
-| `minPrice` / `maxPrice` | Price range filter                             |
-| `sortBy`                | `price`, `rating`, `salesCount`, `createdAt`   |
-| `type`                  | `product` or `identity` (default: all)         |
+| Parameter               | Description                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `q`                     | Free-text search across names and descriptions                                |
+| `category`              | Filter by category                                                            |
+| `tags`                  | Filter by tags (comma-separated)                                              |
+| `seller`                | Filter by seller **`cryptoId`** — not the username. See the note below.       |
+| `minPrice` / `maxPrice` | Price range filter                                                            |
+| `sortBy`                | `price`, `rating`, `salesCount`, `createdAt`                                  |
+| `type`                  | `product` or `identity` (default: all)                                        |
+| `limit`                 | Page size. Omitted, the endpoint returns the full result set.                 |
+| `offset`                | Rows to skip; page with `limit` until a page returns fewer than `limit` rows. |
+
+> **`seller` takes a `cryptoId`.** `GET /marketplace/identities?seller=<cryptoId>`
+> returns that seller's listings; passing a username (with or without the leading
+> `@`) matches nothing and returns an empty list rather than an error. There is no
+> `sellerCryptoId` parameter — that spelling is ignored and the response comes back
+> unfiltered, which is easy to mistake for "this seller owns everything". Verified
+> against production; see [#231](https://github.com/tinyhumansai/tiny.place/issues/231),
+> where a client that browsed the marketplace-wide feed instead of scoping to the
+> viewer lost for-sale badges once the feed outgrew its page size.
+>
+> To answer "what has this account listed?", scope **and** page the query:
+>
+> ```
+> GET /marketplace/identities?seller=<cryptoId>&limit=100&offset=0
+> ```
 
 ## Purchase Flow
 


### PR DESCRIPTION
Documentation-only. Records `GET /marketplace/identities` as it actually behaves, so the identity-market re-implementation doesn't build on a contract the API doesn't honour.

## Problem

`website/public/spec/marketplace.md` documents the browse `seller` parameter as *"Filter by seller username"*. The live API matches the seller's **`cryptoId`** instead. A client that follows the spec gets `count: 0` back — not an error — so a valid account reads as "nothing listed".

Reproduced against production on two different sellers:

| Query | `count` |
| --- | --- |
| `?seller=CQNcpyeuAhGjxyuiStmmU4j8fiameGTdmV53dEoztLiz` (cryptoId) | 147 |
| `?seller=B721U8rP585FCMgmXr4hQPzUmD835Cju7evcfJXCY9b9` (cryptoId) | 8 |
| `?seller=bestbot` (username, per spec) | 0 |
| `?seller=@bestbot` (username with `@`) | 0 |
| `?sellerCryptoId=<cryptoId>` | 166 — parameter ignored, response unfiltered |

The `sellerCryptoId` spelling is the trap worth naming: it is silently dropped and the caller gets the entire marketplace back, which looks like one seller owning everything.

This is the contract behind #231. The handle overview there resolved each handle's for-sale badge out of a **marketplace-wide** feed capped at 100 rows rather than scoping to the viewer, so badges disappeared once the feed outgrew that window — 166 active listings today, 147 of them from the reporter. Full diagnosis in [#231](https://github.com/tinyhumansai/tiny.place/issues/231#issuecomment-5133059719).

## Solution

- `seller` is documented as taking a `cryptoId`, with a note that a username matches nothing and that `sellerCryptoId` is not a parameter.
- Adds `limit` / `offset` rows — both are honoured today (`?limit=5` → 5 rows; `?offset=160` → the remaining 6 of 166) and were undocumented, yet any owner-scoped lookup needs them to page correctly.
- Shows the correct call shape for "what has this account listed?":

  ```
  GET /marketplace/identities?seller=<cryptoId>&limit=100&offset=0
  ```

This documents the API as-built. **Whether backend-tinyplace-v2 should *also* accept a username is a separate decision for the backend team** — if it does, this note is the thing to update. Flagged on the issue.

## Impact

Docs only — no code, no runtime, no build surface. `website/public/spec/marketplace.md` is served as reference content; nothing imports it.

Out of scope, flagged on the issue rather than fixed here: `GET /marketplace/products` currently returns `404 Route Not Found` on backend-v2 while this spec documents it — the same spec/impl drift, but a backend call rather than a docs one.

## Related

- Context: #231 (for-sale status disappearing for accounts with 140+ handles) — this PR fixes only the contract-documentation half. The overview UI itself was removed from `main` in `4b9c2eab` (2026-06-22), so there is no client code left to patch; #231 is best tracked against the identity-market re-implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated marketplace search documentation to clarify that `seller` requires a seller crypto ID.
  * Added documentation for `limit` and `offset` pagination parameters.
  * Clarified behavior for invalid usernames and incorrect seller ID queries.
  * Added an example showing scoped, paginated identity-listing searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->