### PR TITLE
chore(deps): bump tokio-tungstenite to 0.29 in the Rust SDK

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["api-bindings", "asynchronous"]
 [dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["time", "rt", "sync", "macros"] }
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 url = "2"
 serde = { version = "1", features = ["derive"] }

--- a/sdk/rust/src/websocket.rs
+++ b/sdk/rust/src/websocket.rs
@@ -340,7 +340,7 @@ impl WebSocketConnection {
     pub async fn send(&mut self, value: &serde_json::Value) -> Result<()> {
         let text = serde_json::to_string(value)?;
         self.inner
-            .send(Message::Text(text))
+            .send(Message::Text(text.into()))
             .await
             .map_err(|error| Error::WebSocket(error.to_string()))
     }


### PR DESCRIPTION
Bumps \`tokio-tungstenite\` 0.24 → 0.29 in \`sdk/rust\`, aligning with tinychannels (already on 0.29). In tinyhumansai/openhuman this removes the duplicate \`tungstenite\` 0.24 major and the \`thiserror\` 1.x + \`thiserror-impl\` 1.x proc-macro compile from the kernel dependency profile.

Code updated for the 0.29 API (\`Message::Text\`/\`Binary\` now wrap \`Utf8Bytes\`/\`Bytes\`). \`cargo fmt --check\` and a standalone \`cargo check\` pass in \`sdk/rust\`.

Companion openhuman PR bumps the gitlink alongside its own tokio-tungstenite bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket text-message handling for more reliable message delivery.
  * Updated WebSocket support to maintain compatibility with the latest underlying networking improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->